### PR TITLE
feat(chat): move tool approvals out of transcript

### DIFF
--- a/apps/auravibes_app/assets/i18n/en.json
+++ b/apps/auravibes_app/assets/i18n/en.json
@@ -117,6 +117,9 @@
     "skip": "Skip",
     "stop_all": "Stop All"
   },
+  "tool_approval": {
+    "pending_count": "Tool approval {} of {}"
+  },
   "tool_call_status": {
     "success": "Completed",
     "skipped_by_user": "Skipped",

--- a/apps/auravibes_app/assets/i18n/es.json
+++ b/apps/auravibes_app/assets/i18n/es.json
@@ -117,6 +117,9 @@
     "skip": "Omitir",
     "stop_all": "Detener todo"
   },
+  "tool_approval": {
+    "pending_count": "Aprobación de herramienta {} de {}"
+  },
   "tool_call_status": {
     "success": "Completado",
     "skipped_by_user": "Omitido",

--- a/apps/auravibes_app/lib/features/chats/providers/messages_providers.dart
+++ b/apps/auravibes_app/lib/features/chats/providers/messages_providers.dart
@@ -91,3 +91,39 @@ List<String> pendingMcpConnections(Ref ref) {
   // explicitly again, there is no reliable source for this indicator.
   return const <String>[];
 }
+
+class PendingToolCall {
+  const PendingToolCall({
+    required this.toolCall,
+    required this.messageId,
+  });
+
+  final MessageToolCallEntity toolCall;
+  final String messageId;
+}
+
+@Riverpod(dependencies: [ChatMessagesNotifier])
+List<PendingToolCall> pendingToolCalls(Ref ref) {
+  final messages = ref.watch(
+    chatMessagesProvider.select((value) => value.value),
+  );
+  if (messages == null || messages.isEmpty) return const [];
+
+  final latestAssistantMessage = messages.lastWhereOrNull(
+    (message) => !message.isUser,
+  );
+  if (latestAssistantMessage == null) return const [];
+
+  final toolCalls = latestAssistantMessage.metadata?.toolCalls;
+  if (toolCalls == null || toolCalls.isEmpty) return const [];
+
+  return toolCalls
+      .where((toolCall) => toolCall.isPending)
+      .map(
+        (toolCall) => PendingToolCall(
+          toolCall: toolCall,
+          messageId: latestAssistantMessage.id,
+        ),
+      )
+      .toList();
+}

--- a/apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart
+++ b/apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart
@@ -8,7 +8,7 @@ import 'package:auravibes_app/features/chats/widgets/chat_input_widget.dart';
 import 'package:auravibes_app/features/chats/widgets/chat_messages_widget.dart';
 import 'package:auravibes_app/features/chats/widgets/chat_queued_messages_indicator.dart';
 import 'package:auravibes_app/features/chats/widgets/chat_thinking_indicator.dart';
-import 'package:auravibes_app/features/chats/widgets/chat_tool_resolution_indicator.dart';
+import 'package:auravibes_app/features/chats/widgets/chat_tool_approval_card.dart';
 import 'package:auravibes_app/features/chats/widgets/mcp_connecting_indicator.dart';
 import 'package:auravibes_app/features/models/widgets/select_chat_model.dart';
 import 'package:auravibes_app/features/tools/widgets/tools_management_modal.dart';
@@ -92,31 +92,32 @@ class _ChatConversationScreen extends HookConsumerWidget {
         children: [
           const Expanded(child: _ChatList()),
           const McpConnectingIndicator(),
-          if (busyState?.isStreaming == true)
-            const ChatThinkingIndicator()
-          else if (busyState?.hasPendingTools == true)
-            const ChatToolResolutionIndicator(),
+          if (busyState?.isStreaming == true) const ChatThinkingIndicator(),
           if (queuedDrafts.isNotEmpty)
             ChatQueuedMessagesIndicator(queuedDrafts: queuedDrafts),
-          ChatInputWidget(
-            onToolsPress: onToolsPress,
-            onSendMessage: (message) async {
-              final conversationId = ref.read(conversationSelectedProvider);
-              try {
-                await ref
-                    .read(sendMessageUsecaseProvider)
-                    .call(
-                      conversationId: conversationId,
-                      content: message,
+          if (busyState?.hasPendingTools == true) const ChatToolApprovalCard(),
+          Offstage(
+            offstage: busyState?.hasPendingTools == true,
+            child: ChatInputWidget(
+              onToolsPress: onToolsPress,
+              onSendMessage: (message) async {
+                final conversationId = ref.read(conversationSelectedProvider);
+                try {
+                  await ref
+                      .read(sendMessageUsecaseProvider)
+                      .call(
+                        conversationId: conversationId,
+                        content: message,
+                      );
+                } on Exception catch (e) {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Failed to send message: $e')),
                     );
-              } on Exception catch (e) {
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('Failed to send message: $e')),
-                  );
+                  }
                 }
-              }
-            },
+              },
+            ),
           ),
         ],
       ),

--- a/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
@@ -102,7 +102,6 @@ class _ChatMessageRow extends HookConsumerWidget {
                 key: ValueKey('tool_${toolCall.id}'),
                 toolCall: toolCall,
                 messageId: message.id,
-                isLastMessage: isLastMessage,
               ),
           ],
         ],
@@ -179,13 +178,11 @@ class _ToolCallWidget extends ConsumerWidget {
   const _ToolCallWidget({
     required this.toolCall,
     required this.messageId,
-    required this.isLastMessage,
     super.key,
   });
 
   final MessageToolCallEntity toolCall;
   final String messageId;
-  final bool isLastMessage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -217,9 +214,11 @@ class _ToolCallWidget extends ConsumerWidget {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                if (decodedArgs != null) const TextSpan(text: ' "'),
-                TextSpan(text: decodedArgs),
-                const TextSpan(text: '"'),
+                if (decodedArgs != null) ...[
+                  const TextSpan(text: ' "'),
+                  TextSpan(text: decodedArgs),
+                  const TextSpan(text: '"'),
+                ],
               ],
             ),
           ),

--- a/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:auravibes_app/domain/entities/messages.dart';
 import 'package:auravibes_app/domain/enums/message_types.dart';
 import 'package:auravibes_app/domain/enums/tool_call_result_status.dart';
@@ -8,6 +6,7 @@ import 'package:auravibes_app/features/chats/providers/tool_display_name_provide
 import 'package:auravibes_app/features/chats/widgets/tool_call_response_preview.dart';
 import 'package:auravibes_app/utils/relative_time_formatter.dart';
 import 'package:auravibes_app/utils/tool_name_formatter.dart';
+import 'package:auravibes_app/utils/try_decode_tool_metadata.dart';
 import 'package:auravibes_app/widgets/text_locale.dart';
 import 'package:auravibes_ui/ui.dart';
 import 'package:flutter/material.dart';
@@ -44,28 +43,6 @@ class ChatMessagesWidget extends HookConsumerWidget {
       },
     );
   }
-}
-
-JsonEncoder encoder = const JsonEncoder.withIndent('  ');
-
-String? _tryDecode(Object? metadata) {
-  if (metadata == null) return null;
-  dynamic decoded;
-  try {
-    if (metadata is String) {
-      decoded = jsonDecode(metadata);
-    }
-  } on Exception catch (_) {
-    return metadata.toString();
-  }
-
-  if (decoded is Map<String, dynamic>) {
-    if (decoded.length == 1) {
-      return _tryDecode(decoded.values.first);
-    }
-  }
-
-  return encoder.convert(decoded);
 }
 
 class _ChatMessageRow extends HookConsumerWidget {
@@ -237,9 +214,9 @@ class _ToolCallWidget extends ConsumerWidget {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                if (_tryDecode(toolCall.argumentsRaw) != null)
+                if (tryDecodeToolMetadata(toolCall.argumentsRaw) != null)
                   const TextSpan(text: ' "'),
-                TextSpan(text: _tryDecode(toolCall.argumentsRaw)),
+                TextSpan(text: tryDecodeToolMetadata(toolCall.argumentsRaw)),
                 const TextSpan(text: '"'),
               ],
             ),
@@ -250,12 +227,12 @@ class _ToolCallWidget extends ConsumerWidget {
               icon: _getStatusIcon(toolCall.resultStatus!),
               color: _getStatusColor(context, toolCall.resultStatus!),
             ),
-          if (_tryDecode(toolCall.responseRaw) != null)
+          if (tryDecodeToolMetadata(toolCall.responseRaw) != null)
             Padding(
               padding: EdgeInsets.only(top: context.auraTheme.spacing.xs),
               child: ToolCallResponsePreview(
                 toolName: toolCall.name,
-                content: _tryDecode(toolCall.responseRaw)!,
+                content: tryDecodeToolMetadata(toolCall.responseRaw)!,
               ),
             ),
         ],

