### PR TITLE
feat(chats): add reactive conversation-by-id stream provider

### DIFF
--- a/apps/auravibes_app/lib/data/database/drift/daos/conversation_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/conversation_dao.dart
@@ -28,6 +28,10 @@ class ConversationDao extends DatabaseAccessor<AppDatabase>
     conversations,
   )..where((tbl) => tbl.id.equals(id))).go().then((count) => count > 0);
 
+  Stream<ConversationsTable?> watchConversationById(String id) => (select(
+    conversations,
+  )..where((tbl) => tbl.id.equals(id))).watchSingleOrNull();
+
   Stream<List<ConversationsTable>> watchConversationsByWorkspace(
     String workspaceId, {
     int? limit,

--- a/apps/auravibes_app/lib/data/repositories/conversation_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/conversation_repository_impl.dart
@@ -19,6 +19,13 @@ class ConversationRepositoryImpl implements ConversationRepository {
   }
 
   @override
+  Stream<ConversationEntity?> watchConversationById(String id) {
+    return _database.conversationDao
+        .watchConversationById(id)
+        .map((row) => row != null ? _mapToConversation(row) : null);
+  }
+
+  @override
   Future<ConversationEntity?> getConversationById(String id) async {
     final conversationTable = await _database.conversationDao
         .getConversationById(id);

--- a/apps/auravibes_app/lib/domain/repositories/conversation_repository.dart
+++ b/apps/auravibes_app/lib/domain/repositories/conversation_repository.dart
@@ -6,6 +6,8 @@ abstract class ConversationRepository {
     int? limit,
   });
 
+  Stream<ConversationEntity?> watchConversationById(String id);
+
   Future<ConversationEntity?> getConversationById(String id);
 
   Future<ConversationEntity> createConversation(

--- a/apps/auravibes_app/lib/features/chats/notifiers/conversation_chat_notifier.dart
+++ b/apps/auravibes_app/lib/features/chats/notifiers/conversation_chat_notifier.dart
@@ -28,10 +28,11 @@ class ConversationChatNotifier extends _$ConversationChatNotifier {
   @override
   Future<ConversationResult> build(String workspaceId) async {
     final conversationId = ref.watch(conversationSelectedProvider);
-
-    final conversation = await ref.watch(
-      conversationByIdStreamProvider(conversationId: conversationId).future,
+    final asyncConv = ref.watch(
+      conversationByIdStreamProvider(conversationId: conversationId),
     );
+
+    final conversation = asyncConv.value;
 
     if (conversation == null) {
       return const ConversationNotFound();

--- a/apps/auravibes_app/lib/features/chats/notifiers/conversation_chat_notifier.dart
+++ b/apps/auravibes_app/lib/features/chats/notifiers/conversation_chat_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:auravibes_app/domain/entities/conversation.dart';
+import 'package:auravibes_app/features/chats/providers/conversation_providers.dart';
 import 'package:auravibes_app/features/chats/providers/conversation_repository_provider.dart';
 import 'package:auravibes_app/features/chats/providers/conversation_selection_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -28,9 +29,9 @@ class ConversationChatNotifier extends _$ConversationChatNotifier {
   Future<ConversationResult> build(String workspaceId) async {
     final conversationId = ref.watch(conversationSelectedProvider);
 
-    final conversation = await ref
-        .watch(conversationRepositoryProvider)
-        .getConversationById(conversationId);
+    final conversation = await ref.watch(
+      conversationByIdStreamProvider(conversationId: conversationId).future,
+    );
 
     if (conversation == null) {
       return const ConversationNotFound();

--- a/apps/auravibes_app/lib/features/chats/providers/conversation_providers.dart
+++ b/apps/auravibes_app/lib/features/chats/providers/conversation_providers.dart
@@ -9,9 +9,9 @@ part 'conversation_providers.g.dart';
 Stream<ConversationEntity?> conversationByIdStream(
   Ref ref, {
   required String conversationId,
-}) async* {
+}) {
   final repo = ref.watch(conversationRepositoryProvider);
-  yield* repo.watchConversationById(conversationId);
+  return repo.watchConversationById(conversationId);
 }
 
 @riverpod
@@ -19,9 +19,9 @@ Stream<List<ConversationEntity>> conversationsStream(
   Ref ref, {
   required String workspaceId,
   int? limit,
-}) async* {
+}) {
   final repo = ref.watch(conversationRepositoryProvider);
-  yield* repo.watchConversationsByWorkspace(workspaceId, limit: limit);
+  return repo.watchConversationsByWorkspace(workspaceId, limit: limit);
 }
 
 @riverpod

--- a/apps/auravibes_app/lib/features/chats/providers/conversation_providers.dart
+++ b/apps/auravibes_app/lib/features/chats/providers/conversation_providers.dart
@@ -6,6 +6,15 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'conversation_providers.g.dart';
 
 @riverpod
+Stream<ConversationEntity?> conversationByIdStream(
+  Ref ref, {
+  required String conversationId,
+}) async* {
+  final repo = ref.watch(conversationRepositoryProvider);
+  yield* repo.watchConversationById(conversationId);
+}
+
+@riverpod
 Stream<List<ConversationEntity>> conversationsStream(
   Ref ref, {
   required String workspaceId,


### PR DESCRIPTION
## What
- Add `watchConversationById` stream across DAO → repository → provider layers
- Migrate `ConversationChatNotifier` to use the new stream for reactive UI updates

## Why
- `ConversationChatNotifier` was using one-shot `getConversationById`, requiring manual state updates after mutations
- With the reactive stream, the UI auto-updates when conversation metadata changes (title, modelId, isPinned, updatedAt)

## Changes
### Data layer
- **DAO**: `watchConversationById(id)` using Drift's `watchSingleOrNull()`
- **Repository interface**: `Stream<ConversationEntity?> watchConversationById(String id)`
- **Repository impl**: delegates to DAO, maps rows → entities

### Provider layer
- **`conversationByIdStreamProvider(conversationId:)`**: new Riverpod stream provider

### Consumer migration
- **`ConversationChatNotifier`**: switched from `getConversationById` → `conversationByIdStreamProvider`

## Testing
- 127 tests passing, no regressions