### PR TITLE
feat(chats): add context window usage indicator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,8 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 - Dart 3.x (FVM pinned to 3.41.4+) + Flutter, Riverpod (with code generation), Freezed, auravibes_ui (001-two-step-model-selector)
 - Drift database (existing, no schema changes needed) (001-two-step-model-selector)
 - Dart 3.11+ (Flutter 3.41.4+ via FVM) + Flutter SDK, flutter_portal, gpt_markdown, riverpod (existing) (001-ui-library-widgets)
+- Dart 3.11+ with Flutter 3.41.4+ (FVM pinned) + Flutter, Riverpod, Drift, LangChain (`ChatResult` / `LanguageModelUsage`), auravibes_ui (003-token-usage-context)
+- Existing Drift `messages` table metadata JSON (no schema migration planned) (003-token-usage-context)
 
 ## Recent Changes
 - 001-two-step-model-selector: Added Dart 3.x (FVM pinned to 3.41.4+) + Flutter, Riverpod (with code generation), Freezed, auravibes_ui

--- a/apps/auravibes_app/assets/i18n/en.json
+++ b/apps/auravibes_app/assets/i18n/en.json
@@ -77,7 +77,20 @@
       "delete_confirm": "Are you sure you want to delete this conversation? This action cannot be undone.",
       "options_tooltip": "More options",
       "error_workspace_mismatch": "This conversation belongs to a different workspace",
-      "error_not_found": "Conversation not found"
+      "error_not_found": "Conversation not found",
+      "context_usage": {
+        "label": "Context window usage",
+        "limit_unavailable": "Context window limit unavailable for this model.",
+        "tooltip_normal": "Using {used} of {limit} tokens ({percent}%). Healthy headroom.",
+        "tooltip_elevated": "Using {used} of {limit} tokens ({percent}%). Approaching limit.",
+        "tooltip_warning": "Using {used} of {limit} tokens ({percent}%). Near context limit.",
+        "tooltip_overflow": "Using {used} of {limit} tokens ({percent}%). Over limit by {overflow} tokens.",
+        "semantic_limit_unavailable": "{usage}, context limit unavailable",
+        "semantic_normal": "{usage}, {percent} percent",
+        "semantic_elevated": "{usage}, {percent} percent, approaching limit",
+        "semantic_warning": "{usage}, {percent} percent, near limit",
+        "semantic_overflow": "{usage}, {percent} percent, over limit by {overflow} tokens"
+      }
     }
   },
   "tools_screen": {

--- a/apps/auravibes_app/assets/i18n/es.json
+++ b/apps/auravibes_app/assets/i18n/es.json
@@ -77,7 +77,20 @@
       "delete_confirm": "¿Estás seguro de que deseas eliminar esta conversación? Esta acción no se puede deshacer.",
       "options_tooltip": "Más opciones",
       "error_workspace_mismatch": "Esta conversación pertenece a un espacio de trabajo diferente",
-      "error_not_found": "Conversación no encontrada"
+      "error_not_found": "Conversación no encontrada",
+      "context_usage": {
+        "label": "Uso de ventana de contexto",
+        "limit_unavailable": "El límite de contexto no está disponible para este modelo.",
+        "tooltip_normal": "Usando {used} de {limit} tokens ({percent}%). Margen saludable.",
+        "tooltip_elevated": "Usando {used} de {limit} tokens ({percent}%). Acercándose al límite.",
+        "tooltip_warning": "Usando {used} de {limit} tokens ({percent}%). Cerca del límite de contexto.",
+        "tooltip_overflow": "Usando {used} de {limit} tokens ({percent}%). Supera el límite por {overflow} tokens.",
+        "semantic_limit_unavailable": "{usage}, límite de contexto no disponible",
+        "semantic_normal": "{usage}, {percent} por ciento",
+        "semantic_elevated": "{usage}, {percent} por ciento, acercándose al límite",
+        "semantic_warning": "{usage}, {percent} por ciento, cerca del límite",
+        "semantic_overflow": "{usage}, {percent} por ciento, supera el límite por {overflow} tokens"
+      }
     }
   },
   "tools_screen": {

--- a/apps/auravibes_app/lib/data/database/drift/app_database.dart
+++ b/apps/auravibes_app/lib/data/database/drift/app_database.dart
@@ -109,9 +109,9 @@ class AppDatabase extends _$AppDatabase {
             '  SELECT t1.rowid FROM tools t1'
             '  INNER JOIN tools t2 ON t1.workspace_id = t2.workspace_id'
             '    AND t1.tool_id = t2.tool_id'
-            '    AND t1.workspace_tools_group_id IS NULL'
-            '    AND t2.workspace_tools_group_id IS NULL'
-            '    AND t1.rowid > t2.rowid'
+            '    AND t1.workspace_tools_group_id IS NULL '
+            '    AND t2.workspace_tools_group_id IS NULL '
+            '    AND t1.rowid > t2.rowid '
             ')',
           );
           // Unique index for native tools (groupId IS NULL)
@@ -127,8 +127,8 @@ class AppDatabase extends _$AppDatabase {
             '  INNER JOIN tools t2 ON t1.workspace_id = t2.workspace_id'
             '    AND t1.tool_id = t2.tool_id'
             '    AND t1.workspace_tools_group_id = t2.workspace_tools_group_id'
-            '    AND t1.workspace_tools_group_id IS NOT NULL'
-            '    AND t1.rowid > t2.rowid'
+            '    AND t1.workspace_tools_group_id IS NOT NULL '
+            '    AND t1.rowid > t2.rowid '
             ')',
           );
           // Unique index for MCP tools (groupId IS NOT NULL)

--- a/apps/auravibes_app/lib/domain/entities/messages.dart
+++ b/apps/auravibes_app/lib/domain/entities/messages.dart
@@ -66,7 +66,11 @@ String? _toolCallResultStatusToJson(ToolCallResultStatus? status) {
 abstract class MessageMetadataEntity with _$MessageMetadataEntity {
   const factory MessageMetadataEntity({
     @Default(<MessageToolCallEntity>[]) List<MessageToolCallEntity> toolCalls,
+    int? promptTokens,
+    int? completionTokens,
+    int? totalTokens,
   }) = _MessageMetadataEntity;
+  const MessageMetadataEntity._();
 
   factory MessageMetadataEntity.fromJson(Map<String, dynamic> json) =>
       _$MessageMetadataEntityFromJson(json);
@@ -79,6 +83,10 @@ abstract class MessageMetadataEntity with _$MessageMetadataEntity {
     } on Exception catch (_) {
       return null;
     }
+  }
+
+  int get usedTokens {
+    return totalTokens ?? ((promptTokens ?? 0) + (completionTokens ?? 0));
   }
 }
 

--- a/apps/auravibes_app/lib/features/chats/providers/messages_providers.dart
+++ b/apps/auravibes_app/lib/features/chats/providers/messages_providers.dart
@@ -7,6 +7,9 @@ import 'package:auravibes_app/features/chats/notifiers/messages_streaming_notifi
 import 'package:auravibes_app/features/chats/providers/conversation_repository_provider.dart';
 import 'package:auravibes_app/features/chats/providers/conversation_selection_provider.dart';
 import 'package:auravibes_app/features/chats/usecases/get_conversation_busy_state_usecase.dart';
+import 'package:auravibes_app/features/models/providers/api_model_repository_providers.dart';
+import 'package:auravibes_app/features/models/providers/model_providers_repository_providers.dart';
+import 'package:auravibes_app/utils/chat_result_extension.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -149,6 +152,108 @@ class PendingToolCall {
 
   final MessageToolCallEntity toolCall;
   final String messageId;
+}
+
+@immutable
+class ConversationTokenUsageSummary {
+  const ConversationTokenUsageSummary({
+    required this.usedTokens,
+    required this.limitTokens,
+    required this.percent,
+    required this.progress,
+  });
+
+  final int usedTokens;
+  final int limitTokens;
+  // Raw percent can exceed 100 when context overflows.
+  final int percent;
+  // Progress is normalized for meters and clamped to 0..1.
+  final double progress;
+}
+
+@Riverpod(
+  dependencies: [
+    apiModelRepository,
+    credentialsModelsRepository,
+  ],
+)
+Future<int> modelContextLimit(Ref ref, String? credentialsModelId) async {
+  if (credentialsModelId == null) return 0;
+
+  final selectedModel = await ref
+      .watch(credentialsModelsRepositoryProvider)
+      .getCredentialsModelById(credentialsModelId);
+  final modelId = selectedModel?.credentialsModel.modelId;
+  if (modelId == null) return 0;
+
+  final models = await ref.watch(apiModelRepositoryProvider).getAllModels();
+  final apiModel = models.firstWhereOrNull((model) => model.id == modelId);
+  return apiModel?.limitContext ?? 0;
+}
+
+@Riverpod(dependencies: [chatMessages, MessagesStreamingNotifier])
+int conversationUsedTokens(Ref ref) {
+  final messages = ref.watch(
+    chatMessagesProvider.select((value) => value.value),
+  );
+  if (messages == null || messages.isEmpty) return 0;
+
+  final latestAssistantMessage = messages.lastWhereOrNull(
+    (message) => !message.isUser,
+  );
+  if (latestAssistantMessage == null) return 0;
+
+  final streamingResult = ref.watch(
+    messagesStreamingProvider.select(
+      (state) => state[latestAssistantMessage.id]?.lastResult,
+    ),
+  );
+
+  return streamingResult?.entityTotalTokens ??
+      latestAssistantMessage.metadata?.usedTokens ??
+      0;
+}
+
+@Riverpod(dependencies: [conversationSelected])
+Future<int> conversationContextLimit(Ref ref) async {
+  final conversationId = ref.watch(conversationSelectedProvider);
+  final conversation = await ref
+      .watch(conversationRepositoryProvider)
+      .getConversationById(conversationId);
+  final conversationModelId = conversation?.modelId;
+
+  if (conversationModelId == null) return 0;
+
+  final selectedModel = await ref.watch(
+    modelContextLimitProvider(conversationModelId).future,
+  );
+
+  return selectedModel;
+}
+
+@Riverpod(
+  dependencies: [conversationUsedTokens, conversationContextLimit],
+)
+AsyncValue<ConversationTokenUsageSummary> conversationTokenUsageSummary(
+  Ref ref,
+) {
+  final usedTokens = ref.watch(conversationUsedTokensProvider);
+  final limitTokensAsync = ref.watch(conversationContextLimitProvider);
+
+  return limitTokensAsync.whenData((limitTokens) {
+    final normalizedLimit = limitTokens < 0 ? 0 : limitTokens;
+    final rawPercent = normalizedLimit == 0
+        ? 0
+        : ((usedTokens / normalizedLimit) * 100).round();
+    final normalizedProgress = rawPercent.clamp(0, 100) / 100;
+
+    return ConversationTokenUsageSummary(
+      usedTokens: usedTokens,
+      limitTokens: normalizedLimit,
+      percent: rawPercent,
+      progress: normalizedProgress,
+    );
+  });
 }
 
 @Riverpod(dependencies: [chatMessages])

