### PR TITLE
ci: add copilot cloud agent setup workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 🔗 Create FVM symlink for Copilot
         run: |
           mkdir -p .fvm
-          ln -sfn ${{ steps.flutter-action.outputs.tool-cache-path }}/flutter .fvm/flutter_sdk
+          ln -sfn "$FLUTTER_ROOT" .fvm/flutter_sdk
 
       - name: 📦 Melos Bootstrap
         uses: bluefireteam/melos-action@main

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -40,7 +40,7 @@ jobs:
           ln -sfn "$FLUTTER_ROOT" .fvm/flutter_sdk
 
       - name: 📦 Melos Bootstrap
-        uses: bluefireteam/melos-action@main
+        uses: bluefireteam/melos-action@3ddd2cf0f7cf2de348b114c25d953dd8fbd62907
         with:
           run-bootstrap: true
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,48 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    steps:
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v6
+
+      - name: 🔧 Setup FVM
+        uses: kuhnroyal/flutter-fvm-config-action/config@v3
+        id: fvm-config-action
+
+      - name: 🐦 Setup Flutter
+        uses: subosito/flutter-action@v2
+        id: flutter-action
+        with:
+          flutter-version: ${{ steps.fvm-config-action.outputs.FLUTTER_VERSION }}
+          channel: ${{ steps.fvm-config-action.outputs.FLUTTER_CHANNEL }}
+          cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:"
+          cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
+          pub-cache-key: "flutter-pub-:os:-:channel:-:version:-:arch:-${{ hashFiles('pubspec.lock') }}"
+
+      - name: 🔗 Create FVM symlink for Copilot
+        run: |
+          mkdir -p .fvm
+          ln -sfn ${{ steps.flutter-action.outputs.tool-cache-path }}/flutter .fvm/flutter_sdk
+
+      - name: 📦 Melos Bootstrap
+        uses: bluefireteam/melos-action@main
+        with:
+          run-bootstrap: true
+
+      - name: 🛠️ Generate Code
+        run: melos run generate --no-select


### PR DESCRIPTION
## Summary
- add `.github/workflows/copilot-setup-steps.yml` for GitHub Copilot cloud agent
- prepare the repo with checkout, FVM-driven Flutter setup, Melos bootstrap, and code generation before agent sessions start
- keep the workflow limited to environment bootstrap instead of full validation or build steps

## Test Plan
- [x] Validate the workflow YAML parses locally
- [x] Verify the file contains the required single `copilot-setup-steps` job and expected bootstrap steps
- [ ] Run the workflow in GitHub Actions after merge/default-branch availability
- [ ] Verify a real Copilot cloud-agent session uses the setup workflow