### PR TITLE
chore(coderabbit): disable auto-review auto-pause

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -72,6 +72,7 @@ reviews:
     enabled: true
     drafts: false
     auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
     ignore_title_keywords:
       - "WIP"
       - "wip"


### PR DESCRIPTION
## Summary
- disable CodeRabbit incremental auto-pause by setting `reviews.auto_review.auto_pause_after_reviewed_commits` to `0`
- keep automatic incremental reviews enabled while preventing reviews from being paused after commit bursts
- preserve existing review behavior and only update this single configuration key