--- a/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
@@ -66,13 +66,14 @@ class _ChatMessageRow extends HookConsumerWidget {
     final allToolCalls =
         message.metadata?.toolCalls ?? const <MessageToolCallEntity>[];
     final visibleToolCalls = allToolCalls
-        .where((toolCall) => toolCall.isResolved)
+        .where(
+          (toolCall) => toolCall.isResolved || toolCall.resultStatus == null,
+        )
         .toList();
-    final hasToolCalls = allToolCalls.isNotEmpty;
     final hasVisibleToolCalls = visibleToolCalls.isNotEmpty;
     // Hide the text bubble when content is empty/whitespace and there are tool calls
     final hasContent = message.content.trim().isNotEmpty;
-    final showTextBubble = hasContent || !hasToolCalls;
+    final showTextBubble = hasContent || !hasVisibleToolCalls;
 
     return AnimatedSize(
       duration: const Duration(microseconds: 200),

--- a/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
@@ -197,6 +197,9 @@ class _ToolCallWidget extends ConsumerWidget {
       ),
     );
 
+    final decodedArgs = tryDecodeToolMetadata(toolCall.argumentsRaw);
+    final decodedResponse = tryDecodeToolMetadata(toolCall.responseRaw);
+
     return AuraContainer(
       backgroundColor: AuraColorVariant.surfaceVariant,
       borderRadius: 10,
@@ -214,9 +217,8 @@ class _ToolCallWidget extends ConsumerWidget {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                if (tryDecodeToolMetadata(toolCall.argumentsRaw) != null)
-                  const TextSpan(text: ' "'),
-                TextSpan(text: tryDecodeToolMetadata(toolCall.argumentsRaw)),
+                if (decodedArgs != null) const TextSpan(text: ' "'),
+                TextSpan(text: decodedArgs),
                 const TextSpan(text: '"'),
               ],
             ),
@@ -227,12 +229,12 @@ class _ToolCallWidget extends ConsumerWidget {
               icon: _getStatusIcon(toolCall.resultStatus!),
               color: _getStatusColor(context, toolCall.resultStatus!),
             ),
-          if (tryDecodeToolMetadata(toolCall.responseRaw) != null)
+          if (decodedResponse != null)
             Padding(
               padding: EdgeInsets.only(top: context.auraTheme.spacing.xs),
               child: ToolCallResponsePreview(
                 toolName: toolCall.name,
-                content: tryDecodeToolMetadata(toolCall.responseRaw)!,
+                content: decodedResponse,
               ),
             ),
         ],

--- a/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
@@ -62,14 +62,22 @@ class _ChatMessageRow extends HookConsumerWidget {
     }
 
     final isStreaming = ref.watch(isMessageStreamingProvider(messageId));
+    final busyState = ref.watch(
+      conversationBusyStateProvider.select(
+        (value) => value.maybeWhen(data: (state) => state, orElse: () => null),
+      ),
+    );
 
     final allToolCalls =
         message.metadata?.toolCalls ?? const <MessageToolCallEntity>[];
-    final visibleToolCalls = allToolCalls
-        .where(
-          (toolCall) => toolCall.isResolved || toolCall.resultStatus == null,
-        )
-        .toList();
+    final hidePendingToolCalls =
+        !message.isUser &&
+        isLastMessage &&
+        (busyState?.hasPendingTools ?? false) &&
+        !(busyState?.isStreaming ?? false);
+    final visibleToolCalls = hidePendingToolCalls
+        ? allToolCalls.where((toolCall) => toolCall.isResolved).toList()
+        : allToolCalls;
     final hasVisibleToolCalls = visibleToolCalls.isNotEmpty;
     // Hide the text bubble when content is empty/whitespace and there are tool calls
     final hasContent = message.content.trim().isNotEmpty;

--- a/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/chat_messages_widget.dart
@@ -5,9 +5,7 @@ import 'package:auravibes_app/domain/enums/message_types.dart';
 import 'package:auravibes_app/domain/enums/tool_call_result_status.dart';
 import 'package:auravibes_app/features/chats/providers/messages_providers.dart';
 import 'package:auravibes_app/features/chats/providers/tool_display_name_provider.dart';
-import 'package:auravibes_app/features/chats/widgets/tool_call_confirmation_widget.dart';
 import 'package:auravibes_app/features/chats/widgets/tool_call_response_preview.dart';
-import 'package:auravibes_app/i18n/locale_keys.dart';
 import 'package:auravibes_app/utils/relative_time_formatter.dart';
 import 'package:auravibes_app/utils/tool_name_formatter.dart';
 import 'package:auravibes_app/widgets/text_locale.dart';
