### PR TITLE
chore(wt): copy ignored setup caches on start

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -2,6 +2,8 @@
 # https://worktrunk.dev/
 
 [pre-start]
+# Copy selected gitignored caches from the primary worktree before setup.
+copy = "wt step copy-ignored"
 # Install the FVM Flutter version configured in .fvmrc
 fvm = "fvm install && fvm use"
 # Get root dependencies first, then bootstrap melos packages

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.dart_tool/
+.fvm/


### PR DESCRIPTION
## Summary
- add a `pre-start` Worktrunk hook that runs `wt step copy-ignored` before the existing Flutter setup steps
- add `.worktreeinclude` so new worktrees can reuse the shared `.dart_tool/` and `.fvm/` caches
- keep the rest of the startup flow unchanged while reducing cold-start work for bootstrap and code generation