### PR TITLE
fix(chats): process queued drafts on every agent iteration

### DIFF
--- a/apps/auravibes_app/lib/features/chats/usecases/run_agent_iteration_usecase.dart
+++ b/apps/auravibes_app/lib/features/chats/usecases/run_agent_iteration_usecase.dart
@@ -1,3 +1,5 @@
+import 'package:auravibes_app/domain/entities/messages.dart';
+import 'package:auravibes_app/domain/enums/message_types.dart';
 import 'package:auravibes_app/domain/repositories/conversation_repository.dart';
 import 'package:auravibes_app/domain/repositories/message_repository.dart';
 import 'package:auravibes_app/features/chats/providers/conversation_repository_provider.dart';
@@ -37,37 +39,22 @@ class RunAgentIterationUsecase {
     var currentContext = context;
 
     while (true) {
+      currentContext = await _withQueuedDrafts(
+        conversationId: conversationId,
+        context: currentContext,
+      );
+
       final continueResult = await continueAgentUsecase.call(
         conversationId: conversationId,
         context: currentContext,
       );
+
+      currentContext = AgentIterationContext(
+        origin: currentContext?.origin ?? AgentIterationOrigin.userMessage,
+      );
+
       if (!continueResult.hasToolCalls) {
-        final queuedDrafts = sendQueueRuntime.dequeueAll(
-          conversationId,
-        );
-        if (queuedDrafts.isEmpty) {
-          return AgentIterationDecision.done;
-        }
-
-        final createdMessages = <String>[];
-        for (final queuedDraft in queuedDrafts) {
-          final createdMessage = await messageRepository.createMessage(
-            .new(
-              conversationId: conversationId,
-              content: queuedDraft.content,
-              messageType: .text,
-              isUser: true,
-              status: .sending,
-            ),
-          );
-          createdMessages.add(createdMessage.id);
-        }
-
-        currentContext = AgentIterationContext(
-          origin: AgentIterationOrigin.userMessage,
-          ackMessageIds: createdMessages,
-        );
-        continue;
+        return AgentIterationDecision.done;
       }
 
       final decision = await runAllowedToolsUsecase.call(
@@ -79,6 +66,38 @@ class RunAgentIterationUsecase {
         return decision;
       }
     }
+  }
+
+  Future<AgentIterationContext?> _withQueuedDrafts({
+    required String conversationId,
+    required AgentIterationContext? context,
+  }) async {
+    final queuedDrafts = sendQueueRuntime.dequeueAll(conversationId);
+    if (queuedDrafts.isEmpty) {
+      return context;
+    }
+
+    final createdMessages = <String>[];
+    for (final queuedDraft in queuedDrafts) {
+      final createdMessage = await messageRepository.createMessage(
+        MessageToCreate(
+          conversationId: conversationId,
+          content: queuedDraft.content,
+          messageType: MessageType.text,
+          isUser: true,
+          status: MessageStatus.sending,
+        ),
+      );
+      createdMessages.add(createdMessage.id);
+    }
+
+    return AgentIterationContext(
+      origin: context?.origin ?? AgentIterationOrigin.userMessage,
+      ackMessageIds: [
+        ...context?.ackMessageIds ?? const [],
+        ...createdMessages,
+      ],
+    );
   }
 }
 

--- a/apps/auravibes_app/lib/features/chats/usecases/run_agent_iteration_usecase.dart
+++ b/apps/auravibes_app/lib/features/chats/usecases/run_agent_iteration_usecase.dart
@@ -54,7 +54,16 @@ class RunAgentIterationUsecase {
       );
 
       if (!continueResult.hasToolCalls) {
-        return AgentIterationDecision.done;
+        final queuedContext = await _withQueuedDrafts(
+          conversationId: conversationId,
+          context: currentContext,
+        );
+        if (queuedContext == currentContext) {
+          return AgentIterationDecision.done;
+        }
+
+        currentContext = queuedContext;
+        continue;
       }
 
       final decision = await runAllowedToolsUsecase.call(
@@ -77,25 +86,25 @@ class RunAgentIterationUsecase {
       return context;
     }
 
-    final createdMessages = <String>[];
-    for (final queuedDraft in queuedDrafts) {
-      final createdMessage = await messageRepository.createMessage(
-        MessageToCreate(
-          conversationId: conversationId,
-          content: queuedDraft.content,
-          messageType: MessageType.text,
-          isUser: true,
-          status: MessageStatus.sending,
+    final createdMessages = await Future.wait(
+      queuedDrafts.map(
+        (queuedDraft) => messageRepository.createMessage(
+          MessageToCreate(
+            conversationId: conversationId,
+            content: queuedDraft.content,
+            messageType: MessageType.text,
+            isUser: true,
+            status: MessageStatus.sending,
+          ),
         ),
-      );
-      createdMessages.add(createdMessage.id);
-    }
+      ),
+    );
 
     return AgentIterationContext(
       origin: context?.origin ?? AgentIterationOrigin.userMessage,
       ackMessageIds: [
         ...context?.ackMessageIds ?? const [],
-        ...createdMessages,
+        ...createdMessages.map((message) => message.id),
       ],
     );
   }

--- a/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
@@ -233,6 +233,7 @@ void main() {
               context,
               const AgentIterationContext(
                 origin: AgentIterationOrigin.userMessage,
+                ackMessageIds: [], // ignore: avoid_redundant_argument_values - Explicit empty ack expectation for review clarity.
               ),
             );
           }

--- a/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
@@ -163,7 +163,7 @@ void main() {
             expect(
               context,
               const AgentIterationContext(
-                origin: AgentIterationOrigin.userMessage,
+                origin: .userMessage,
                 ackMessageIds: ['user-1'],
               ),
             );
@@ -183,7 +183,7 @@ void main() {
           expect(
             context,
             const AgentIterationContext(
-              origin: AgentIterationOrigin.userMessage,
+              origin: .userMessage,
               ackMessageIds: ['queued-user-1'],
             ),
           );
@@ -232,7 +232,7 @@ void main() {
             expect(
               context,
               const AgentIterationContext(
-                origin: AgentIterationOrigin.userMessage,
+                origin: .userMessage,
                 ackMessageIds:
                     [], // ignore: avoid_redundant_argument_values - Explicit empty ack expectation for review clarity.
               ),

--- a/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
@@ -418,7 +418,7 @@ void main() {
     );
 
     test(
-      'drains multiple queued drafts sequentially before returning done',
+      'drains multiple queued drafts in one iteration before returning done',
       () async {
         container
             .read(conversationSendQueueProvider.notifier)

--- a/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
@@ -146,6 +146,75 @@ void main() {
     });
 
     test(
+      'continues with drafts queued during a tool-free continuation',
+      () async {
+        var callCount = 0;
+        when(
+          continueAgentUsecase.call(
+            conversationId: 'conversation-1',
+            context: anyNamed('context'),
+          ),
+        ).thenAnswer((invocation) async {
+          final context =
+              invocation.namedArguments[#context] as AgentIterationContext?;
+          callCount += 1;
+
+          if (callCount == 1) {
+            expect(
+              context,
+              const AgentIterationContext(
+                origin: AgentIterationOrigin.userMessage,
+                ackMessageIds: ['user-1'],
+              ),
+            );
+            container
+                .read(conversationSendQueueProvider.notifier)
+                .enqueue(
+                  conversationId: 'conversation-1',
+                  content: 'Queued during stream',
+                );
+
+            return const ContinueAgentResult(
+              messageId: 'assistant-1',
+              hasToolCalls: false,
+            );
+          }
+
+          expect(
+            context,
+            const AgentIterationContext(
+              origin: AgentIterationOrigin.userMessage,
+              ackMessageIds: ['queued-user-1'],
+            ),
+          );
+
+          return const ContinueAgentResult(
+            messageId: 'assistant-2',
+            hasToolCalls: false,
+          );
+        });
+
+        final result = await usecase.call(
+          conversationId: 'conversation-1',
+          context: const AgentIterationContext(
+            origin: AgentIterationOrigin.userMessage,
+            ackMessageIds: ['user-1'],
+          ),
+        );
+
+        expect(result, AgentIterationDecision.done);
+        expect(callCount, 2);
+        verify(messageRepository.createMessage(any)).called(1);
+        expect(
+          container
+              .read(conversationSendQueueProvider.notifier)
+              .peek('conversation-1'),
+          isNull,
+        );
+      },
+    );
+
+    test(
       'continues looping while tool execution requests another iteration',
       () async {
         var callCount = 0;

--- a/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
@@ -233,7 +233,8 @@ void main() {
               context,
               const AgentIterationContext(
                 origin: AgentIterationOrigin.userMessage,
-                ackMessageIds: [], // ignore: avoid_redundant_argument_values - Explicit empty ack expectation for review clarity.
+                ackMessageIds:
+                    [], // ignore: avoid_redundant_argument_values - Explicit empty ack expectation for review clarity.
               ),
             );
           }

--- a/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/run_agent_iteration_usecase_test.dart
@@ -152,9 +152,21 @@ void main() {
         when(
           continueAgentUsecase.call(
             conversationId: 'conversation-1',
+            context: anyNamed('context'),
           ),
-        ).thenAnswer((_) async {
+        ).thenAnswer((invocation) async {
+          final context =
+              invocation.namedArguments[#context] as AgentIterationContext?;
           callCount += 1;
+
+          if (callCount == 2) {
+            expect(
+              context,
+              const AgentIterationContext(
+                origin: AgentIterationOrigin.userMessage,
+              ),
+            );
+          }
 
           if (callCount == 1) {
             return const ContinueAgentResult(
@@ -181,6 +193,7 @@ void main() {
         verify(
           continueAgentUsecase.call(
             conversationId: 'conversation-1',
+            context: anyNamed('context'),
           ),
         ).called(2);
         verify(
@@ -219,7 +232,7 @@ void main() {
     );
 
     test(
-      'drains the next queued draft after the current iteration finishes',
+      'includes queued drafts in the same iteration context',
       () async {
         container
             .read(conversationSendQueueProvider.notifier)
@@ -233,26 +246,12 @@ void main() {
             conversationId: 'conversation-1',
             context: const AgentIterationContext(
               origin: AgentIterationOrigin.userMessage,
-              ackMessageIds: ['user-1'],
+              ackMessageIds: ['user-1', 'queued-user-1'],
             ),
           ),
         ).thenAnswer(
           (_) async => const ContinueAgentResult(
             messageId: 'assistant-1',
-            hasToolCalls: false,
-          ),
-        );
-        when(
-          continueAgentUsecase.call(
-            conversationId: 'conversation-1',
-            context: const AgentIterationContext(
-              origin: AgentIterationOrigin.userMessage,
-              ackMessageIds: ['queued-user-1'],
-            ),
-          ),
-        ).thenAnswer(
-          (_) async => const ContinueAgentResult(
-            messageId: 'assistant-2',
             hasToolCalls: false,
           ),
         );
@@ -272,10 +271,72 @@ void main() {
             conversationId: 'conversation-1',
             context: const AgentIterationContext(
               origin: AgentIterationOrigin.userMessage,
-              ackMessageIds: ['queued-user-1'],
+              ackMessageIds: ['user-1', 'queued-user-1'],
             ),
           ),
         ).called(1);
+        expect(
+          container
+              .read(conversationSendQueueProvider.notifier)
+              .peek('conversation-1'),
+          isNull,
+        );
+      },
+    );
+
+    test(
+      'adds queued drafts before the next continuation after tool execution',
+      () async {
+        var callCount = 0;
+        when(
+          continueAgentUsecase.call(
+            conversationId: 'conversation-1',
+            context: anyNamed('context'),
+          ),
+        ).thenAnswer((invocation) async {
+          final ctx =
+              invocation.namedArguments[#context] as AgentIterationContext?;
+          callCount += 1;
+
+          if (callCount == 1) {
+            return const ContinueAgentResult(
+              messageId: 'assistant-1',
+              hasToolCalls: true,
+            );
+          }
+          if (callCount == 2) {
+            expect(
+              ctx?.ackMessageIds,
+              ['queued-user-1'],
+              reason: 'queued draft should be acked before the next iteration',
+            );
+          }
+
+          return const ContinueAgentResult(
+            messageId: 'assistant-2',
+            hasToolCalls: false,
+          );
+        });
+        when(
+          runAllowedToolsUsecase.call(
+            conversationId: 'conversation-1',
+            workspaceId: 'workspace-1',
+          ),
+        ).thenAnswer((_) async {
+          container
+              .read(conversationSendQueueProvider.notifier)
+              .enqueue(
+                conversationId: 'conversation-1',
+                content: 'Queued follow-up',
+              );
+          return AgentIterationDecision.continueIteration;
+        });
+
+        final result = await usecase.call(conversationId: 'conversation-1');
+
+        expect(result, AgentIterationDecision.done);
+        verify(messageRepository.createMessage(any)).called(1);
+        expect(callCount, 2);
         expect(
           container
               .read(conversationSendQueueProvider.notifier)
@@ -313,10 +374,11 @@ void main() {
           callCount += 1;
 
           if (callCount == 1) {
-            expect(context?.ackMessageIds, ['user-1']);
-          }
-          if (callCount == 2) {
-            expect(context?.ackMessageIds, ['queued-user-1', 'queued-user-2']);
+            expect(context?.ackMessageIds, [
+              'user-1',
+              'queued-user-1',
+              'queued-user-2',
+            ]);
           }
 
           return ContinueAgentResult(
@@ -349,7 +411,7 @@ void main() {
         );
 
         expect(result, AgentIterationDecision.done);
-        expect(callCount, 2);
+        expect(callCount, 1);
         verify(messageRepository.createMessage(any)).called(2);
         expect(
           container


### PR DESCRIPTION
## Summary
- process queued user drafts before every agent continuation instead of only after tool-free responses
- keep queued draft acknowledgements scoped to the current continuation so earlier user messages are not re-marked on later failures
- expand `RunAgentIterationUsecase` coverage for same-iteration queueing, post-tool queueing, and batched queued drafts

## Testing
- `fvm dart run melos run format:check`
- `fvm flutter test --no-pub` in `apps/auravibes_app`
- `fvm flutter test --no-pub` in `packages/auravibes_ui`

## Notes
- no branch-specific task/spec file was found for this change
- `fvm dart run melos run validate:quick` is currently broken in this repo because it calls a missing `format` script
- `fvm dart run melos run test` is interactive in this environment, so package test suites were run directly instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Queued drafts are now drained at the start of each agent iteration and converted into user messages concurrently, so acknowledgements are grouped and continuation behavior is deterministic.

* **Tests**
  * Expanded and refactored tests to cover drafts enqueued mid-iteration or by tools, aggregation of multiple queued drafts into a single iteration, and precise acknowledgement/context behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->