### PR TITLE
fix(models): reset add-provider mutation before dialog open

### DIFF
--- a/apps/auravibes_app/lib/features/models/screens/models_screen.dart
+++ b/apps/auravibes_app/lib/features/models/screens/models_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auravibes_app/features/models/providers/add_model_provider_providers.dart';
 import 'package:auravibes_app/features/models/providers/list_models_providers.dart';
 import 'package:auravibes_app/features/models/widgets/add_chat_model.dart';
 import 'package:auravibes_app/features/models/widgets/list_model_credentials.dart';
@@ -45,6 +46,7 @@ class _AddModelModalButton extends ConsumerWidget {
             Expanded(
               child: AuraButton(
                 onPressed: () {
+                  addCredentialsModelMutationProvider.reset(ref);
                   showDialog<void>(
                     context: context,
                     builder: (ctx) => Dialog(

--- a/apps/auravibes_app/lib/features/models/widgets/add_chat_model.dart
+++ b/apps/auravibes_app/lib/features/models/widgets/add_chat_model.dart
@@ -38,11 +38,6 @@ class AddModelProviderWidget extends HookConsumerWidget {
     final scrollController = useScrollController();
     final formKey = useMemoized(GlobalKey<FormState>.new, []);
 
-    useEffect(() {
-      addCredentialsModelMutationProvider.reset(ref);
-      return null;
-    }, []);
-
     final hasModel = ref.watch(
       addModelProviderStateProvider(workspaceId).select(
         (value) => value.modelId != null,


### PR DESCRIPTION
## Summary
- reset `addCredentialsModelMutationProvider` before opening the add-provider dialog instead of during hook initialization
- remove the `useEffect` reset from `AddModelProviderWidget` to avoid inherited widget access in `HookState.initState`
- keep modal behavior unchanged while fixing the runtime assertion in flutter_hooks

## Validation
- fvm dart analyze apps/auravibes_app/lib/features/models/screens/models_screen.dart apps/auravibes_app/lib/features/models/widgets/add_chat_model.dart