### PR TITLE
docs(agents): add dart shorthand guidance

### DIFF
--- a/.agents/skills/dart-shorthand/SKILL.md
+++ b/.agents/skills/dart-shorthand/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dart-shorthand
-description: Use when writing or reviewing Dart 3.10+ code and you want to apply dot shorthand syntax safely for enum values, constructors, and static members.
+description: Use when writing or reviewing Dart 3.11+ code and you want to apply dot shorthand syntax safely for enum values, constructors, and static members.
 license: MIT
 metadata:
   author: OpenCode
@@ -21,7 +21,7 @@ Official reference: `https://dart.dev/language/dot-shorthands`
 
 ## When to Use This Skill
 
-- Writing Dart 3.10+ code
+- Writing Dart 3.11+ code
 - Refactoring repetitive enum prefixes such as `MyEnum.value`
 - Initializing typed fields or locals with constructors like `.new()` or `.origin()`
 - Using static members where the target type is obvious from context

--- a/.agents/skills/dart-shorthand/SKILL.md
+++ b/.agents/skills/dart-shorthand/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: dart-shorthand
+description: Use when writing or reviewing Dart 3.10+ code and you want to apply dot shorthand syntax safely for enum values, constructors, and static members.
+license: MIT
+metadata:
+  author: OpenCode
+  version: "1.0.0"
+  domain: dart
+  triggers: Dart shorthand, dot shorthand, .new, enum shorthand, static member shorthand
+  role: specialist
+  scope: implementation
+  output-format: code
+  related-skills: dart-best-practices, flutter-expert
+---
+
+# Dart Shorthand
+
+Use Dart dot shorthand syntax when the surrounding context type is clear and the shorter form improves readability.
+
+Official reference: `https://dart.dev/language/dot-shorthands`
+
+## When to Use This Skill
+
+- Writing Dart 3.10+ code
+- Refactoring repetitive enum prefixes such as `MyEnum.value`
+- Initializing typed fields or locals with constructors like `.new()` or `.origin()`
+- Using static members where the target type is obvious from context
+- Reviewing code for shorthand opportunities without reducing clarity
+
+## Preferred Uses
+
+- Enum values in assignments, arguments, collection literals, and switch expressions
+- Named and unnamed constructors when the variable, field, or return type is explicit
+- Static methods and getters when the expected type is unambiguous
+
+## Examples
+
+```dart
+enum Status { idle, loading, success, failure }
+
+Status status = .idle;
+
+switch (status) {
+  case .idle:
+  case .loading:
+  case .success:
+  case .failure:
+}
+
+final ScrollController controller = .new();
+final GlobalKey<FormState> formKey = .new();
+
+int port = .parse('8080');
+```
+
+## Rules
+
+- Only use dot shorthand when the context type is immediately clear to the reader and compiler.
+- Prefer shorthand for enums; this is the strongest and clearest use case.
+- Use `.new()` for unnamed constructors only when the declared type is visible nearby.
+- Use shorthand in `const` expressions when the target constructor or enum value is const.
+- Fall back to the explicit type if shorthand makes the code harder to scan.
+
+## Limitations
+
+- Requires language version 3.10 or later.
+- An expression statement cannot start with `.`.
+- Equality checks are asymmetric: shorthand must be on the right side of `==` or `!=`.
+- Shorthand depends on context type, so avoid it where inference is weak, indirect, or surprising.
+- Be careful in chained expressions; the whole expression still has to satisfy the original context type.
+
+## Review Checklist
+
+- Is the expected type obvious at the usage site?
+- Is the shorthand shorter without being less readable?
+- Would an explicit type be clearer for someone unfamiliar with the code?
+- Does the file already use shorthand consistently?
+- Is the code running with Dart 3.10+ semantics?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 - This is a **Flutter monorepo** using Melos for workspace management
 - **Always use `fvm` prefix** for Dart/Flutter commands to ensure correct SDK version
 - The project uses `very_good_analysis` for linting with strict rules
-- Prefer Dart dot shorthand syntax when possible in Dart 3.10+ code if the context type is clear, especially for enums, constructors, and obvious static members
+- Prefer Dart dot shorthand syntax when possible in Dart 3.11+ code if the context type is clear, especially for enums, constructors, and obvious static members
 
 ### Dart Style
 - Use Dart dot shorthand syntax from `https://dart.dev/language/dot-shorthands` when it improves readability and the context type is obvious

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,12 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 - This is a **Flutter monorepo** using Melos for workspace management
 - **Always use `fvm` prefix** for Dart/Flutter commands to ensure correct SDK version
 - The project uses `very_good_analysis` for linting with strict rules
+- Prefer Dart dot shorthand syntax when possible in Dart 3.10+ code if the context type is clear, especially for enums, constructors, and obvious static members
+
+### Dart Style
+- Use Dart dot shorthand syntax from `https://dart.dev/language/dot-shorthands` when it improves readability and the context type is obvious
+- Prefer shorthand most strongly for enum values and typed constructor initialization such as `.new()`
+- Use the explicit type instead when shorthand would be ambiguous, surprising, or harder to scan
 
 ### When Reviewing Code
 - Check if ignore directives are documented and justified


### PR DESCRIPTION
## Summary
- add a local `dart-shorthand` skill with usage guidance, examples, and limitations for Dart dot shorthand syntax
- update `AGENTS.md` to tell agents to prefer dot shorthand when the context type is clear
- align agent guidance with the official Dart dot shorthand feature documentation

## Testing
- `fvm dart run melos exec --dir-exists=test -- \"flutter test --coverage --reporter=expanded\"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Dart dot-shorthand guidance document with usage scenarios, examples, rules, and a review checklist for applying dot shorthand in Dart 3.10+.
  * Updated developer guidelines to recommend when to prefer dot-shorthand (enums, typed constructors, obvious statics) and when to use explicit forms for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->