@@ -88,7 +86,13 @@ class _ChatMessageRow extends HookConsumerWidget {
 
     final isStreaming = ref.watch(isMessageStreamingProvider(messageId));
 
-    final hasToolCalls = message.metadata?.toolCalls.isNotEmpty ?? false;
+    final allToolCalls =
+        message.metadata?.toolCalls ?? const <MessageToolCallEntity>[];
+    final visibleToolCalls = allToolCalls
+        .where((toolCall) => toolCall.isResolved)
+        .toList();
+    final hasToolCalls = allToolCalls.isNotEmpty;
+    final hasVisibleToolCalls = visibleToolCalls.isNotEmpty;
     // Hide the text bubble when content is empty/whitespace and there are tool calls
     final hasContent = message.content.trim().isNotEmpty;
     final showTextBubble = hasContent || !hasToolCalls;
@@ -115,8 +119,8 @@ class _ChatMessageRow extends HookConsumerWidget {
                 timestamp: message.createdAt,
                 status: _mapMessageStatus(message.status, isStreaming),
               ),
-          if (hasToolCalls) ...[
-            for (final toolCall in message.metadata!.toolCalls)
+          if (hasVisibleToolCalls) ...[
+            for (final toolCall in visibleToolCalls)
               _ToolCallWidget(
                 key: ValueKey('tool_${toolCall.id}'),
                 toolCall: toolCall,
@@ -208,16 +212,9 @@ class _ToolCallWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Only show confirmation for pending tool calls in the last message.
-    // If a tool call is pending in a previous message, the user skipped it.
-    // A tool is pending if resultStatus is null (not yet resolved).
-    final isPendingConfirmation = toolCall.isPending && isLastMessage;
-
-    // Get human-readable display name for the tool
     final displayNameAsync = ref.watch(toolDisplayNameProvider(toolCall.name));
     final displayName = displayNameAsync.maybeWhen(
       data: (name) => name,
-      // Fallback to formatted name while loading or on error
       orElse: () => ToolNameFormatter.formatDisplayName(
         ToolNameFormatter.parse(toolCall.name),
       ),
@@ -236,7 +233,7 @@ class _ToolCallWidget extends ConsumerWidget {
               children: [
                 TextSpan(
                   text: displayName,
-                  style: const .new(
+                  style: const TextStyle(
                     fontWeight: FontWeight.bold,
                   ),
                 ),
@@ -247,29 +244,12 @@ class _ToolCallWidget extends ConsumerWidget {
               ],
             ),
           ),
-          // Show pending confirmation indicator
-          if (isPendingConfirmation) ...[
-            _ToolCallStatusIndicator(
-              statusText: const TextLocale(LocaleKeys.tool_call_status_pending),
-              icon: Icons.help_outline,
-              color: context.auraColors.warning,
-            ),
-            Padding(
-              padding: EdgeInsets.only(top: context.auraTheme.spacing.sm),
-              child: ToolCallConfirmationWidget(
-                toolCall: toolCall,
-                messageId: messageId,
-              ),
-            ),
-          ],
-          // Show resolved status once persisted on the tool call metadata.
           if (toolCall.isResolved)
             _ToolCallStatusIndicator(
               statusText: TextLocale(toolCall.resultStatus!.localeKey),
               icon: _getStatusIcon(toolCall.resultStatus!),
               color: _getStatusColor(context, toolCall.resultStatus!),
             ),
-          // Show response content if available
           if (_tryDecode(toolCall.responseRaw) != null)
             Padding(
               padding: EdgeInsets.only(top: context.auraTheme.spacing.xs),

--- a/apps/auravibes_app/lib/features/chats/widgets/chat_tool_approval_card.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/chat_tool_approval_card.dart
@@ -1,0 +1,398 @@
+import 'dart:convert';
+
+import 'package:auravibes_app/domain/entities/messages.dart';
+import 'package:auravibes_app/domain/enums/tool_grant_level.dart';
+import 'package:auravibes_app/features/chats/notifiers/chat_messages_notifier.dart';
+import 'package:auravibes_app/features/chats/providers/messages_providers.dart';
+import 'package:auravibes_app/features/chats/providers/tool_display_name_provider.dart';
+import 'package:auravibes_app/features/tools/usecases/approve_tool_call_usecase.dart';
+import 'package:auravibes_app/features/tools/usecases/skip_tool_call_usecase.dart';
+import 'package:auravibes_app/features/tools/usecases/stop_all_pending_tool_calls_usecase.dart';
+import 'package:auravibes_app/i18n/locale_keys.dart';
+import 'package:auravibes_app/utils/tool_name_formatter.dart';
+import 'package:auravibes_app/widgets/text_locale.dart';
+import 'package:auravibes_ui/ui.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class ChatToolApprovalCard extends HookConsumerWidget {
+  const ChatToolApprovalCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final pendingCalls = ref.watch(pendingToolCallsProvider);
+    if (pendingCalls.isEmpty) return const SizedBox.shrink();
+
+    final currentIndex = useState(0);
+    final lastIndex = pendingCalls.length - 1;
+    final clamped = currentIndex.value > lastIndex
+        ? lastIndex
+        : currentIndex.value;
+
+    if (currentIndex.value != clamped) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        currentIndex.value = clamped;
+      });
+    }
+
+    final item = pendingCalls[clamped];
+    final total = pendingCalls.length;
+
+    return _ApprovalCardContent(
+      current: item,
+      currentIndex: clamped,
+      totalCount: total,
+      hasPrev: clamped > 0,
+      hasNext: clamped < total - 1,
+      onPrev: () => currentIndex.value = clamped - 1,
+      onNext: () => currentIndex.value = clamped + 1,
+    );
+  }
+}
+
+class _ApprovalCardContent extends ConsumerWidget {
+  const _ApprovalCardContent({
+    required this.current,
+    required this.currentIndex,
+    required this.totalCount,
+    required this.hasPrev,
+    required this.hasNext,
+    required this.onPrev,
+    required this.onNext,
+  });
+
+  final PendingToolCall current;
+  final int currentIndex;
+  final int totalCount;
+  final bool hasPrev;
+  final bool hasNext;
+  final VoidCallback onPrev;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auraColors = context.auraColors;
+    final spacing = context.auraTheme.spacing;
+    final toolCall = current.toolCall;
+
+    final displayNameAsync = ref.watch(
+      toolDisplayNameProvider(toolCall.name),
+    );
+    final displayName = displayNameAsync.maybeWhen(
+      data: (name) => name,
+      orElse: () => ToolNameFormatter.formatDisplayName(
+        ToolNameFormatter.parse(toolCall.name),
+      ),
+    );
+
+    return Container(
+      width: double.infinity,
+      margin: EdgeInsets.all(spacing.md),
+      decoration: BoxDecoration(
+        color: auraColors.warning.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(
+          context.auraTheme.borderRadius.lg,
+        ),
+        border: Border.all(
+          color: auraColors.warning.withValues(alpha: 0.3),
+        ),
+      ),
+      padding: EdgeInsets.all(spacing.md),
+      child: AuraColumn(
+        spacing: AuraSpacing.sm,
+        children: [
+          _NavigationHeader(
+            currentIndex: currentIndex,
+            totalCount: totalCount,
+            hasPrev: hasPrev,
+            hasNext: hasNext,
+            onPrev: onPrev,
+            onNext: onNext,
+          ),
+          _ToolCallInfo(
+            displayName: displayName,
+            argumentsRaw: toolCall.argumentsRaw,
+          ),
+          _ConfirmationButtons(
+            toolCall: toolCall,
+            messageId: current.messageId,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NavigationHeader extends StatelessWidget {
+  const _NavigationHeader({
+    required this.currentIndex,
+    required this.totalCount,
+    required this.hasPrev,
+    required this.hasNext,
+    required this.onPrev,
+    required this.onNext,
+  });
+
+  final int currentIndex;
+  final int totalCount;
+  final bool hasPrev;
+  final bool hasNext;
+  final VoidCallback onPrev;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    final auraColors = context.auraColors;
+
+    return Row(
+      children: [
+        Icon(
+          Icons.build_outlined,
+          size: 16,
+          color: auraColors.warning,
+        ),
+        SizedBox(width: context.auraTheme.spacing.xs),
+        Expanded(
+          child: Text(
+            LocaleKeys.tool_approval_pending_count.tr(
+              args: [(currentIndex + 1).toString(), totalCount.toString()],
+            ),
+            style: TextStyle(
+              fontSize: DesignTypography.fontSizeSm,
+              fontWeight: FontWeight.w600,
+              color: auraColors.onSurface,
+            ),
+          ),
+        ),
+        _NavButton(
+          icon: Icons.chevron_left,
+          onPressed: hasPrev ? onPrev : null,
+        ),
+        SizedBox(width: context.auraTheme.spacing.xs),
+        _NavButton(
+          icon: Icons.chevron_right,
+          onPressed: hasNext ? onNext : null,
+        ),
+      ],
+    );
+  }
+}
+
+class _NavButton extends StatelessWidget {
+  const _NavButton({
+    required this.icon,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final auraColors = context.auraColors;
+    final isEnabled = onPressed != null;
+
+    return SizedBox(
+      width: 32,
+      height: 32,
+      child: IconButton(
+        onPressed: onPressed,
+        icon: Icon(
+          icon,
+          size: 18,
+          color: isEnabled
+              ? auraColors.onSurface
+              : auraColors.onSurfaceVariant.withValues(alpha: 0.3),
+        ),
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints(
+          minWidth: 32,
+          minHeight: 32,
+        ),
+        style: IconButton.styleFrom(
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+      ),
+    );
+  }
+}
+
+class _ToolCallInfo extends StatelessWidget {
+  const _ToolCallInfo({
+    required this.displayName,
+    required this.argumentsRaw,
+  });
+
+  final String displayName;
+  final String argumentsRaw;
+
+  @override
+  Widget build(BuildContext context) {
+    final auraColors = context.auraColors;
+    final decodedArgs = _tryDecode(argumentsRaw);
+
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.all(context.auraTheme.spacing.sm),
+      decoration: BoxDecoration(
+        color: auraColors.surfaceVariant.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(context.auraTheme.borderRadius.sm),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            displayName,
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              fontSize: DesignTypography.fontSizeSm,
+              color: auraColors.onSurface,
+            ),
+          ),
+          if (decodedArgs != null) ...[
+            SizedBox(height: context.auraTheme.spacing.xs),
+            Text(
+              decodedArgs,
+              style: TextStyle(
+                fontSize: DesignTypography.fontSizeXs,
+                color: auraColors.onSurfaceVariant,
+              ),
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ConfirmationButtons extends ConsumerWidget {
+  const _ConfirmationButtons({
+    required this.toolCall,
+    required this.messageId,
+  });
+
+  final MessageToolCallEntity toolCall;
+  final String messageId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AuraColumn(
+      spacing: AuraSpacing.sm,
+      children: [
+        AuraRow(
+          children: [
+            Expanded(
+              child: AuraButton(
+                size: AuraButtonSize.small,
+                variant: AuraButtonVariant.outlined,
+                onPressed: () => _onAllowOnce(ref),
+                child: const TextLocale(
+                  LocaleKeys.tool_confirmation_allow_once,
+                ),
+              ),
+            ),
+            Expanded(
+              child: AuraButton(
+                size: AuraButtonSize.small,
+                variant: AuraButtonVariant.outlined,
+                onPressed: () => _onAllowForConversation(ref),
+                child: const TextLocale(
+                  LocaleKeys.tool_confirmation_allow_conversation,
+                ),
+              ),
+            ),
+          ],
+        ),
+        AuraRow(
+          children: [
+            Expanded(
+              child: AuraButton(
+                size: AuraButtonSize.small,
+                variant: AuraButtonVariant.outlined,
+                colorVariant: .primary,
+                onPressed: () => _onSkip(ref),
+                child: const TextLocale(LocaleKeys.tool_confirmation_skip),
+              ),
+            ),
+            Expanded(
+              child: AuraButton(
+                size: AuraButtonSize.small,
+                variant: AuraButtonVariant.outlined,
+                colorVariant: .error,
+                onPressed: () => _onStopAll(ref),
+                child: const TextLocale(
+                  LocaleKeys.tool_confirmation_stop_all,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Future<void> _onAllowOnce(WidgetRef ref) async {
+    await ref
+        .read(approveToolCallUsecaseProvider)
+        .call(
+          toolCallId: toolCall.id,
+          messageId: messageId,
+          level: ToolGrantLevel.once,
+        );
+    ref.invalidate(chatMessagesProvider);
+  }
+
+  Future<void> _onAllowForConversation(WidgetRef ref) async {
+    await ref
+        .read(approveToolCallUsecaseProvider)
+        .call(
+          toolCallId: toolCall.id,
+          messageId: messageId,
+          level: ToolGrantLevel.conversation,
+        );
+    ref.invalidate(chatMessagesProvider);
+  }
+
+  Future<void> _onSkip(WidgetRef ref) async {
+    await ref
+        .read(skipToolCallUsecaseProvider)
+        .call(
+          toolCallId: toolCall.id,
+          messageId: messageId,
+        );
+    ref.invalidate(chatMessagesProvider);
+  }
+
+  Future<void> _onStopAll(WidgetRef ref) async {
+    await ref
+        .read(stopAllPendingToolCallsUsecaseProvider)
+        .call(
+          messageId: messageId,
+        );
+    ref.invalidate(chatMessagesProvider);
+  }
+}
+
+String? _tryDecode(Object? metadata) {
+  if (metadata == null) return null;
+  dynamic decoded;
+  try {
+    if (metadata is String) {
+      decoded = jsonDecode(metadata);
+    }
+  } on Exception catch (_) {
+    return metadata.toString();
+  }
+
+  if (decoded is Map<String, dynamic>) {
+    if (decoded.length == 1) {
+      return _tryDecode(decoded.values.first);
+    }
+  }
+
+  return const JsonEncoder.withIndent('  ').convert(decoded);
+}

--- a/apps/auravibes_app/lib/features/chats/widgets/chat_tool_approval_card.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/chat_tool_approval_card.dart
@@ -1,4 +1,4 @@
-import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:auravibes_app/domain/entities/messages.dart';
 import 'package:auravibes_app/domain/enums/tool_grant_level.dart';
@@ -10,6 +10,7 @@ import 'package:auravibes_app/features/tools/usecases/skip_tool_call_usecase.dar
 import 'package:auravibes_app/features/tools/usecases/stop_all_pending_tool_calls_usecase.dart';
 import 'package:auravibes_app/i18n/locale_keys.dart';
 import 'package:auravibes_app/utils/tool_name_formatter.dart';
+import 'package:auravibes_app/utils/try_decode_tool_metadata.dart';
 import 'package:auravibes_app/widgets/text_locale.dart';
 import 'package:auravibes_ui/ui.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -27,15 +28,17 @@ class ChatToolApprovalCard extends HookConsumerWidget {
 
     final currentIndex = useState(0);
     final lastIndex = pendingCalls.length - 1;
-    final clamped = currentIndex.value > lastIndex
-        ? lastIndex
-        : currentIndex.value;
+    useEffect(
+      () {
+        if (currentIndex.value > lastIndex) {
+          currentIndex.value = lastIndex;
+        }
+        return null;
+      },
+      [lastIndex],
+    );
 
-    if (currentIndex.value != clamped) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        currentIndex.value = clamped;
-      });
-    }
+    final clamped = math.min(currentIndex.value, lastIndex);
 
     final item = pendingCalls[clamped];
     final total = pendingCalls.length;
@@ -231,7 +234,7 @@ class _ToolCallInfo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final auraColors = context.auraColors;
-    final decodedArgs = _tryDecode(argumentsRaw);
+    final decodedArgs = tryDecodeToolMetadata(argumentsRaw);
 
     return Container(
       width: double.infinity,
@@ -289,7 +292,7 @@ class _ConfirmationButtons extends ConsumerWidget {
               child: AuraButton(
                 size: AuraButtonSize.small,
                 variant: AuraButtonVariant.outlined,
-                onPressed: () => _onAllowOnce(ref),
+                onPressed: () => _onAllowOnce(ref, context),
                 child: const TextLocale(
                   LocaleKeys.tool_confirmation_allow_once,
                 ),
@@ -299,7 +302,7 @@ class _ConfirmationButtons extends ConsumerWidget {
               child: AuraButton(
                 size: AuraButtonSize.small,
                 variant: AuraButtonVariant.outlined,
-                onPressed: () => _onAllowForConversation(ref),
+                onPressed: () => _onAllowForConversation(ref, context),
                 child: const TextLocale(
                   LocaleKeys.tool_confirmation_allow_conversation,
                 ),
@@ -314,7 +317,7 @@ class _ConfirmationButtons extends ConsumerWidget {
                 size: AuraButtonSize.small,
                 variant: AuraButtonVariant.outlined,
                 colorVariant: .primary,
-                onPressed: () => _onSkip(ref),
+                onPressed: () => _onSkip(ref, context),
                 child: const TextLocale(LocaleKeys.tool_confirmation_skip),
               ),
             ),
@@ -323,7 +326,7 @@ class _ConfirmationButtons extends ConsumerWidget {
                 size: AuraButtonSize.small,
                 variant: AuraButtonVariant.outlined,
                 colorVariant: .error,
-                onPressed: () => _onStopAll(ref),
+                onPressed: () => _onStopAll(ref, context),
                 child: const TextLocale(
                   LocaleKeys.tool_confirmation_stop_all,
                 ),
@@ -335,64 +338,89 @@ class _ConfirmationButtons extends ConsumerWidget {
     );
   }
 
-  Future<void> _onAllowOnce(WidgetRef ref) async {
-    await ref
-        .read(approveToolCallUsecaseProvider)
-        .call(
-          toolCallId: toolCall.id,
-          messageId: messageId,
-          level: ToolGrantLevel.once,
-        );
-    ref.invalidate(chatMessagesProvider);
+  Future<void> _onAllowOnce(WidgetRef ref, BuildContext context) async {
+    await _runAction(
+      ref,
+      context,
+      errorMessage: 'Failed to approve tool call.',
+      action: () {
+        return ref
+            .read(approveToolCallUsecaseProvider)
+            .call(
+              toolCallId: toolCall.id,
+              messageId: messageId,
+              level: ToolGrantLevel.once,
+            );
+      },
+    );
   }
 
-  Future<void> _onAllowForConversation(WidgetRef ref) async {
-    await ref
-        .read(approveToolCallUsecaseProvider)
-        .call(
-          toolCallId: toolCall.id,
-          messageId: messageId,
-          level: ToolGrantLevel.conversation,
-        );
-    ref.invalidate(chatMessagesProvider);
+  Future<void> _onAllowForConversation(
+    WidgetRef ref,
+    BuildContext context,
+  ) async {
+    await _runAction(
+      ref,
+      context,
+      errorMessage: 'Failed to approve tool call for this conversation.',
+      action: () {
+        return ref
+            .read(approveToolCallUsecaseProvider)
+            .call(
+              toolCallId: toolCall.id,
+              messageId: messageId,
+              level: ToolGrantLevel.conversation,
+            );
+      },
+    );
   }
 
-  Future<void> _onSkip(WidgetRef ref) async {
-    await ref
-        .read(skipToolCallUsecaseProvider)
-        .call(
-          toolCallId: toolCall.id,
-          messageId: messageId,
-        );
-    ref.invalidate(chatMessagesProvider);
+  Future<void> _onSkip(WidgetRef ref, BuildContext context) async {
+    await _runAction(
+      ref,
+      context,
+      errorMessage: 'Failed to skip tool call.',
+      action: () {
+        return ref
+            .read(skipToolCallUsecaseProvider)
+            .call(
+              toolCallId: toolCall.id,
+              messageId: messageId,
+            );
+      },
+    );
   }
 
-  Future<void> _onStopAll(WidgetRef ref) async {
-    await ref
-        .read(stopAllPendingToolCallsUsecaseProvider)
-        .call(
-          messageId: messageId,
-        );
-    ref.invalidate(chatMessagesProvider);
+  Future<void> _onStopAll(WidgetRef ref, BuildContext context) async {
+    await _runAction(
+      ref,
+      context,
+      errorMessage: 'Failed to stop pending tool calls.',
+      action: () {
+        return ref
+            .read(stopAllPendingToolCallsUsecaseProvider)
+            .call(
+              messageId: messageId,
+            );
+      },
+    );
   }
-}
 
-String? _tryDecode(Object? metadata) {
-  if (metadata == null) return null;
-  dynamic decoded;
-  try {
-    if (metadata is String) {
-      decoded = jsonDecode(metadata);
+  Future<void> _runAction(
+    WidgetRef ref,
+    BuildContext context, {
+    required String errorMessage,
+    required Future<void> Function() action,
+  }) async {
+    try {
+      await action();
+      ref.invalidate(chatMessagesProvider);
+    } on Exception catch (error) {
+      debugPrint('Tool approval action failed: $error');
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('$errorMessage $error')),
+      );
     }
-  } on Exception catch (_) {
-    return metadata.toString();
   }
-
-  if (decoded is Map<String, dynamic>) {
-    if (decoded.length == 1) {
-      return _tryDecode(decoded.values.first);
-    }
-  }
-
-  return const JsonEncoder.withIndent('  ').convert(decoded);
 }

--- a/apps/auravibes_app/lib/i18n/locale_keys.dart
+++ b/apps/auravibes_app/lib/i18n/locale_keys.dart
@@ -156,6 +156,8 @@ abstract class LocaleKeys {
   static const tool_confirmation_skip = 'tool_confirmation.skip';
   static const tool_confirmation_stop_all = 'tool_confirmation.stop_all';
   static const tool_confirmation = 'tool_confirmation';
+  static const tool_approval_pending_count = 'tool_approval.pending_count';
+  static const tool_approval = 'tool_approval';
   static const tool_call_status_success = 'tool_call_status.success';
   static const tool_call_status_skipped_by_user =
       'tool_call_status.skipped_by_user';

--- a/apps/auravibes_app/lib/utils/try_decode_tool_metadata.dart
+++ b/apps/auravibes_app/lib/utils/try_decode_tool_metadata.dart
@@ -19,7 +19,11 @@ String? tryDecodeToolMetadata(Object? metadata) {
   }
 
   if (decoded is Map || decoded is List) {
-    return _toolMetadataEncoder.convert(decoded);
+    try {
+      return _toolMetadataEncoder.convert(decoded);
+    } on Object {
+      return decoded.toString();
+    }
   }
 
   return decoded.toString();

--- a/apps/auravibes_app/lib/utils/try_decode_tool_metadata.dart
+++ b/apps/auravibes_app/lib/utils/try_decode_tool_metadata.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+
+const JsonEncoder _toolMetadataEncoder = JsonEncoder.withIndent('  ');
+
+String? tryDecodeToolMetadata(Object? metadata) {
+  if (metadata == null) return null;
+
+  dynamic decoded;
+  try {
+    decoded = metadata is String ? jsonDecode(metadata) : metadata;
+  } on Exception catch (_) {
+    return metadata.toString();
+  }
+
+  if (decoded == null) return null;
+
+  if (decoded is Map && decoded.length == 1) {
+    return tryDecodeToolMetadata(decoded.values.first);
+  }
+
+  if (decoded is Map || decoded is List) {
+    return _toolMetadataEncoder.convert(decoded);
+  }
+
+  return decoded.toString();
+}


### PR DESCRIPTION
## What
- move pending tool approvals out of inline assistant message rows into a dedicated bottom approval card
- show one pending tool call at a time with previous/next navigation and the existing approval actions
- hide unresolved tool calls from the transcript while continuing to show resolved tool results

## Why
- inline approval controls made the transcript noisy and easy to miss during longer conversations
- keeping approvals in a fixed card preserves transcript context while making the pending action the primary focus

## Details
- add a `pendingToolCallsProvider` to derive pending approvals from the latest assistant message
- add `ChatToolApprovalCard` with localized approval count text and the existing allow/skip/stop actions
- keep the chat input mounted offstage so typed drafts are preserved while the approval card is visible
- avoid rendering empty assistant bubbles for messages that only contain pending tool calls

## Testing
- `fvm dart analyze lib/`
- `fvm flutter test --coverage --reporter=expanded`

## Checklist
- [x] main feature implemented
- [x] tests passing
- [x] code review ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a tool approval card showing pending tool calls with navigation, argument/response preview, and actions to approve once, approve for conversation, skip, or stop all.

* **UI Changes**
  * Replaces inline pending/confirmation indicators with the approval card; message input is hidden while approvals are pending and thinking indicator logic simplified.

* **Localization**
  * Added English and Spanish strings and new i18n keys for tool approval status.

* **Utilities**
  * Adds robust decoding for tool argument/response metadata to improve previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->