--- a/apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart
+++ b/apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart
@@ -111,10 +111,8 @@ class _ChatConversationScreen extends HookConsumerWidget {
     return AuraScreen(
       appBar: AuraAppBarWithDrawer(
         title: Text(conversation.title),
-        actions: [
-          ConversationContextUsagePill(
-            credentialsModelId: conversation.modelId,
-          ),
+        actions: const [
+          ConversationContextUsagePill(),
         ],
         bottom: SelectCredentialsModelWidget(
           workspaceId: workspaceId,

--- a/apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart
+++ b/apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart
@@ -8,6 +8,7 @@ import 'package:auravibes_app/features/chats/widgets/chat_messages_widget.dart';
 import 'package:auravibes_app/features/chats/widgets/chat_queued_messages_indicator.dart';
 import 'package:auravibes_app/features/chats/widgets/chat_thinking_indicator.dart';
 import 'package:auravibes_app/features/chats/widgets/chat_tool_approval_card.dart';
+import 'package:auravibes_app/features/chats/widgets/conversation_context_usage_pill.dart';
 import 'package:auravibes_app/features/chats/widgets/mcp_connecting_indicator.dart';
 import 'package:auravibes_app/features/models/widgets/select_chat_model.dart';
 import 'package:auravibes_app/features/tools/widgets/tools_management_modal.dart';
@@ -110,6 +111,11 @@ class _ChatConversationScreen extends HookConsumerWidget {
     return AuraScreen(
       appBar: AuraAppBarWithDrawer(
         title: Text(conversation.title),
+        actions: [
+          ConversationContextUsagePill(
+            credentialsModelId: conversation.modelId,
+          ),
+        ],
         bottom: SelectCredentialsModelWidget(
           workspaceId: workspaceId,
           credentialsModelId: conversation.modelId,

--- a/apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart
+++ b/apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart
@@ -176,7 +176,8 @@ class ContinueAgentUsecase {
 
       await messageRepository.updateMessage(
         firstMessage.id,
-        const .new(
+        .new(
+          metadata: lastResult.entityMetadata,
           status: .sent,
         ),
       );

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -307,6 +307,13 @@ String _formatCompactTokens(int value) {
     final formatted = value % 1000 == 0
         ? k.toStringAsFixed(0)
         : k.toStringAsFixed(1);
+    if (double.tryParse(formatted) != null && double.parse(formatted) >= 1000) {
+      final m = value / 1000000;
+      final mFormatted = (m * 10).truncateToDouble() == m * 10
+          ? m.toStringAsFixed(1)
+          : m.toStringAsFixed(1);
+      return '${mFormatted}m';
+    }
     return '${formatted}k';
   }
 

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -31,6 +31,7 @@ class ConversationContextUsagePill extends ConsumerWidget {
               .tr(),
           value: viewModel.semanticValue,
           container: true,
+          excludeSemantics: true,
           child: AuraContainer(
             padding: const AuraEdgeInsetsGeometry.symmetric(
               horizontal: AuraSpacing.sm,

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -55,7 +55,7 @@ class ConversationContextUsagePill extends ConsumerWidget {
                     ),
                     child: LinearProgressIndicator(
                       minHeight: 4,
-                      value: viewModel.progress,
+                      value: viewModel.progress.clamp(0.0, 1.0),
                       color: viewModel.progressColor(auraColors),
                       backgroundColor: auraColors.onSurfaceVariant.withValues(
                         alpha: 0.25,

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -10,16 +10,11 @@ class ConversationContextUsagePill extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final usageSummary =
-        ref.watch(conversationTokenUsageSummaryProvider).value ??
-        const ConversationTokenUsageSummary(
-          usedTokens: 0,
-          limitTokens: 0,
-          percent: 0,
-          progress: 0,
-        );
-
-    final viewModel = _ContextUsageViewModel.fromSummary(usageSummary);
+    final usageSummaryAsync = ref.watch(conversationTokenUsageSummaryProvider);
+    final viewModel = switch (usageSummaryAsync) {
+      AsyncData(:final value) => _ContextUsageViewModel.fromSummary(value),
+      AsyncLoading() || AsyncError() => _ContextUsageViewModel.unavailable(),
+    };
     final auraColors = context.auraColors;
 
     return Padding(
@@ -212,6 +207,29 @@ class _ContextUsageViewModel {
       iconColor: level.iconColor,
       level: level,
       progress: summary.progress,
+    );
+  }
+
+  factory _ContextUsageViewModel.unavailable() {
+    const usageLabel = '--/--';
+    const semanticLimitUnavailable = LocaleKeys
+        // ignore: lines_longer_than_80_chars - generated LocaleKeys name
+        .chats_screens_chat_conversation_context_usage_semantic_limit_unavailable;
+
+    return _ContextUsageViewModel(
+      usageLabel: usageLabel,
+      percentLabel: '--',
+      tooltip: LocaleKeys
+          .chats_screens_chat_conversation_context_usage_limit_unavailable
+          .tr(),
+      semanticValue: semanticLimitUnavailable.tr(
+        namedArgs: {'usage': usageLabel},
+      ),
+      badgeVariant: AuraBadgeVariant.neutral,
+      icon: Icons.help_outline,
+      iconColor: AuraColorVariant.onSurfaceVariant,
+      level: _ContextUsageLevel.unknown,
+      progress: 0,
     );
   }
 

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -1,0 +1,317 @@
+import 'package:auravibes_app/features/chats/providers/messages_providers.dart';
+import 'package:auravibes_app/i18n/locale_keys.dart';
+import 'package:auravibes_ui/ui.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class ConversationContextUsagePill extends ConsumerWidget {
+  const ConversationContextUsagePill({
+    required this.credentialsModelId,
+    super.key,
+  });
+
+  final String? credentialsModelId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final usedTokens = ref.watch(conversationUsedTokensProvider);
+    final limitTokens =
+        ref.watch(modelContextLimitProvider(credentialsModelId)).value ?? 0;
+    final rawPercent = limitTokens == 0
+        ? 0
+        : ((usedTokens / limitTokens) * 100).round();
+    final usageSummary = ConversationTokenUsageSummary(
+      usedTokens: usedTokens,
+      limitTokens: limitTokens,
+      percent: rawPercent,
+      progress: rawPercent.clamp(0, 100) / 100,
+    );
+
+    final viewModel = _ContextUsageViewModel.fromSummary(usageSummary);
+    final auraColors = context.auraColors;
+
+    return Padding(
+      padding: const EdgeInsets.only(right: DesignSpacing.sm),
+      child: AuraTooltip(
+        message: viewModel.tooltip,
+        child: Semantics(
+          label: LocaleKeys.chats_screens_chat_conversation_context_usage_label
+              .tr(),
+          value: viewModel.semanticValue,
+          liveRegion: true,
+          child: AuraContainer(
+            padding: const AuraEdgeInsetsGeometry.symmetric(
+              horizontal: AuraSpacing.sm,
+              vertical: AuraSpacing.xs,
+            ),
+            borderRadius: context.auraTheme.borderRadius.full,
+            backgroundColor: AuraColorVariant.surfaceVariant,
+            border: Border.all(color: auraColors.outlineVariant),
+            child: AuraRow(
+              mainAxisSize: MainAxisSize.min,
+              spacing: AuraSpacing.xs,
+              children: [
+                AuraIcon(
+                  viewModel.icon,
+                  size: AuraIconSize.extraSmall,
+                  color: viewModel.iconColor,
+                ),
+                SizedBox(
+                  width: 26,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(
+                      DesignBorderRadius.full,
+                    ),
+                    child: LinearProgressIndicator(
+                      minHeight: 4,
+                      value: viewModel.progress,
+                      color: viewModel.progressColor(auraColors),
+                      backgroundColor: auraColors.onSurfaceVariant.withValues(
+                        alpha: 0.25,
+                      ),
+                    ),
+                  ),
+                ),
+                AuraText(
+                  style: AuraTextStyle.caption,
+                  color: AuraColorVariant.onSurfaceVariant,
+                  child: Text(viewModel.usageLabel),
+                ),
+                AuraBadge.text(
+                  size: AuraBadgeSize.small,
+                  variant: viewModel.badgeVariant,
+                  child: Text(viewModel.percentLabel),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ContextUsageViewModel {
+  const _ContextUsageViewModel({
+    required this.usageLabel,
+    required this.percentLabel,
+    required this.tooltip,
+    required this.semanticValue,
+    required this.badgeVariant,
+    required this.icon,
+    required this.iconColor,
+    required this.level,
+    required this.progress,
+  });
+
+  factory _ContextUsageViewModel.fromSummary(
+    ConversationTokenUsageSummary summary,
+  ) {
+    final hasLimit = summary.limitTokens > 0;
+    const limitUnavailableSemantic =
+        'chats_screens.chat_conversation.context_usage.'
+        'semantic_limit_unavailable';
+    final usageLabel = hasLimit
+        ? '${_formatCompactTokens(summary.usedTokens)}/${_formatCompactTokens(summary.limitTokens)}'
+        : '${_formatCompactTokens(summary.usedTokens)}/--';
+
+    if (!hasLimit) {
+      return _ContextUsageViewModel(
+        usageLabel: usageLabel,
+        percentLabel: '--',
+        tooltip: LocaleKeys
+            .chats_screens_chat_conversation_context_usage_limit_unavailable
+            .tr(),
+        semanticValue: limitUnavailableSemantic.tr(
+          namedArgs: {'usage': usageLabel},
+        ),
+        badgeVariant: AuraBadgeVariant.neutral,
+        icon: Icons.help_outline,
+        iconColor: AuraColorVariant.onSurfaceVariant,
+        level: _ContextUsageLevel.unknown,
+        progress: 0,
+      );
+    }
+
+    final level = _ContextUsageLevel.fromPercent(summary.percent);
+    final overflowTokens = summary.usedTokens - summary.limitTokens;
+    final tooltip = switch (level) {
+      _ContextUsageLevel.normal =>
+        LocaleKeys.chats_screens_chat_conversation_context_usage_tooltip_normal
+            .tr(
+              namedArgs: _tooltipArgs(summary),
+            ),
+      _ContextUsageLevel.elevated =>
+        LocaleKeys
+            .chats_screens_chat_conversation_context_usage_tooltip_elevated
+            .tr(
+              namedArgs: _tooltipArgs(summary),
+            ),
+      _ContextUsageLevel.warning =>
+        LocaleKeys.chats_screens_chat_conversation_context_usage_tooltip_warning
+            .tr(
+              namedArgs: _tooltipArgs(summary),
+            ),
+      _ContextUsageLevel.overflow =>
+        LocaleKeys
+            .chats_screens_chat_conversation_context_usage_tooltip_overflow
+            .tr(
+              namedArgs: {
+                ..._tooltipArgs(summary),
+                'overflow': '$overflowTokens',
+              },
+            ),
+      _ContextUsageLevel.unknown =>
+        LocaleKeys
+            .chats_screens_chat_conversation_context_usage_limit_unavailable
+            .tr(),
+    };
+
+    final semanticValue = switch (level) {
+      _ContextUsageLevel.normal =>
+        LocaleKeys.chats_screens_chat_conversation_context_usage_semantic_normal
+            .tr(
+              namedArgs: {
+                'usage': usageLabel,
+                'percent': '${summary.percent}',
+              },
+            ),
+      _ContextUsageLevel.elevated =>
+        LocaleKeys
+            .chats_screens_chat_conversation_context_usage_semantic_elevated
+            .tr(
+              namedArgs: {
+                'usage': usageLabel,
+                'percent': '${summary.percent}',
+              },
+            ),
+      _ContextUsageLevel.warning =>
+        LocaleKeys
+            .chats_screens_chat_conversation_context_usage_semantic_warning
+            .tr(
+              namedArgs: {
+                'usage': usageLabel,
+                'percent': '${summary.percent}',
+              },
+            ),
+      _ContextUsageLevel.overflow =>
+        LocaleKeys
+            .chats_screens_chat_conversation_context_usage_semantic_overflow
+            .tr(
+              namedArgs: {
+                'usage': usageLabel,
+                'percent': '${summary.percent}',
+                'overflow': '$overflowTokens',
+              },
+            ),
+      _ContextUsageLevel.unknown => limitUnavailableSemantic.tr(
+        namedArgs: {'usage': usageLabel},
+      ),
+    };
+
+    return _ContextUsageViewModel(
+      usageLabel: usageLabel,
+      percentLabel: '${summary.percent}%',
+      tooltip: tooltip,
+      semanticValue: semanticValue,
+      badgeVariant: level.badgeVariant,
+      icon: level.icon,
+      iconColor: level.iconColor,
+      level: level,
+      progress: summary.progress,
+    );
+  }
+
+  final String usageLabel;
+  final String percentLabel;
+  final String tooltip;
+  final String semanticValue;
+  final AuraBadgeVariant badgeVariant;
+  final IconData icon;
+  final AuraColorVariant iconColor;
+  final _ContextUsageLevel level;
+  final double progress;
+
+  Color progressColor(AuraColorScheme colors) {
+    return switch (level) {
+      _ContextUsageLevel.normal => colors.success,
+      _ContextUsageLevel.elevated => colors.info,
+      _ContextUsageLevel.warning => colors.warning,
+      _ContextUsageLevel.overflow => colors.error,
+      _ContextUsageLevel.unknown => colors.onSurfaceVariant,
+    };
+  }
+}
+
+Map<String, String> _tooltipArgs(ConversationTokenUsageSummary summary) {
+  return {
+    'used': '${summary.usedTokens}',
+    'limit': '${summary.limitTokens}',
+    'percent': '${summary.percent}',
+  };
+}
+
+enum _ContextUsageLevel {
+  normal,
+  elevated,
+  warning,
+  overflow,
+  unknown
+  ;
+
+  static _ContextUsageLevel fromPercent(int percent) {
+    if (percent > 100) return _ContextUsageLevel.overflow;
+    if (percent >= 85) return _ContextUsageLevel.warning;
+    if (percent >= 70) return _ContextUsageLevel.elevated;
+    return _ContextUsageLevel.normal;
+  }
+
+  AuraBadgeVariant get badgeVariant {
+    return switch (this) {
+      _ContextUsageLevel.normal => AuraBadgeVariant.success,
+      _ContextUsageLevel.elevated => AuraBadgeVariant.info,
+      _ContextUsageLevel.warning => AuraBadgeVariant.warning,
+      _ContextUsageLevel.overflow => AuraBadgeVariant.error,
+      _ContextUsageLevel.unknown => AuraBadgeVariant.neutral,
+    };
+  }
+
+  IconData get icon {
+    return switch (this) {
+      _ContextUsageLevel.normal => Icons.check_circle_outline,
+      _ContextUsageLevel.elevated => Icons.info_outline,
+      _ContextUsageLevel.warning => Icons.warning_amber_outlined,
+      _ContextUsageLevel.overflow => Icons.priority_high,
+      _ContextUsageLevel.unknown => Icons.help_outline,
+    };
+  }
+
+  AuraColorVariant get iconColor {
+    return switch (this) {
+      _ContextUsageLevel.normal => AuraColorVariant.success,
+      _ContextUsageLevel.elevated => AuraColorVariant.info,
+      _ContextUsageLevel.warning => AuraColorVariant.warning,
+      _ContextUsageLevel.overflow => AuraColorVariant.error,
+      _ContextUsageLevel.unknown => AuraColorVariant.onSurfaceVariant,
+    };
+  }
+}
+
+String _formatCompactTokens(int value) {
+  if (value >= 1000000) {
+    final formatted = value % 1000000 == 0
+        ? (value / 1000000).toStringAsFixed(0)
+        : (value / 1000000).toStringAsFixed(1);
+    return '${formatted}m';
+  }
+
+  if (value >= 1000) {
+    final formatted = value % 1000 == 0
+        ? (value / 1000).toStringAsFixed(0)
+        : (value / 1000).toStringAsFixed(1);
+    return '${formatted}k';
+  }
+
+  return '$value';
+}

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -300,17 +300,12 @@ String _formatCompactTokens(int value) {
 
   if (value >= 1000) {
     final k = value / 1000;
-    if (k >= 1000) {
-      final formatted = k.truncateToDouble() == k
-          ? (value / 1000000).toStringAsFixed(0)
-          : (value / 1000000).toStringAsFixed(1);
-      return '${formatted}m';
-    }
     final formatted = value % 1000 == 0
         ? k.toStringAsFixed(0)
         : k.toStringAsFixed(1);
-    if (double.tryParse(formatted) != null && double.parse(formatted) >= 1000) {
-      final m = value / 1000000;
+    final roundedK = double.tryParse(formatted);
+    if (roundedK != null && roundedK >= 1000) {
+      final m = roundedK / 1000;
       final mFormatted = m.truncateToDouble() == m
           ? m.toStringAsFixed(0)
           : m.toStringAsFixed(1);

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -100,7 +100,7 @@ class _ContextUsageViewModel {
   ) {
     final hasLimit = summary.limitTokens > 0;
     const _s = LocaleKeys
-        // ignore: lines_longer_than_80_chars
+        // ignore: lines_longer_than_80_chars - generated LocaleKeys name
         .chats_screens_chat_conversation_context_usage_semantic_limit_unavailable;
     final usageLabel = hasLimit
         ? '${_formatCompactTokens(summary.usedTokens)}/${_formatCompactTokens(summary.limitTokens)}'

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -6,27 +6,18 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 class ConversationContextUsagePill extends ConsumerWidget {
-  const ConversationContextUsagePill({
-    required this.credentialsModelId,
-    super.key,
-  });
-
-  final String? credentialsModelId;
+  const ConversationContextUsagePill({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final usedTokens = ref.watch(conversationUsedTokensProvider);
-    final limitTokens =
-        ref.watch(modelContextLimitProvider(credentialsModelId)).value ?? 0;
-    final rawPercent = limitTokens == 0
-        ? 0
-        : ((usedTokens / limitTokens) * 100).round();
-    final usageSummary = ConversationTokenUsageSummary(
-      usedTokens: usedTokens,
-      limitTokens: limitTokens,
-      percent: rawPercent,
-      progress: rawPercent.clamp(0, 100) / 100,
-    );
+    final usageSummary =
+        ref.watch(conversationTokenUsageSummaryProvider).value ??
+        const ConversationTokenUsageSummary(
+          usedTokens: 0,
+          limitTokens: 0,
+          percent: 0,
+          progress: 0,
+        );
 
     final viewModel = _ContextUsageViewModel.fromSummary(usageSummary);
     final auraColors = context.auraColors;
@@ -39,7 +30,6 @@ class ConversationContextUsagePill extends ConsumerWidget {
           label: LocaleKeys.chats_screens_chat_conversation_context_usage_label
               .tr(),
           value: viewModel.semanticValue,
-          liveRegion: true,
           child: AuraContainer(
             padding: const AuraEdgeInsetsGeometry.symmetric(
               horizontal: AuraSpacing.sm,
@@ -109,9 +99,9 @@ class _ContextUsageViewModel {
     ConversationTokenUsageSummary summary,
   ) {
     final hasLimit = summary.limitTokens > 0;
-    const limitUnavailableSemantic =
-        'chats_screens.chat_conversation.context_usage.'
-        'semantic_limit_unavailable';
+    const _s = LocaleKeys
+        // ignore: lines_longer_than_80_chars
+        .chats_screens_chat_conversation_context_usage_semantic_limit_unavailable;
     final usageLabel = hasLimit
         ? '${_formatCompactTokens(summary.usedTokens)}/${_formatCompactTokens(summary.limitTokens)}'
         : '${_formatCompactTokens(summary.usedTokens)}/--';
@@ -123,7 +113,7 @@ class _ContextUsageViewModel {
         tooltip: LocaleKeys
             .chats_screens_chat_conversation_context_usage_limit_unavailable
             .tr(),
-        semanticValue: limitUnavailableSemantic.tr(
+        semanticValue: _s.tr(
           namedArgs: {'usage': usageLabel},
         ),
         badgeVariant: AuraBadgeVariant.neutral,
@@ -205,7 +195,7 @@ class _ContextUsageViewModel {
                 'overflow': '$overflowTokens',
               },
             ),
-      _ContextUsageLevel.unknown => limitUnavailableSemantic.tr(
+      _ContextUsageLevel.unknown => _s.tr(
         namedArgs: {'usage': usageLabel},
       ),
     };
@@ -307,9 +297,16 @@ String _formatCompactTokens(int value) {
   }
 
   if (value >= 1000) {
+    final k = value / 1000;
+    if (k >= 1000) {
+      final formatted = k.truncateToDouble() == k
+          ? (value / 1000000).toStringAsFixed(0)
+          : (value / 1000000).toStringAsFixed(1);
+      return '${formatted}m';
+    }
     final formatted = value % 1000 == 0
-        ? (value / 1000).toStringAsFixed(0)
-        : (value / 1000).toStringAsFixed(1);
+        ? k.toStringAsFixed(0)
+        : k.toStringAsFixed(1);
     return '${formatted}k';
   }
 

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -30,6 +30,7 @@ class ConversationContextUsagePill extends ConsumerWidget {
           label: LocaleKeys.chats_screens_chat_conversation_context_usage_label
               .tr(),
           value: viewModel.semanticValue,
+          container: true,
           child: AuraContainer(
             padding: const AuraEdgeInsetsGeometry.symmetric(
               horizontal: AuraSpacing.sm,
@@ -309,8 +310,8 @@ String _formatCompactTokens(int value) {
         : k.toStringAsFixed(1);
     if (double.tryParse(formatted) != null && double.parse(formatted) >= 1000) {
       final m = value / 1000000;
-      final mFormatted = (m * 10).truncateToDouble() == m * 10
-          ? m.toStringAsFixed(1)
+      final mFormatted = m.truncateToDouble() == m
+          ? m.toStringAsFixed(0)
           : m.toStringAsFixed(1);
       return '${mFormatted}m';
     }

--- a/apps/auravibes_app/lib/i18n/locale_keys.dart
+++ b/apps/auravibes_app/lib/i18n/locale_keys.dart
@@ -10,7 +10,6 @@ abstract class LocaleKeys {
   static const menu_models = 'menu.models';
   static const menu_agents = 'menu.agents';
   static const menu_prompts = 'menu.prompts';
-  static const menu = 'menu';
   static const models_screens_select_provider =
       'models_screens.select_provider';
   static const models_screens_select_model = 'models_screens.select_model';
@@ -41,51 +40,36 @@ abstract class LocaleKeys {
       'models_screens.add_provider.create_button';
   static const models_screens_add_provider_sections_advanced =
       'models_screens.add_provider.sections.advanced';
-  static const models_screens_add_provider_sections =
-      'models_screens.add_provider.sections';
   static const models_screens_add_provider_fields_name_label =
       'models_screens.add_provider.fields.name.label';
   static const models_screens_add_provider_fields_name_placeholder =
       'models_screens.add_provider.fields.name.placeholder';
   static const models_screens_add_provider_fields_name_hint =
       'models_screens.add_provider.fields.name.hint';
-  static const models_screens_add_provider_fields_name =
-      'models_screens.add_provider.fields.name';
   static const models_screens_add_provider_fields_key_label =
       'models_screens.add_provider.fields.key.label';
   static const models_screens_add_provider_fields_key_placeholder =
       'models_screens.add_provider.fields.key.placeholder';
   static const models_screens_add_provider_fields_key_hint =
       'models_screens.add_provider.fields.key.hint';
-  static const models_screens_add_provider_fields_key =
-      'models_screens.add_provider.fields.key';
   static const models_screens_add_provider_fields_url_label =
       'models_screens.add_provider.fields.url.label';
   static const models_screens_add_provider_fields_url_placeholder =
       'models_screens.add_provider.fields.url.placeholder';
   static const models_screens_add_provider_fields_url_hint =
       'models_screens.add_provider.fields.url.hint';
-  static const models_screens_add_provider_fields_url =
-      'models_screens.add_provider.fields.url';
-  static const models_screens_add_provider_fields =
-      'models_screens.add_provider.fields';
   static const models_screens_add_provider_search_placeholder =
       'models_screens.add_provider.search.placeholder';
   static const models_screens_add_provider_search_no_models_found =
       'models_screens.add_provider.search.no_models_found';
   static const models_screens_add_provider_search_no_icon =
       'models_screens.add_provider.search.no_icon';
-  static const models_screens_add_provider_search =
-      'models_screens.add_provider.search';
   static const models_screens_add_provider_errors_unknown =
       'models_screens.add_provider.errors.unknown';
-  static const models_screens_add_provider = 'models_screens.add_provider';
-  static const models_screens = 'models_screens';
   static const chats_screens_chats_list_title =
       'chats_screens.chats_list.title';
   static const chats_screens_chats_list_add_chat =
       'chats_screens.chats_list.add_chat';
-  static const chats_screens_chats_list = 'chats_screens.chats_list';
   static const chats_screens_chat_conversation_select_model_selctor =
       'chats_screens.chat_conversation.select_model_selctor';
   static const chats_screens_chat_conversation_message_placeholder =
@@ -112,9 +96,28 @@ abstract class LocaleKeys {
       'chats_screens.chat_conversation.error_workspace_mismatch';
   static const chats_screens_chat_conversation_error_not_found =
       'chats_screens.chat_conversation.error_not_found';
-  static const chats_screens_chat_conversation =
-      'chats_screens.chat_conversation';
-  static const chats_screens = 'chats_screens';
+  static const chats_screens_chat_conversation_context_usage_label =
+      'chats_screens.chat_conversation.context_usage.label';
+  static const chats_screens_chat_conversation_context_usage_limit_unavailable =
+      'chats_screens.chat_conversation.context_usage.limit_unavailable';
+  static const chats_screens_chat_conversation_context_usage_tooltip_normal =
+      'chats_screens.chat_conversation.context_usage.tooltip_normal';
+  static const chats_screens_chat_conversation_context_usage_tooltip_elevated =
+      'chats_screens.chat_conversation.context_usage.tooltip_elevated';
+  static const chats_screens_chat_conversation_context_usage_tooltip_warning =
+      'chats_screens.chat_conversation.context_usage.tooltip_warning';
+  static const chats_screens_chat_conversation_context_usage_tooltip_overflow =
+      'chats_screens.chat_conversation.context_usage.tooltip_overflow';
+  static const chats_screens_chat_conversation_context_usage_semantic_limit_unavailable =
+      'chats_screens.chat_conversation.context_usage.semantic_limit_unavailable';
+  static const chats_screens_chat_conversation_context_usage_semantic_normal =
+      'chats_screens.chat_conversation.context_usage.semantic_normal';
+  static const chats_screens_chat_conversation_context_usage_semantic_elevated =
+      'chats_screens.chat_conversation.context_usage.semantic_elevated';
+  static const chats_screens_chat_conversation_context_usage_semantic_warning =
+      'chats_screens.chat_conversation.context_usage.semantic_warning';
+  static const chats_screens_chat_conversation_context_usage_semantic_overflow =
+      'chats_screens.chat_conversation.context_usage.semantic_overflow';
   static const tools_screen_title = 'tools_screen.title';
   static const tools_screen_refresh_tooltip = 'tools_screen.refresh_tooltip';
   static const tools_screen_workspace_ai_tools =
@@ -156,15 +159,12 @@ abstract class LocaleKeys {
       'tools_screen.delete_mcp_confirm';
   static const tools_screen_no_tools_in_group =
       'tools_screen.no_tools_in_group';
-  static const tools_screen = 'tools_screen';
   static const tool_confirmation_allow_once = 'tool_confirmation.allow_once';
   static const tool_confirmation_allow_conversation =
       'tool_confirmation.allow_conversation';
   static const tool_confirmation_skip = 'tool_confirmation.skip';
   static const tool_confirmation_stop_all = 'tool_confirmation.stop_all';
-  static const tool_confirmation = 'tool_confirmation';
   static const tool_approval_pending_count = 'tool_approval.pending_count';
-  static const tool_approval = 'tool_approval';
   static const tool_call_status_success = 'tool_call_status.success';
   static const tool_call_status_skipped_by_user =
       'tool_call_status.skipped_by_user';
@@ -182,7 +182,6 @@ abstract class LocaleKeys {
       'tool_call_status.execution_error';
   static const tool_call_status_running = 'tool_call_status.running';
   static const tool_call_status_pending = 'tool_call_status.pending';
-  static const tool_call_status = 'tool_call_status';
   static const common_cancel = 'common.cancel';
   static const common_remove = 'common.remove';
   static const common_add = 'common.add';
@@ -191,15 +190,11 @@ abstract class LocaleKeys {
   static const common_confirm = 'common.confirm';
   static const common_close = 'common.close';
   static const common_show_more = 'common.show_more';
-  static const common = 'common';
   static const tools_names_calculator_name = 'tools_names.calculator.name';
   static const tools_names_calculator_description =
       'tools_names.calculator.description';
-  static const tools_names_calculator = 'tools_names.calculator';
   static const tools_names_url_name = 'tools_names.url.name';
   static const tools_names_url_description = 'tools_names.url.description';
-  static const tools_names_url = 'tools_names.url';
-  static const tools_names = 'tools_names';
   static const home_screen_welcome_title = 'home_screen.welcome_title';
   static const home_screen_welcome_subtitle = 'home_screen.welcome_subtitle';
   static const home_screen_quick_actions = 'home_screen.quick_actions';
@@ -212,7 +207,6 @@ abstract class LocaleKeys {
   static const home_screen_actions_models = 'home_screen.actions.models';
   static const home_screen_actions_tools = 'home_screen.actions.tools';
   static const home_screen_actions_agents = 'home_screen.actions.agents';
-  static const home_screen_actions = 'home_screen.actions';
   static const home_screen_conversation_states_no_conversations =
       'home_screen.conversation_states.no_conversations';
   static const home_screen_conversation_states_no_chats_yet =
@@ -223,8 +217,6 @@ abstract class LocaleKeys {
       'home_screen.conversation_states.error_loading_conversations';
   static const home_screen_conversation_states_error_loading_chats =
       'home_screen.conversation_states.error_loading_chats';
-  static const home_screen_conversation_states =
-      'home_screen.conversation_states';
   static const home_screen_date_formatting_just_now =
       'home_screen.date_formatting.just_now';
   static const home_screen_date_formatting_minutes_ago =
@@ -233,97 +225,72 @@ abstract class LocaleKeys {
       'home_screen.date_formatting.hours_ago';
   static const home_screen_date_formatting_days_ago =
       'home_screen.date_formatting.days_ago';
-  static const home_screen_date_formatting = 'home_screen.date_formatting';
-  static const home_screen = 'home_screen';
   static const status_bar_models_available = 'status_bar.models_available';
   static const status_bar_loading_models = 'status_bar.loading_models';
   static const status_bar_model_error = 'status_bar.model_error';
   static const status_bar_api_connected = 'status_bar.api_connected';
-  static const status_bar = 'status_bar';
   static const settings_screen_title = 'settings_screen.title';
   static const settings_screen_app_settings_title =
       'settings_screen.app_settings.title';
   static const settings_screen_app_settings_subtitle =
       'settings_screen.app_settings.subtitle';
-  static const settings_screen_app_settings = 'settings_screen.app_settings';
   static const settings_screen_theme_title = 'settings_screen.theme.title';
   static const settings_screen_theme_light = 'settings_screen.theme.light';
   static const settings_screen_theme_dark = 'settings_screen.theme.dark';
   static const settings_screen_theme_system = 'settings_screen.theme.system';
   static const settings_screen_theme_system_default =
       'settings_screen.theme.system_default';
-  static const settings_screen_theme = 'settings_screen.theme';
   static const settings_screen_actions_cancel =
       'settings_screen.actions.cancel';
-  static const settings_screen_actions = 'settings_screen.actions';
-  static const settings_screen = 'settings_screen';
   static const sidebar_recent_chats = 'sidebar.recent_chats';
   static const sidebar_no_recent_chats = 'sidebar.no_recent_chats';
   static const sidebar_view_all_chats = 'sidebar.view_all_chats';
-  static const sidebar = 'sidebar';
   static const mcp_modal_title = 'mcp_modal.title';
   static const mcp_modal_add_mcp_tooltip = 'mcp_modal.add_mcp_tooltip';
   static const mcp_modal_transport_sse = 'mcp_modal.transport.sse';
   static const mcp_modal_transport_streamable_http =
       'mcp_modal.transport.streamable_http';
-  static const mcp_modal_transport = 'mcp_modal.transport';
   static const mcp_modal_auth_none = 'mcp_modal.auth.none';
   static const mcp_modal_auth_oauth = 'mcp_modal.auth.oauth';
   static const mcp_modal_auth_bearer_token = 'mcp_modal.auth.bearer_token';
-  static const mcp_modal_auth = 'mcp_modal.auth';
   static const mcp_modal_oauth_section_title = 'mcp_modal.oauth_section_title';
   static const mcp_modal_bearer_section_title =
       'mcp_modal.bearer_section_title';
   static const mcp_modal_fields_name_label = 'mcp_modal.fields.name.label';
   static const mcp_modal_fields_name_placeholder =
       'mcp_modal.fields.name.placeholder';
-  static const mcp_modal_fields_name = 'mcp_modal.fields.name';
   static const mcp_modal_fields_description_label =
       'mcp_modal.fields.description.label';
   static const mcp_modal_fields_description_placeholder =
       'mcp_modal.fields.description.placeholder';
-  static const mcp_modal_fields_description = 'mcp_modal.fields.description';
   static const mcp_modal_fields_url_label = 'mcp_modal.fields.url.label';
   static const mcp_modal_fields_url_placeholder =
       'mcp_modal.fields.url.placeholder';
   static const mcp_modal_fields_url_hint = 'mcp_modal.fields.url.hint';
-  static const mcp_modal_fields_url = 'mcp_modal.fields.url';
   static const mcp_modal_fields_transport_label =
       'mcp_modal.fields.transport.label';
-  static const mcp_modal_fields_transport = 'mcp_modal.fields.transport';
   static const mcp_modal_fields_authentication_label =
       'mcp_modal.fields.authentication.label';
-  static const mcp_modal_fields_authentication =
-      'mcp_modal.fields.authentication';
   static const mcp_modal_fields_use_http2_label =
       'mcp_modal.fields.use_http2.label';
   static const mcp_modal_fields_use_http2_hint =
       'mcp_modal.fields.use_http2.hint';
-  static const mcp_modal_fields_use_http2 = 'mcp_modal.fields.use_http2';
   static const mcp_modal_fields_client_id_label =
       'mcp_modal.fields.client_id.label';
   static const mcp_modal_fields_client_id_placeholder =
       'mcp_modal.fields.client_id.placeholder';
-  static const mcp_modal_fields_client_id = 'mcp_modal.fields.client_id';
   static const mcp_modal_fields_token_endpoint_label =
       'mcp_modal.fields.token_endpoint.label';
   static const mcp_modal_fields_token_endpoint_placeholder =
       'mcp_modal.fields.token_endpoint.placeholder';
-  static const mcp_modal_fields_token_endpoint =
-      'mcp_modal.fields.token_endpoint';
   static const mcp_modal_fields_auth_endpoint_label =
       'mcp_modal.fields.auth_endpoint.label';
   static const mcp_modal_fields_auth_endpoint_placeholder =
       'mcp_modal.fields.auth_endpoint.placeholder';
-  static const mcp_modal_fields_auth_endpoint =
-      'mcp_modal.fields.auth_endpoint';
   static const mcp_modal_fields_bearer_token_label =
       'mcp_modal.fields.bearer_token.label';
   static const mcp_modal_fields_bearer_token_placeholder =
       'mcp_modal.fields.bearer_token.placeholder';
   static const mcp_modal_fields_bearer_token_hint =
       'mcp_modal.fields.bearer_token.hint';
-  static const mcp_modal_fields_bearer_token = 'mcp_modal.fields.bearer_token';
-  static const mcp_modal_fields = 'mcp_modal.fields';
-  static const mcp_modal = 'mcp_modal';
 }

--- a/apps/auravibes_app/lib/utils/chat_result_extension.dart
+++ b/apps/auravibes_app/lib/utils/chat_result_extension.dart
@@ -25,7 +25,12 @@ extension ChatResultEntities on ChatResult {
   }
 
   MessageMetadataEntity? get entityMetadata {
-    if (output.toolCalls.isEmpty) {
+    final hasUsage =
+        usage.promptTokens != null ||
+        usage.responseTokens != null ||
+        usage.totalTokens != null;
+
+    if (output.toolCalls.isEmpty && !hasUsage) {
       return null;
     }
 

--- a/apps/auravibes_app/lib/utils/chat_result_extension.dart
+++ b/apps/auravibes_app/lib/utils/chat_result_extension.dart
@@ -16,11 +16,24 @@ extension ChatResultEntities on ChatResult {
     }).toList();
   }
 
+  int get entityPromptTokens => usage.promptTokens ?? 0;
+
+  int get entityCompletionTokens => usage.responseTokens ?? 0;
+
+  int get entityTotalTokens {
+    return usage.totalTokens ?? (entityPromptTokens + entityCompletionTokens);
+  }
+
   MessageMetadataEntity? get entityMetadata {
     if (output.toolCalls.isEmpty) {
       return null;
     }
 
-    return MessageMetadataEntity(toolCalls: entityTools);
+    return MessageMetadataEntity(
+      toolCalls: entityTools,
+      promptTokens: usage.promptTokens,
+      completionTokens: usage.responseTokens,
+      totalTokens: usage.totalTokens,
+    );
   }
 }

--- a/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
+++ b/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
@@ -161,6 +161,7 @@ void main() {
     );
 
     test('computes token usage percentage, clamps progress at 100%', () async {
+      container.dispose();
       container =
           ProviderContainer(
               overrides: [

--- a/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
+++ b/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
@@ -107,6 +107,99 @@ void main() {
         'streaming',
       );
     });
+
+    test(
+      'uses latest assistant usage and replaces with streaming value',
+      () async {
+        container
+          ..listen(
+            chatMessagesProvider,
+            (_, _) {},
+            fireImmediately: true,
+          )
+          ..listen(
+            conversationUsedTokensProvider,
+            (_, _) {},
+            fireImmediately: true,
+          );
+
+        repository.emit([
+          _message(
+            id: 'message-1',
+            content: 'first',
+            isUser: true,
+            metadata: const MessageMetadataEntity(totalTokens: 1000),
+          ),
+          _message(
+            id: 'message-2',
+            content: 'second',
+            isUser: false,
+            metadata: const MessageMetadataEntity(totalTokens: 500),
+          ),
+        ]);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(container.read(conversationUsedTokensProvider), 500);
+
+        container.read(messagesStreamingProvider.notifier)
+          ..startSubscription(CompositeSubscription(), 'message-2')
+          ..updateResult(
+            const ChatResult(
+              id: 'chunk-2',
+              output: AIChatMessage(content: 'streaming'),
+              finishReason: FinishReason.unspecified,
+              metadata: {},
+              usage: LanguageModelUsage(totalTokens: 900),
+              streaming: true,
+            ),
+            'message-2',
+          );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(container.read(conversationUsedTokensProvider), 900);
+      },
+    );
+
+    test('computes token usage percentage and clamps over 100%', () async {
+      container =
+          ProviderContainer(
+              overrides: [
+                conversationSelectedProvider.overrideWithValue(
+                  'conversation-1',
+                ),
+                messageRepositoryProvider.overrideWithValue(repository),
+                conversationContextLimitProvider.overrideWith(
+                  (ref) async => 1000,
+                ),
+              ],
+            )
+            ..listen(chatMessagesProvider, (_, _) {}, fireImmediately: true)
+            ..listen(
+              conversationTokenUsageSummaryProvider,
+              (_, _) {},
+              fireImmediately: true,
+            );
+
+      repository.emit([
+        _message(
+          id: 'message-1',
+          content: 'first',
+          isUser: false,
+          metadata: const MessageMetadataEntity(totalTokens: 1900),
+        ),
+      ]);
+      await Future<void>.delayed(Duration.zero);
+
+      final summaryAsync = container.read(
+        conversationTokenUsageSummaryProvider,
+      );
+      final summary = summaryAsync.value;
+
+      expect(summary?.usedTokens, 1900);
+      expect(summary?.limitTokens, 1000);
+      expect(summary?.percent, 190);
+      expect(summary?.progress, 1);
+    });
   });
 }
 
@@ -114,6 +207,7 @@ MessageEntity _message({
   required String id,
   required String content,
   required bool isUser,
+  MessageMetadataEntity? metadata,
 }) {
   final now = DateTime(2026);
 
@@ -126,6 +220,7 @@ MessageEntity _message({
     status: MessageStatus.sent,
     createdAt: now,
     updatedAt: now,
+    metadata: metadata,
   );
 }
 

--- a/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
+++ b/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
@@ -160,7 +160,7 @@ void main() {
       },
     );
 
-    test('computes token usage percentage and clamps over 100%', () async {
+    test('computes token usage percentage, clamps progress at 100%', () async {
       container =
           ProviderContainer(
               overrides: [

--- a/apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.dart
@@ -124,7 +124,10 @@ void main() {
               output: AIChatMessage(content: 'Working'),
               finishReason: FinishReason.unspecified,
               metadata: {},
-              usage: LanguageModelUsage(),
+              usage: LanguageModelUsage(
+                promptTokens: 10,
+                responseTokens: 5,
+              ),
               streaming: true,
             ),
             const ChatResult(
@@ -142,7 +145,9 @@ void main() {
               ),
               finishReason: FinishReason.toolCalls,
               metadata: {},
-              usage: LanguageModelUsage(),
+              usage: LanguageModelUsage(
+                responseTokens: 7,
+              ),
               streaming: true,
             ),
           ]),
@@ -167,11 +172,15 @@ void main() {
         ).captured;
 
         final streamingUpdate = updates.cast<MessageToUpdate>().firstWhere(
-          (update) => update.metadata != null,
+          (update) => update.metadata?.toolCalls.isNotEmpty ?? false,
         );
 
         expect(streamingUpdate.metadata?.toolCalls, hasLength(1));
         expect(streamingUpdate.metadata?.toolCalls.single.id, 'tool-1');
+        expect(streamingUpdate.metadata?.promptTokens, 10);
+        expect(streamingUpdate.metadata?.completionTokens, 12);
+        expect(streamingUpdate.metadata?.totalTokens, isNull);
+        expect(streamingUpdate.metadata?.usedTokens, 22);
       },
     );
 

--- a/specs/003-token-usage-context/checklists/requirements.md
+++ b/specs/003-token-usage-context/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning  
 **Created**: 2026-04-15  
-**Feature**: [/Users/davidlondono/Code/Mine/aura_vibes/auravibes.token-usage/specs/003-token-usage-context/spec.md](../spec.md)
+**Feature**: [`specs/003-token-usage-context/spec.md`](../spec.md)
 
 ## Content Quality
 

--- a/specs/003-token-usage-context/checklists/requirements.md
+++ b/specs/003-token-usage-context/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Conversation Token Usage Indicator
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-15  
+**Feature**: [/Users/davidlondono/Code/Mine/aura_vibes/auravibes.token-usage/specs/003-token-usage-context/spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass complete. Ready for planning.

--- a/specs/003-token-usage-context/contracts/README.md
+++ b/specs/003-token-usage-context/contracts/README.md
@@ -1,0 +1,9 @@
+# Contracts
+
+No external API or CLI contracts required for this feature.
+
+Feature scope is internal application behavior:
+
+- message metadata persistence
+- conversation usage aggregation
+- top-bar UI rendering

--- a/specs/003-token-usage-context/data-model.md
+++ b/specs/003-token-usage-context/data-model.md
@@ -25,18 +25,14 @@ Runtime-only aggregate used by chat top bar.
 
 - `usedTokens: int`
 - `limitTokens: int`
-- `percentUsed: int` (0..100)
-- `progress: double` (0.0..1.0)
+- `percentUsed: int` (raw percent; may exceed 100 when usage overflows limit)
+- `progress: double` (clamped 0.0..1.0)
 
 ### Derivation Rules
 
-For each message:
-
-1. `messageUsed = totalTokens ?? (promptTokens + completionTokens) ?? 0`
-2. Conversation used = sum(`messageUsed`) across conversation messages.
-3. If a message is currently streaming, overlay with latest `ChatResult.usage`-derived value.
-4. `percentUsed = clamp(round((usedTokens / limitTokens) * 100), 0, 100)` when `limitTokens > 0`, else `0`.
-5. `progress = percentUsed / 100`.
+1. `usedTokens` is taken from the latest assistant message usage (with streaming overlay when in-progress).
+2. `percentUsed = round((usedTokens / limitTokens) * 100)` when `limitTokens > 0`, else `0`.
+3. `progress = clamp(percentUsed / 100, 0.0, 1.0)`.
 
 ## State Transitions
 

--- a/specs/003-token-usage-context/data-model.md
+++ b/specs/003-token-usage-context/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Conversation Token Usage Indicator
+
+## Entity: MessageMetadataEntity (extended)
+
+Represents persisted metadata for one chat message.
+
+### Fields
+
+- `toolCalls: List<MessageToolCallEntity>` (existing)
+- `promptTokens: int?` (new)
+- `completionTokens: int?` (new)
+- `totalTokens: int?` (new)
+
+### Validation Rules
+
+- Token fields are optional.
+- When present, values are non-negative integers.
+- Serialization remains JSON-compatible with previous metadata payloads.
+
+## Derived View Model: ConversationTokenUsage
+
+Runtime-only aggregate used by chat top bar.
+
+### Fields
+
+- `usedTokens: int`
+- `limitTokens: int`
+- `percentUsed: int` (0..100)
+- `progress: double` (0.0..1.0)
+
+### Derivation Rules
+
+For each message:
+
+1. `messageUsed = totalTokens ?? (promptTokens + completionTokens) ?? 0`
+2. Conversation used = sum(`messageUsed`) across conversation messages.
+3. If a message is currently streaming, overlay with latest `ChatResult.usage`-derived value.
+4. `percentUsed = clamp(round((usedTokens / limitTokens) * 100), 0, 100)` when `limitTokens > 0`, else `0`.
+5. `progress = percentUsed / 100`.
+
+## State Transitions
+
+1. Assistant message created as unfinished with initial metadata.
+2. During stream, message content and metadata updated incrementally.
+3. On completion, final metadata persisted with final usage snapshot.

--- a/specs/003-token-usage-context/plan.md
+++ b/specs/003-token-usage-context/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Conversation Token Usage Indicator
+
+**Branch**: `003-token-usage-context` | **Date**: 2026-04-15 | **Spec**: `/specs/003-token-usage-context/spec.md`
+**Input**: Feature specification from `/specs/003-token-usage-context/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Persist per-message token usage metadata from `ChatResult.usage`, aggregate usage per conversation (including in-flight streaming state), and render top-bar context usage (`used/limit - percent`) with a circular progress indicator.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: Dart 3.11+ with Flutter 3.41.4+ (FVM pinned)  
+**Primary Dependencies**: Flutter, Riverpod, Drift, LangChain (`ChatResult` / `LanguageModelUsage`), auravibes_ui  
+**Storage**: Existing Drift `messages` table metadata JSON (no schema migration planned)  
+**Testing**: Flutter unit/widget tests with existing test suites under `apps/auravibes_app/test`  
+**Target Platform**: Flutter app targets currently supported by monorepo  
+**Project Type**: Mobile/desktop/web Flutter application in Melos monorepo  
+**Performance Goals**: Top bar usage updates during stream without visible lag; preserve current chat streaming smoothness (60fps target)  
+**Constraints**: Minimal persistence fields only; no broad data-model refactor; percent/progress clamped to `[0,100]`  
+**Scale/Scope**: One feature in chat conversation flow; no cross-conversation analytics
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- ✅ Principle I (User Needs): Spec has prioritized user stories and acceptance criteria focused on conversation usage visibility.
+- ✅ Principle II (Design with Data): Data model updates defined before UI implementation; persistence flow explicit.
+- ✅ Principle III/IV (Package/UI): UI changes stay in app screen and use existing design system widgets/tokens.
+- ✅ Principle V (TDD): Add/extend unit tests for usage mapping, aggregation, and streaming overlay behavior.
+- ✅ Principle VI (Fail Fast): Missing usage fields default to safe zero behavior.
+- ✅ Principle VII (Simplicity): Reuse existing metadata JSON and providers; avoid schema/migration unless proven necessary.
+- ✅ Principle VIII (Observability/Performance): Lightweight calculations; no heavy recomputation loops.
+- ✅ Principle IX (Security/Privacy): No new sensitive data persisted.
+- ✅ Principle X (Quality): Maintain lint/format/test standards.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-token-usage-context/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+apps/auravibes_app/
+├── lib/
+│   ├── domain/entities/messages.dart
+│   ├── data/repositories/message_repository_impl.dart
+│   ├── utils/chat_result_extension.dart
+│   ├── features/chats/usecases/continue_agent_usecase.dart
+│   ├── features/chats/providers/messages_providers.dart
+│   └── features/chats/screens/chat_conversation_screen.dart
+└── test/
+    ├── features/chats/usecases/continue_agent_usecase_test.dart
+    └── features/chats/providers/chat_messages_provider_test.dart
+```
+
+**Structure Decision**: Existing Flutter app structure in `apps/auravibes_app` is sufficient. Feature touches domain metadata entity, chat streaming persistence use case, providers for conversation aggregation, and conversation app bar UI.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/003-token-usage-context/quickstart.md
+++ b/specs/003-token-usage-context/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart: Conversation Token Usage Indicator
+
+## 1) Implement persistence mapping
+
+1. Extend message metadata entity with usage fields.
+2. Map `ChatResult.usage` into metadata during assistant message streaming updates.
+3. Ensure final message update persists usage snapshot.
+
+## 2) Implement aggregation
+
+1. Add conversation-level provider to compute used tokens from persisted messages.
+2. Overlay in-flight streaming usage from `messagesStreamingNotifier` state.
+3. Resolve model context limit for active conversation model.
+4. Apply fallback order `totalTokens -> prompt+completion -> 0` and clamp UI percent to `0..100`.
+
+## 3) Implement top-bar UI
+
+1. Add usage label in format `39k/205k - 19%`.
+2. Add circular progress indicator bound to computed percent.
+3. Ensure values refresh while streaming.
+
+## 4) Validate
+
+1. Run focused tests for use case and provider behavior.
+2. Run app-level analysis/tests as feasible.
+
+## 5) Commands
+
+From repo root:
+
+- `fvm dart run melos analyze`
+- `fvm dart run melos run test`
+
+Or package/app-scoped tests during development.

--- a/specs/003-token-usage-context/research.md
+++ b/specs/003-token-usage-context/research.md
@@ -1,0 +1,36 @@
+# Research: Conversation Token Usage Indicator
+
+## Decision 1: Persist usage in existing message metadata JSON
+
+- **Decision**: Extend `MessageMetadataEntity` with token usage fields and persist through existing `metadata` column.
+- **Rationale**: Current repository already serializes/deserializes metadata JSON; avoids Drift schema migration.
+- **Alternatives considered**:
+  - Add dedicated token columns in `messages` table (rejected: unnecessary migration and broader surface area).
+
+## Decision 2: Per-message used tokens formula
+
+- **Decision**: `used = totalTokens ?? (promptTokens + completionTokens) ?? 0`.
+- **Rationale**: Works across providers where streaming events may not emit full totals.
+- **Alternatives considered**:
+  - Require `totalTokens` only (rejected: would undercount many stream/provider cases).
+
+## Decision 3: Conversation total source of truth
+
+- **Decision**: Sum usage from conversation messages and overlay in-flight streaming usage from runtime state.
+- **Rationale**: Matches existing message content overlay approach and enables live updates.
+- **Alternatives considered**:
+  - Recompute only after message finalized (rejected: fails live-update requirement).
+
+## Decision 4: Context limit denominator
+
+- **Decision**: Use selected model `limitContext` for conversation percent denominator.
+- **Rationale**: Explicit requirement and aligns user mental model of context window.
+- **Alternatives considered**:
+  - Static global limit (rejected: incorrect for model-specific windows).
+
+## Decision 5: UI behavior for edge cases
+
+- **Decision**: Clamp percent/progress in `[0,100]`; guard division by zero.
+- **Rationale**: Prevents invalid UI states and regressions when model limit unavailable.
+- **Alternatives considered**:
+  - Allow overflow >100 in progress ring (rejected for this scope; can be added later with warning style).

--- a/specs/003-token-usage-context/spec.md
+++ b/specs/003-token-usage-context/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: Conversation Token Usage Indicator
+
+**Feature Branch**: `003-token-usage-context`  
+**Created**: 2026-04-15  
+**Status**: Draft  
+**Input**: User description: "Store token usage in messages, calculate total token usage by conversation, and show used/limit/percent with circular progress in the conversation top bar."
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - View live context usage while chatting (Priority: P1)
+
+As a user in a conversation, I can see how many tokens have been used out of the model context limit and the percentage consumed, so I can decide when to shorten prompts or start a new conversation.
+
+**Why this priority**: This is the core user value requested and must work in real time while responses stream.
+
+**Independent Test**: Send a message that produces a streaming assistant response and verify the top bar updates continuously to show used tokens, max limit, percentage text, and circular progress.
+
+**Acceptance Scenarios**:
+
+1. **Given** a conversation with prior messages that have token usage data, **When** the conversation screen opens, **Then** the top bar shows `used/limit - percent` derived from those messages.
+2. **Given** an assistant response is streaming with growing token usage, **When** new stream chunks arrive, **Then** top bar values and progress indicator update without waiting for stream completion.
+
+---
+
+### User Story 2 - Preserve usage across app restarts (Priority: P2)
+
+As a user returning to a conversation, I can still see accurate usage totals without re-running old requests.
+
+**Why this priority**: Persisted usage avoids confusion and keeps historical context consumption visible.
+
+**Independent Test**: Complete a conversation turn, close/reopen app, open same conversation, and verify displayed usage matches previous session.
+
+**Acceptance Scenarios**:
+
+1. **Given** assistant messages were previously stored with usage, **When** app restarts and conversation reloads, **Then** usage totals are reconstructed from stored message data and displayed.
+
+---
+
+### User Story 3 - Graceful behavior with partial usage data (Priority: P3)
+
+As a user, I still get a stable usage display even if a provider returns partial token fields.
+
+**Why this priority**: Different providers and stream events may omit some usage fields.
+
+**Independent Test**: Simulate usage where `totalTokens` is absent but prompt/response are present and verify display computes correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a message has no `totalTokens` but has prompt and completion tokens, **When** totals are computed, **Then** system uses `prompt + completion` for that message.
+
+---
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- Model context limit is missing or zero: UI must not divide by zero and must show a safe fallback (e.g., used only and 0% progress).
+- Percent exceeds 100 due to stale or changed model limit: percent display and progress must clamp to 100%.
+- Streaming usage not present on intermediate chunks: keep last known value until a newer valid value arrives.
+- A message has no usage fields at all: treat message usage as zero.
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST store token usage per message in message metadata using the fields `promptTokens`, `completionTokens`, and `totalTokens` when available.
+- **FR-002**: System MUST compute message token usage using this order: `totalTokens`; otherwise `promptTokens + completionTokens`; otherwise `0`.
+- **FR-003**: System MUST compute conversation used tokens as the sum of usage across all messages in the active conversation.
+- **FR-004**: System MUST include in-progress streaming usage in conversation totals while the assistant message is unfinished.
+- **FR-005**: System MUST use the selected conversation model context window limit as the denominator for percent usage.
+- **FR-006**: System MUST display in the conversation top bar: used tokens, model limit, and percent in the format `39k/205k - 19%`.
+- **FR-007**: System MUST render a circular progress indicator in the top bar where fill amount matches displayed percent.
+- **FR-008**: System MUST update the top bar usage display live during streaming responses.
+- **FR-009**: System MUST persist message usage so totals remain available after app restart.
+- **FR-010**: System MUST clamp percent and progress to a minimum of 0 and maximum of 100.
+
+### Key Entities *(include if feature involves data)*
+
+- **MessageUsageMetadata**: Per-message usage snapshot with `promptTokens`, `completionTokens`, `totalTokens`.
+- **ConversationUsageSummary**: Derived runtime aggregate for one conversation with `usedTokens`, `limitTokens`, `percentUsed`.
+
+## Clarifications
+
+### Session 2026-04-15
+
+- Q: Scope level for tracking? → A: Per conversation only.
+- Q: Formula for used tokens? → A: prompt + completion, with total when provided.
+- Q: Denominator for percent? → A: selected model max context window.
+- Q: Update timing? → A: live while streaming.
+- Q: Persistence strategy? → A: minimal message metadata fields only.
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: In 100% of tested conversation loads, top bar displays a usage string in `used/limit - percent%` format within 1 second of screen render.
+- **SC-002**: During streamed assistant responses, displayed used tokens and percent refresh at least once per persisted stream update cycle.
+- **SC-003**: In provider payloads lacking `totalTokens` but containing prompt and completion tokens, computed used tokens are correct in 100% of test cases.
+- **SC-004**: After app restart, conversation usage totals match pre-restart values for 100% of tested conversations with stored metadata.

--- a/specs/003-token-usage-context/spec.md
+++ b/specs/003-token-usage-context/spec.md
@@ -71,7 +71,7 @@ As a user, I still get a stable usage display even if a provider returns partial
 -->
 
 - Model context limit is missing or zero: UI must not divide by zero and must show a safe fallback (e.g., used only and 0% progress).
-- Percent exceeds 100 due to stale or changed model limit: percent display and progress must clamp to 100%.
+- Percent exceeds 100 due to stale or changed model limit: display raw percent value (may exceed 100) while clamping progress bar to 100%.
 - Streaming usage not present on intermediate chunks: keep last known value until a newer valid value arrives.
 - A message has no usage fields at all: treat message usage as zero.
 
@@ -86,14 +86,14 @@ As a user, I still get a stable usage display even if a provider returns partial
 
 - **FR-001**: System MUST store token usage per message in message metadata using the fields `promptTokens`, `completionTokens`, and `totalTokens` when available.
 - **FR-002**: System MUST compute message token usage using this order: `totalTokens`; otherwise `promptTokens + completionTokens`; otherwise `0`.
-- **FR-003**: System MUST compute conversation used tokens as the sum of usage across all messages in the active conversation.
+- **FR-003**: System MUST compute conversation used tokens from the latest assistant message usage (with streaming overlay when in-progress).
 - **FR-004**: System MUST include in-progress streaming usage in conversation totals while the assistant message is unfinished.
 - **FR-005**: System MUST use the selected conversation model context window limit as the denominator for percent usage.
 - **FR-006**: System MUST display in the conversation top bar: used tokens, model limit, and percent in the format `39k/205k - 19%`.
 - **FR-007**: System MUST render a circular progress indicator in the top bar where fill amount matches displayed percent.
 - **FR-008**: System MUST update the top bar usage display live during streaming responses.
 - **FR-009**: System MUST persist message usage so totals remain available after app restart.
-- **FR-010**: System MUST clamp percent and progress to a minimum of 0 and maximum of 100.
+- **FR-010**: System MUST clamp progress to a minimum of 0 and maximum of 1.0; raw percent may exceed 100 to indicate overflow.
 
 ### Key Entities *(include if feature involves data)*
 

--- a/specs/003-token-usage-context/tasks.md
+++ b/specs/003-token-usage-context/tasks.md
@@ -1,0 +1,136 @@
+# Tasks: Conversation Token Usage Indicator
+
+**Input**: Design documents from `/specs/003-token-usage-context/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Included (feature requires streaming + persistence correctness).
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare feature docs and verify baseline test targets.
+
+- [X] T001 Verify baseline chat tests in `apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.dart` and `apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared domain primitives and reusable computations.
+
+- [X] T002 Extend `MessageMetadataEntity` with usage fields in `apps/auravibes_app/lib/domain/entities/messages.dart`
+- [X] T003 [P] Add `ChatResult` usage mapping helpers in `apps/auravibes_app/lib/utils/chat_result_extension.dart`
+- [X] T004 [P] Add shared usage formatting/aggregation helpers in `apps/auravibes_app/lib/features/chats/providers/messages_providers.dart`
+
+**Checkpoint**: Shared usage model ready.
+
+---
+
+## Phase 3: User Story 1 - View live context usage while chatting (Priority: P1) 🎯 MVP
+
+**Goal**: Show live used/limit/percent and progress circle in conversation top bar.
+
+**Independent Test**: Stream assistant response and verify top bar updates before message finalization.
+
+### Tests for User Story 1
+
+- [X] T005 [P] [US1] Add usage-mapping unit tests in `apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.dart`
+- [X] T006 [P] [US1] Add conversation usage aggregation tests in `apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart`
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Persist streaming usage metadata in `apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart`
+- [X] T008 [US1] Add provider for conversation token usage summary in `apps/auravibes_app/lib/features/chats/providers/messages_providers.dart`
+- [X] T009 [US1] Render usage text + circular progress in app bar at `apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart`
+
+**Checkpoint**: Live usage shown and updates during stream.
+
+---
+
+## Phase 4: User Story 2 - Preserve usage across app restarts (Priority: P2)
+
+**Goal**: Ensure persisted metadata reconstructs conversation usage.
+
+**Independent Test**: Usage aggregate from repository-loaded messages equals expected stored totals.
+
+### Tests for User Story 2
+
+- [X] T010 [P] [US2] Add metadata serialization regression test in `apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart`
+
+### Implementation for User Story 2
+
+- [X] T011 [US2] Verify/update metadata round-trip mapping in `apps/auravibes_app/lib/data/repositories/message_repository_impl.dart`
+
+**Checkpoint**: Persisted usage survives reload.
+
+---
+
+## Phase 5: User Story 3 - Graceful behavior with partial usage data (Priority: P3)
+
+**Goal**: Handle missing usage fields safely and consistently.
+
+**Independent Test**: Null/partial usage inputs compute expected fallback and clamped percent.
+
+### Tests for User Story 3
+
+- [X] T012 [P] [US3] Add fallback/clamp tests in `apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart`
+
+### Implementation for User Story 3
+
+- [X] T013 [US3] Apply fallback + clamp logic in provider computation at `apps/auravibes_app/lib/features/chats/providers/messages_providers.dart`
+
+**Checkpoint**: Missing data and edge limits produce stable UI.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T014 [P] Update any impacted docs/comments in `specs/003-token-usage-context/quickstart.md` and inline code comments where needed
+- [X] T015 Run targeted tests and app analysis for changed scope
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Phase 1 → Phase 2 → Phase 3/4/5 → Phase 6
+- US2/US3 depend on foundational usage model from Phase 2.
+
+### User Story Dependencies
+
+- **US1 (P1)**: starts after Phase 2.
+- **US2 (P2)**: starts after Phase 2, independent from US1 UI pieces.
+- **US3 (P3)**: starts after Phase 2, validates fallback behavior used by US1/US2.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel.
+- T005 and T006 can run in parallel.
+- T010 and T012 can run in parallel.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Add usage-mapping unit tests in continue_agent_usecase_test.dart"
+Task: "Add conversation usage aggregation tests in chat_messages_provider_test.dart"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Complete Phases 1 and 2.
+2. Complete US1 tests + implementation.
+3. Validate live top-bar usage behavior.
+
+### Incremental Delivery
+
+1. Add persisted metadata behavior (US2).
+2. Add fallback/clamp hardening (US3).
+3. Execute final verification (Phase 6).


### PR DESCRIPTION
## Summary
- persist per-message token usage metadata from `ChatResult.usage` and map prompt/completion/total values into message metadata
- add model-aware context limit resolution and a top-bar context usage pill that shows compact `used/limit`, percent, progress, thresholds, and overflow behavior
- localize context usage copy (en/es), regenerate locale keys, and add provider/usecase tests for usage persistence, model-limit calculation, and streaming updates

## Validation
- `fvm dart run melos analyze`
- `fvm flutter test test/features/chats/providers/chat_messages_provider_test.dart test/features/chats/usecases/continue_agent_usecase_test.dart --no-pub`