### PR TITLE
fix(models): refactor chat model selector async UI

### DIFF
--- a/apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart
+++ b/apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart
@@ -111,19 +111,18 @@ class _ChatConversationScreen extends HookConsumerWidget {
     return AuraScreen(
       appBar: AuraAppBarWithDrawer(
         title: Text(conversation.title),
-        actions: const [
-          ConversationContextUsagePill(),
-        ],
-        bottom: SelectCredentialsModelWidget(
-          workspaceId: workspaceId,
-          credentialsModelId: conversation.modelId,
-          selectCredentialsModelId: ref
-              .watch(conversationChatProvider(workspaceId).notifier)
-              .setModel,
-        ),
       ),
-      child: Column(
+      child: AuraColumn(
         children: [
+          const ConversationContextUsagePill(),
+          SelectCredentialsModelWidget(
+            workspaceId: workspaceId,
+            credentialsModelId: conversation.modelId,
+            selectCredentialsModelId: ref
+                .watch(conversationChatProvider(workspaceId).notifier)
+                .setModel,
+            onProviderChanged: (p1) {},
+          ),
           const Expanded(child: _ChatList()),
           const McpConnectingIndicator(),
           if (busyState?.isStreaming == true) const ChatThinkingIndicator(),

--- a/apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart
+++ b/apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart
@@ -121,7 +121,7 @@ class _ChatConversationScreen extends HookConsumerWidget {
             selectCredentialsModelId: ref
                 .watch(conversationChatProvider(workspaceId).notifier)
                 .setModel,
-            onProviderChanged: (p1) {},
+            onProviderChanged: (_) {},
           ),
           const Expanded(child: _ChatList()),
           const McpConnectingIndicator(),

--- a/apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart
+++ b/apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart
@@ -37,10 +37,10 @@ class SelectCredentialsModelWidget extends HookConsumerWidget
       listModelsGroupedByProviderProvider(workspaceId: workspaceId),
     );
 
-    void onSelectProvider(String? provider) {
+    final onSelectProvider = useCallback<void Function(String?)>((provider) {
       onProviderChanged(provider);
       selectCredentialsModelId(null);
-    }
+    }, [onProviderChanged, selectCredentialsModelId]);
 
     return switch (groupedModelsAsync) {
       AsyncLoading() => const AuraPadding(
@@ -145,7 +145,10 @@ class SelectChatData extends HookWidget {
       selectedModelId: credentialsModelId,
       providerSelected: effectiveProviderId != null,
       onChanged: selectCredentialsModelId,
-      searchValue: searchValue,
+      searchValue: searchValue.value,
+      onSearchChanged: (value) {
+        searchValue.value = value;
+      },
       controller: controller,
     );
 
@@ -217,6 +220,7 @@ class _ModelDropdown extends StatelessWidget {
     required this.providerSelected,
     required this.onChanged,
     required this.searchValue,
+    required this.onSearchChanged,
     required this.controller,
   });
 
@@ -224,7 +228,8 @@ class _ModelDropdown extends StatelessWidget {
   final String? selectedModelId;
   final bool providerSelected;
   final void Function(String?) onChanged;
-  final ValueNotifier<String> searchValue;
+  final String searchValue;
+  final ValueChanged<String> onSearchChanged;
   final TextEditingController controller;
 
   @override
@@ -261,9 +266,7 @@ class _ModelDropdown extends StatelessWidget {
               padding: AuraEdgeInsetsGeometry.medium,
               child: AuraInput(
                 controller: controller,
-                onChanged: (value) {
-                  searchValue.value = value;
-                },
+                onChanged: onSearchChanged,
               ),
             ),
     );

--- a/apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart
+++ b/apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart
@@ -96,7 +96,9 @@ class SelectChatData extends HookWidget {
     final internalProviderId = useState<String?>(null);
     final effectiveProviderId = selectedProviderId ?? internalProviderId.value;
 
-    final _onSelectProvider = useCallback<void Function(String?)>((provider) {
+    final onSelectProviderCallback = useCallback<void Function(String?)>((
+      provider,
+    ) {
       internalProviderId.value = provider;
       onSelectProvider(provider);
     }, [onSelectProvider]);
@@ -127,7 +129,7 @@ class SelectChatData extends HookWidget {
     final provider = _ProviderDropdown(
       providerNames: providerNames,
       selectedProvider: effectiveProviderId,
-      onChanged: _onSelectProvider,
+      onChanged: onSelectProviderCallback,
     );
     final modelDropdown = _ModelDropdown(
       models: filteredModels,
@@ -169,7 +171,7 @@ class SelectChatData extends HookWidget {
 }
 
 /// Provider dropdown widget - first step in two-step selection.
-class _ProviderDropdown extends HookConsumerWidget {
+class _ProviderDropdown extends StatelessWidget {
   const _ProviderDropdown({
     required this.providerNames,
     required this.selectedProvider,
@@ -181,7 +183,7 @@ class _ProviderDropdown extends HookConsumerWidget {
   final void Function(String?) onChanged;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return AuraDropdownSelector<String>(
       value: selectedProvider,
       onChanged: onChanged,
@@ -199,7 +201,7 @@ class _ProviderDropdown extends HookConsumerWidget {
 }
 
 /// Model dropdown widget - second step, disabled until provider selected.
-class _ModelDropdown extends HookConsumerWidget {
+class _ModelDropdown extends StatelessWidget {
   const _ModelDropdown({
     required this.models,
     required this.selectedModelId,
@@ -217,7 +219,7 @@ class _ModelDropdown extends HookConsumerWidget {
   final TextEditingController controller;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     if (!providerSelected) {
       // Disabled state - show placeholder (FR-002)
       return const AuraDropdownSelector<String>(
@@ -246,8 +248,8 @@ class _ModelDropdown extends HookConsumerWidget {
               padding: AuraEdgeInsetsGeometry.medium,
               child: TextLocale(LocaleKeys.models_screens_no_models_available),
             )
-          : Padding(
-              padding: EdgeInsetsGeometry.all(context.auraTheme.spacing.md),
+          : AuraPadding(
+              padding: AuraEdgeInsetsGeometry.medium,
               child: AuraInput(
                 controller: controller,
                 onChanged: (value) {

--- a/apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart
+++ b/apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart
@@ -15,10 +15,10 @@ class SelectCredentialsModelWidget extends HookConsumerWidget
   const SelectCredentialsModelWidget({
     required this.workspaceId,
     required this.selectCredentialsModelId,
+    required this.onProviderChanged,
     super.key,
     this.credentialsModelId,
     this.selectedProviderId,
-    this.onProviderChanged,
   });
 
   final String workspaceId;
@@ -29,7 +29,7 @@ class SelectCredentialsModelWidget extends HookConsumerWidget
   final String? selectedProviderId;
 
   /// Callback when provider selection changes.
-  final void Function(String?)? onProviderChanged;
+  final void Function(String?) onProviderChanged;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -37,23 +37,73 @@ class SelectCredentialsModelWidget extends HookConsumerWidget
       listModelsGroupedByProviderProvider(workspaceId: workspaceId),
     );
 
-    final searchValue = useState<String>('');
-    final controller = useTextEditingController();
+    void onSelectProvider(String? provider) {
+      onProviderChanged(provider);
+      selectCredentialsModelId(null);
+    }
 
-    // Internal provider state if no external control
-    final internalProviderId = useState<String?>(null);
-    final effectiveProviderId = selectedProviderId ?? internalProviderId.value;
+    return switch (groupedModelsAsync) {
+      AsyncLoading() => const AuraPadding(
+        padding: AuraEdgeInsetsGeometry.vertical(.md),
+        child: AuraSpinner(),
+      ),
+      AsyncError(:final error, :final stackTrace) => AppErrorWidget(
+        error: error,
+        stackTrace: stackTrace,
+      ),
+      AsyncData(:final value) => SelectChatData(
+        groupedModels: value,
+        credentialsModelId: credentialsModelId,
+        selectedProviderId: selectedProviderId,
+        onSelectProvider: onSelectProvider,
+        selectCredentialsModelId: selectCredentialsModelId,
+      ),
+    };
+  }
+
+  @override
+  // Use 120 to accommodate both Row (60) and Column (stacked) layouts
+  Size get preferredSize => const Size.fromHeight(120);
+}
+
+class SelectChatData extends HookWidget {
+  const SelectChatData({
+    required this.groupedModels,
+    required this.credentialsModelId,
+    required this.selectedProviderId,
+    required this.onSelectProvider,
+    required this.selectCredentialsModelId,
+    super.key,
+  });
+
+  final Map<String, List<CredentialsModelWithProviderEntity>> groupedModels;
+  final String? credentialsModelId;
+  final String? selectedProviderId;
+  final void Function(String?) onSelectProvider;
+  final void Function(String?) selectCredentialsModelId;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = useTextEditingController();
 
     // Responsive layout - stacked below md breakpoint (768px)
     final screenWidth = MediaQuery.of(context).size.width;
     final isCompact = screenWidth < DesignBreakpoints.md;
 
+    final searchValue = useState<String>('');
+
+    // Internal provider state if no external control
+    final internalProviderId = useState<String?>(null);
+    final effectiveProviderId = selectedProviderId ?? internalProviderId.value;
+
+    final _onSelectProvider = useCallback<void Function(String?)>((provider) {
+      internalProviderId.value = provider;
+      onSelectProvider(provider);
+    }, [onSelectProvider]);
+
     // Filter models by search - computed unconditionally (not in hook)
-    final groupedMap = groupedModelsAsync.hasValue
-        ? groupedModelsAsync.value
-        : null;
-    final modelsForProvider = effectiveProviderId != null && groupedMap != null
-        ? groupedMap[effectiveProviderId] ??
+    final modelsForProvider = effectiveProviderId != null
+        ? groupedModels[effectiveProviderId] ??
               <CredentialsModelWithProviderEntity>[]
         : <CredentialsModelWithProviderEntity>[];
     final filteredModels = searchValue.value.isEmpty
@@ -63,112 +113,59 @@ class SelectCredentialsModelWidget extends HookConsumerWidget
             return searchTerm.contains(searchValue.value.toLowerCase());
           }).toList();
 
-    // Auto-select provider when only one exists (US3)
-    useEffect(() {
-      groupedModelsAsync.whenOrNull(
-        data: (groupedModels) {
-          // Only auto-select if:
-          // 1. Exactly one provider exists
-          // 2. No provider is currently selected (external or internal)
-          // 3. This is internal state (not externally controlled)
-          if (groupedModels.length == 1 &&
-              selectedProviderId == null &&
-              internalProviderId.value == null) {
-            final singleProvider = groupedModels.keys.first;
-            internalProviderId.value = singleProvider;
-            onProviderChanged?.call(singleProvider);
-            selectCredentialsModelId(null); // Reset model when auto-selecting
-          }
-        },
-      );
-      return null;
-    }, [groupedModelsAsync, selectedProviderId]);
-
-    return groupedModelsAsync.when(
-      loading: () => const AuraPadding(
+    if (groupedModels.isEmpty) {
+      return const AuraPadding(
         padding: AuraEdgeInsetsGeometry.vertical(.md),
-        child: AuraSpinner(),
-      ),
-      error: (error, stackTrace) => AppErrorWidget(
-        error: error,
-        stackTrace: stackTrace,
-      ),
-      data: (groupedModels) {
-        if (groupedModels.isEmpty) {
-          return const AuraPadding(
-            padding: AuraEdgeInsetsGeometry.vertical(.md),
-            child: TextLocale(
-              LocaleKeys.models_screens_no_providers_configured,
-            ),
-          );
-        }
+        child: TextLocale(
+          LocaleKeys.models_screens_no_providers_configured,
+        ),
+      );
+    }
 
-        final providerNames = groupedModels.keys.toList();
+    final providerNames = groupedModels.keys.toList();
 
-        return AuraPadding(
-          padding: const AuraEdgeInsetsGeometry.only(
-            bottom: .sm,
-            left: .md,
-            right: .md,
-          ),
-          child: isCompact
-              ? Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    _ProviderDropdown(
-                      providerNames: providerNames,
-                      selectedProvider: effectiveProviderId,
-                      onChanged: (provider) {
-                        internalProviderId.value = provider;
-                        onProviderChanged?.call(provider);
-                        selectCredentialsModelId(null);
-                      },
-                    ),
-                    const SizedBox(height: DesignSpacing.sm),
-                    _ModelDropdown(
-                      models: filteredModels,
-                      selectedModelId: credentialsModelId,
-                      providerSelected: effectiveProviderId != null,
-                      onChanged: selectCredentialsModelId,
-                      searchValue: searchValue,
-                      controller: controller,
-                    ),
-                  ],
-                )
-              : Row(
-                  children: [
-                    Expanded(
-                      child: _ProviderDropdown(
-                        providerNames: providerNames,
-                        selectedProvider: effectiveProviderId,
-                        onChanged: (provider) {
-                          internalProviderId.value = provider;
-                          onProviderChanged?.call(provider);
-                          selectCredentialsModelId(null);
-                        },
-                      ),
-                    ),
-                    const SizedBox(width: DesignSpacing.sm),
-                    Expanded(
-                      child: _ModelDropdown(
-                        models: filteredModels,
-                        selectedModelId: credentialsModelId,
-                        providerSelected: effectiveProviderId != null,
-                        onChanged: selectCredentialsModelId,
-                        searchValue: searchValue,
-                        controller: controller,
-                      ),
-                    ),
-                  ],
+    final provider = _ProviderDropdown(
+      providerNames: providerNames,
+      selectedProvider: effectiveProviderId,
+      onChanged: _onSelectProvider,
+    );
+    final modelDropdown = _ModelDropdown(
+      models: filteredModels,
+      selectedModelId: credentialsModelId,
+      providerSelected: effectiveProviderId != null,
+      onChanged: selectCredentialsModelId,
+      searchValue: searchValue,
+      controller: controller,
+    );
+
+    return AuraPadding(
+      padding: const AuraEdgeInsetsGeometry.only(
+        bottom: .sm,
+        left: .md,
+        right: .md,
+      ),
+      child: isCompact
+          ? AuraColumn(
+              spacing: .sm,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                provider,
+                modelDropdown,
+              ],
+            )
+          : AuraRow(
+              spacing: .sm,
+              children: [
+                Expanded(
+                  child: provider,
                 ),
-        );
-      },
+                Expanded(
+                  child: modelDropdown,
+                ),
+              ],
+            ),
     );
   }
-
-  @override
-  // Use 120 to accommodate both Row (60) and Column (stacked) layouts
-  Size get preferredSize => const Size.fromHeight(120);
 }
 
 /// Provider dropdown widget - first step in two-step selection.

--- a/apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart
+++ b/apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart
@@ -96,12 +96,21 @@ class SelectChatData extends HookWidget {
     final internalProviderId = useState<String?>(null);
     final effectiveProviderId = selectedProviderId ?? internalProviderId.value;
 
+    useEffect(() {
+      if (selectedProviderId == null && internalProviderId.value != null) {
+        internalProviderId.value = null;
+      }
+      return null;
+    }, [selectedProviderId]);
+
     final onSelectProviderCallback = useCallback<void Function(String?)>((
       provider,
     ) {
-      internalProviderId.value = provider;
+      if (selectedProviderId == null) {
+        internalProviderId.value = provider;
+      }
       onSelectProvider(provider);
-    }, [onSelectProvider]);
+    }, [onSelectProvider, selectedProviderId]);
 
     // Filter models by search - computed unconditionally (not in hook)
     final modelsForProvider = effectiveProviderId != null

--- a/apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart
+++ b/apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart
@@ -8,6 +8,26 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+String? _findProviderForModelId(
+  Map<String, List<CredentialsModelWithProviderEntity>> groupedModels,
+  String? credentialsModelId,
+) {
+  if (credentialsModelId == null) {
+    return null;
+  }
+
+  for (final entry in groupedModels.entries) {
+    final hasModel = entry.value.any(
+      (model) => model.credentialsModel.id == credentialsModelId,
+    );
+    if (hasModel) {
+      return entry.key;
+    }
+  }
+
+  return null;
+}
+
 /// Two-step model selector: Provider first, then Model.
 /// Follows user mental model of selecting provider before model.
 class SelectCredentialsModelWidget extends HookConsumerWidget
@@ -94,7 +114,12 @@ class SelectChatData extends HookWidget {
 
     // Internal provider state if no external control
     final internalProviderId = useState<String?>(null);
-    final effectiveProviderId = selectedProviderId ?? internalProviderId.value;
+    final derivedProviderId = useMemoized(
+      () => _findProviderForModelId(groupedModels, credentialsModelId),
+      [groupedModels, credentialsModelId],
+    );
+    final effectiveProviderId =
+        selectedProviderId ?? internalProviderId.value ?? derivedProviderId;
 
     useEffect(() {
       if (selectedProviderId == null && internalProviderId.value != null) {
@@ -102,6 +127,18 @@ class SelectChatData extends HookWidget {
       }
       return null;
     }, [selectedProviderId]);
+
+    useEffect(() {
+      if (selectedProviderId != null || internalProviderId.value != null) {
+        return null;
+      }
+
+      if (derivedProviderId != null) {
+        internalProviderId.value = derivedProviderId;
+      }
+
+      return null;
+    }, [selectedProviderId, internalProviderId.value, derivedProviderId]);
 
     final onSelectProviderCallback = useCallback<void Function(String?)>((
       provider,
@@ -142,6 +179,7 @@ class SelectChatData extends HookWidget {
     );
     final modelDropdown = _ModelDropdown(
       models: filteredModels,
+      hasModelsForProvider: modelsForProvider.isNotEmpty,
       selectedModelId: credentialsModelId,
       providerSelected: effectiveProviderId != null,
       onChanged: selectCredentialsModelId,
@@ -216,6 +254,7 @@ class _ProviderDropdown extends StatelessWidget {
 class _ModelDropdown extends StatelessWidget {
   const _ModelDropdown({
     required this.models,
+    required this.hasModelsForProvider,
     required this.selectedModelId,
     required this.providerSelected,
     required this.onChanged,
@@ -225,6 +264,7 @@ class _ModelDropdown extends StatelessWidget {
   });
 
   final List<CredentialsModelWithProviderEntity> models;
+  final bool hasModelsForProvider;
   final String? selectedModelId;
   final bool providerSelected;
   final void Function(String?) onChanged;
@@ -257,7 +297,7 @@ class _ModelDropdown extends StatelessWidget {
             ),
           )
           .toList(),
-      header: models.isEmpty
+      header: !hasModelsForProvider
           ? const AuraPadding(
               padding: AuraEdgeInsetsGeometry.medium,
               child: TextLocale(LocaleKeys.models_screens_no_models_available),


### PR DESCRIPTION
## Summary
- Refactor `SelectCredentialsModelWidget` to use `AsyncLoading`/`AsyncError`/`AsyncData` switch branches for grouped model loading states.
- Split data-state rendering into `SelectChatData`, keeping async state handling at the parent widget and reducing duplicated provider/model dropdown UI logic.
- Move model selector and context usage pill into the chat screen body layout and pass the new required `onProviderChanged` callback.

## Validation
- `fvm dart analyze apps/auravibes_app/lib/features/models/widgets/select_chat_model.dart apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart`