### PR TITLE
refactor: rename partial update APIs to patch

### DIFF
--- a/apps/auravibes_app/lib/data/database/drift/daos/api_model_providers_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/api_model_providers_dao.dart
@@ -90,21 +90,6 @@ class ApiModelProvidersDao extends DatabaseAccessor<AppDatabase>
     );
   }
 
-  /// Updates an existing provider in the database.
-  ///
-  /// Updates the provider with the given [id] using the provided [provider]
-  /// data.
-  /// Returns true if a provider was updated, false otherwise.
-  Future<bool> updateProvider(
-    String id,
-    ApiModelProvidersCompanion provider,
-  ) async {
-    final updateCount = await (update(
-      apiModelProviders,
-    )..where((t) => t.id.equals(id))).write(provider);
-    return updateCount > 0;
-  }
-
   /// Deletes a provider from the database.
   ///
   /// Deletes the provider with the given [id].

--- a/apps/auravibes_app/lib/data/database/drift/daos/conversation_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/conversation_dao.dart
@@ -17,7 +17,7 @@ class ConversationDao extends DatabaseAccessor<AppDatabase>
     conversations,
   )..where((tbl) => tbl.id.equals(id))).getSingleOrNull();
 
-  Future<bool> updateConversation(
+  Future<bool> patchConversation(
     String id,
     ConversationsCompanion companion,
   ) => (update(conversations)..where((tbl) => tbl.id.equals(id)))

--- a/apps/auravibes_app/lib/data/database/drift/daos/mcp_servers_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/mcp_servers_dao.dart
@@ -46,19 +46,6 @@ class McpServersDao extends DatabaseAccessor<AppDatabase>
   Future<McpServersTable> insertMcpServer(McpServersCompanion companion) =>
       into(mcpServers).insertReturning(companion);
 
-  /// Update an existing MCP server.
-  ///
-  /// Returns true if a row was updated.
-  Future<bool> updateMcpServer(
-    String id,
-    McpServersCompanion companion,
-  ) async {
-    final rowsUpdated = await (update(
-      mcpServers,
-    )..where((t) => t.id.equals(id))).write(companion);
-    return rowsUpdated > 0;
-  }
-
   /// Delete an MCP server by ID.
   ///
   /// Returns true if a row was deleted.

--- a/apps/auravibes_app/lib/data/database/drift/daos/message_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/message_dao.dart
@@ -15,7 +15,7 @@ class MessageDao extends DatabaseAccessor<AppDatabase> with _$MessageDaoMixin {
   Future<MessagesTable?> getMessageById(String id) =>
       (select(messages)..where((tbl) => tbl.id.equals(id))).getSingleOrNull();
 
-  Future<MessagesTable?> updateMessage(
+  Future<MessagesTable?> patchMessage(
     String id,
     MessagesCompanion companion,
   ) => (update(messages)..where((tbl) => tbl.id.equals(id)))

--- a/apps/auravibes_app/lib/data/database/drift/daos/tools_groups_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/tools_groups_dao.dart
@@ -56,7 +56,7 @@ class ToolsGroupsDao extends DatabaseAccessor<AppDatabase>
   /// Update the enabled status of a tools group.
   ///
   /// Returns true if a row was updated.
-  Future<bool> updateToolsGroupEnabled(String id, {required bool isEnabled}) =>
+  Future<bool> setToolsGroupEnabled(String id, {required bool isEnabled}) =>
       (update(toolsGroups)..where((t) => t.id.equals(id)))
           .write(
             ToolsGroupsCompanion(

--- a/apps/auravibes_app/lib/data/database/drift/daos/workspace_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/workspace_dao.dart
@@ -47,12 +47,12 @@ class WorkspaceDao extends DatabaseAccessor<AppDatabase>
     return into(workspaces).insertReturning(workspace);
   }
 
-  /// Updates an existing workspace in the database.
+  /// Patches an existing workspace in the database.
   ///
   /// Updates the workspace with the given [id]
   /// using the provided [workspace] data.
-  /// Returns true if a workspace was updated, false otherwise.
-  Future<bool> updateWorkspace(String id, WorkspacesCompanion workspace) async {
+  /// Returns true if a workspace was patched, false otherwise.
+  Future<bool> patchWorkspace(String id, WorkspacesCompanion workspace) async {
     final updateCount = await (update(
       workspaces,
     )..where((t) => t.id.equals(id))).write(workspace);
@@ -114,7 +114,7 @@ class WorkspaceDao extends DatabaseAccessor<AppDatabase>
         .then((rows) => rows.length);
   }
 
-  Future<bool> updateWorkspaceTimestamp(String id) async {
+  Future<bool> patchWorkspaceTimestamp(String id) async {
     final rowsAffected =
         await (update(workspaces)..where((t) => t.id.equals(id))).write(
           WorkspacesCompanion(updatedAt: Value(DateTime.now())),

--- a/apps/auravibes_app/lib/data/database/drift/daos/workspace_tools_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/workspace_tools_dao.dart
@@ -85,7 +85,7 @@ class WorkspaceToolsDao extends DatabaseAccessor<AppDatabase>
     return (select(tools)..where((tbl) => tbl.id.equals(id))).getSingle();
   }
 
-  Future<List<ToolsTable>> updateWorkspaceToolConfig(
+  Future<List<ToolsTable>> patchWorkspaceToolConfig(
     String workspaceId,
     String toolId,
     String? config,

--- a/apps/auravibes_app/lib/data/datasources/local/workspace_local_datasource.dart
+++ b/apps/auravibes_app/lib/data/datasources/local/workspace_local_datasource.dart
@@ -75,9 +75,9 @@ class WorkspaceLocalDataSource {
   /// [workspace] The updated workspace data.
   /// Returns true if the workspace was updated, false otherwise.
   /// Throws [Exception] if the database operation fails.
-  Future<bool> updateWorkspace(String id, WorkspacesCompanion workspace) async {
+  Future<bool> patchWorkspace(String id, WorkspacesCompanion workspace) async {
     try {
-      return await _workspaceDao.updateWorkspace(id, workspace);
+      return await _workspaceDao.patchWorkspace(id, workspace);
     } catch (e) {
       throw Exception('Failed to update workspace with ID $id: $e');
     }
@@ -152,9 +152,9 @@ class WorkspaceLocalDataSource {
   /// [id] The ID of the workspace to update.
   /// Returns true if the workspace was updated, false otherwise.
   /// Throws [Exception] if the database operation fails.
-  Future<bool> updateWorkspaceTimestamp(String id) async {
+  Future<bool> patchWorkspaceTimestamp(String id) async {
     try {
-      return await _workspaceDao.updateWorkspaceTimestamp(id);
+      return await _workspaceDao.patchWorkspaceTimestamp(id);
     } catch (e) {
       throw Exception(
         'Failed to update timestamp for workspace with ID $id: $e',

--- a/apps/auravibes_app/lib/data/datasources/local/workspace_local_datasource.dart
+++ b/apps/auravibes_app/lib/data/datasources/local/workspace_local_datasource.dart
@@ -69,17 +69,17 @@ class WorkspaceLocalDataSource {
     }
   }
 
-  /// Updates an existing workspace in the local database.
+  /// Applies a partial patch to an existing workspace in the local database.
   ///
-  /// [id] The ID of the workspace to update.
-  /// [workspace] The updated workspace data.
-  /// Returns true if the workspace was updated, false otherwise.
+  /// [id] The ID of the workspace to patch.
+  /// [workspace] The partial workspace data to patch.
+  /// Returns true if the workspace was patched, false otherwise.
   /// Throws [Exception] if the database operation fails.
   Future<bool> patchWorkspace(String id, WorkspacesCompanion workspace) async {
     try {
       return await _workspaceDao.patchWorkspace(id, workspace);
     } catch (e) {
-      throw Exception('Failed to update workspace with ID $id: $e');
+      throw Exception('Failed to patch workspace with ID $id: $e');
     }
   }
 
@@ -147,17 +147,17 @@ class WorkspaceLocalDataSource {
     }
   }
 
-  /// Updates the last updated timestamp for a workspace.
+  /// Patches the last-updated timestamp for a workspace.
   ///
-  /// [id] The ID of the workspace to update.
-  /// Returns true if the workspace was updated, false otherwise.
+  /// [id] The ID of the workspace to patch.
+  /// Returns true if the workspace timestamp was patched, false otherwise.
   /// Throws [Exception] if the database operation fails.
   Future<bool> patchWorkspaceTimestamp(String id) async {
     try {
       return await _workspaceDao.patchWorkspaceTimestamp(id);
     } catch (e) {
       throw Exception(
-        'Failed to update timestamp for workspace with ID $id: $e',
+        'Failed to patch timestamp for workspace with ID $id: $e',
       );
     }
   }

--- a/apps/auravibes_app/lib/data/repositories/conversation_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/conversation_repository_impl.dart
@@ -48,20 +48,20 @@ class ConversationRepositoryImpl implements ConversationRepository {
   }
 
   @override
-  Future<ConversationEntity> updateConversation(
+  Future<ConversationEntity> patchConversation(
     String id,
-    ConversationToUpdate conversation,
+    ConversationPatch conversation,
   ) async {
-    _validateConversationUpdate(conversation);
+    _validateConversationPatch(conversation);
 
     if (!await _conversationExists(id)) {
       throw ConversationNotFoundException(id);
     }
 
-    final conversationCompanion = _mapUpdateToConversationsCompanion(
+    final conversationCompanion = _mapPatchToConversationsCompanion(
       conversation,
     );
-    final updated = await _database.conversationDao.updateConversation(
+    final updated = await _database.conversationDao.patchConversation(
       id,
       conversationCompanion,
     );
@@ -107,7 +107,7 @@ class ConversationRepositoryImpl implements ConversationRepository {
     }
   }
 
-  void _validateConversationUpdate(ConversationToUpdate conversation) {
+  void _validateConversationPatch(ConversationPatch conversation) {
     if (!conversation.isValid) {
       throw ConversationValidationException(
         conversation.title != null && conversation.title!.isEmpty
@@ -142,8 +142,8 @@ class ConversationRepositoryImpl implements ConversationRepository {
     );
   }
 
-  ConversationsCompanion _mapUpdateToConversationsCompanion(
-    ConversationToUpdate conversation,
+  ConversationsCompanion _mapPatchToConversationsCompanion(
+    ConversationPatch conversation,
   ) {
     return ConversationsCompanion(
       title: Value.absentIfNull(conversation.title),

--- a/apps/auravibes_app/lib/data/repositories/message_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/message_repository_impl.dart
@@ -189,11 +189,6 @@ Failed to retrieve messages of type $messageType for conversation $conversationI
     try {
       _validateMessagePatch(message);
 
-      // Check if message exists
-      if (!await messageExists(id)) {
-        throw MessageNotFoundException(id);
-      }
-
       final messageCompanion = _mapPatchToMessagesCompanion(message);
       final updatedMessage = await _database.messageDao.patchMessage(
         id,
@@ -201,7 +196,7 @@ Failed to retrieve messages of type $messageType for conversation $conversationI
       );
 
       if (updatedMessage == null) {
-        throw MessageException('Failed to patch message with ID $id');
+        throw MessageNotFoundException(id);
       }
 
       return _mapToMessage(updatedMessage);

--- a/apps/auravibes_app/lib/data/repositories/message_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/message_repository_impl.dart
@@ -182,13 +182,13 @@ Failed to retrieve messages of type $messageType for conversation $conversationI
   }
 
   @override
-  Future<MessageEntity> updateMessage(
+  Future<MessageEntity> patchMessage(
     String id,
-    MessageToUpdate message,
+    MessagePatch message,
   ) async {
     try {
       // Validate message before updating
-      if (!await _validateMessageToUpdate(message)) {
+      if (!await _validateMessagePatch(message)) {
         throw const MessageValidationException('Invalid message data');
       }
 
@@ -197,8 +197,8 @@ Failed to retrieve messages of type $messageType for conversation $conversationI
         throw MessageNotFoundException(id);
       }
 
-      final messageCompanion = _mapUpdateToMessagesCompanion(message);
-      final updatedMessage = await _database.messageDao.updateMessage(
+      final messageCompanion = _mapPatchToMessagesCompanion(message);
+      final updatedMessage = await _database.messageDao.patchMessage(
         id,
         messageCompanion,
       );
@@ -289,10 +289,10 @@ Failed to retrieve messages with status $status for conversation $conversationId
     }
   }
 
-  Future<bool> _validateMessageToUpdate(MessageToUpdate message) async {
+  Future<bool> _validateMessagePatch(MessagePatch message) async {
     try {
       if (!message.isValid) {
-        throw MessageValidationException(_getValidationErrorToUpdate(message));
+        throw MessageValidationException(_getValidationErrorPatch(message));
       }
       return true;
     } catch (e) {
@@ -338,7 +338,7 @@ Failed to retrieve messages with status $status for conversation $conversationId
     );
   }
 
-  MessagesCompanion _mapUpdateToMessagesCompanion(MessageToUpdate message) {
+  MessagesCompanion _mapPatchToMessagesCompanion(MessagePatch message) {
     return MessagesCompanion(
       content: Value.absentIfNull(message.content),
       status: Value.absentIfNull(
@@ -360,7 +360,7 @@ Failed to retrieve messages with status $status for conversation $conversationId
     return 'Unknown validation error';
   }
 
-  String _getValidationErrorToUpdate(MessageToUpdate message) {
+  String _getValidationErrorPatch(MessagePatch message) {
     if (message.content != null && message.content!.isEmpty) {
       return 'Message content cannot be empty';
     }

--- a/apps/auravibes_app/lib/data/repositories/message_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/message_repository_impl.dart
@@ -207,7 +207,10 @@ Failed to retrieve messages of type $messageType for conversation $conversationI
       return _mapToMessage(updatedMessage);
     } catch (e) {
       if (e is MessageException) rethrow;
-      throw MessageException('Failed to patch message', e as Exception);
+      final wrappedError = e is Exception
+          ? e
+          : Exception('Unexpected message patch error: $e');
+      throw MessageException('Failed to patch message', wrappedError);
     }
   }
 
@@ -279,9 +282,12 @@ Failed to retrieve messages with status $status for conversation $conversationId
       return true;
     } catch (e) {
       if (e is MessageValidationException) rethrow;
+      final wrappedError = e is Exception
+          ? e
+          : Exception('Unexpected message validation error: $e');
       throw MessageValidationException(
         'Message validation failed',
-        e as Exception,
+        wrappedError,
       );
     }
   }

--- a/apps/auravibes_app/lib/data/repositories/message_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/message_repository_impl.dart
@@ -187,10 +187,7 @@ Failed to retrieve messages of type $messageType for conversation $conversationI
     MessagePatch message,
   ) async {
     try {
-      // Validate message before updating
-      if (!await _validateMessagePatch(message)) {
-        throw const MessageValidationException('Invalid message data');
-      }
+      _validateMessagePatch(message);
 
       // Check if message exists
       if (!await messageExists(id)) {
@@ -204,13 +201,13 @@ Failed to retrieve messages of type $messageType for conversation $conversationI
       );
 
       if (updatedMessage == null) {
-        throw MessageException('Failed to update message with ID $id');
+        throw MessageException('Failed to patch message with ID $id');
       }
 
       return _mapToMessage(updatedMessage);
     } catch (e) {
       if (e is MessageException) rethrow;
-      throw MessageException('Failed to update message', e as Exception);
+      throw MessageException('Failed to patch message', e as Exception);
     }
   }
 
@@ -289,12 +286,12 @@ Failed to retrieve messages with status $status for conversation $conversationId
     }
   }
 
-  Future<bool> _validateMessagePatch(MessagePatch message) async {
+  void _validateMessagePatch(MessagePatch message) {
     try {
-      if (!message.isValid) {
-        throw MessageValidationException(_getValidationErrorPatch(message));
+      final validationError = _getValidationErrorPatch(message);
+      if (validationError != null) {
+        throw MessageValidationException(validationError);
       }
-      return true;
     } catch (e) {
       if (e is MessageValidationException) rethrow;
       throw MessageValidationException(
@@ -360,14 +357,16 @@ Failed to retrieve messages with status $status for conversation $conversationId
     return 'Unknown validation error';
   }
 
-  String _getValidationErrorPatch(MessagePatch message) {
-    if (message.content != null && message.content!.isEmpty) {
+  String? _getValidationErrorPatch(MessagePatch message) {
+    if (message.content != null && message.content!.trim().isEmpty) {
       return 'Message content cannot be empty';
     }
-    if (message.metadata != null) {
-      return 'Metadata cannot be empty';
+    if (message.content == null &&
+        message.metadata == null &&
+        message.status == null) {
+      return 'Must set content, metadata, or status';
     }
-    return 'Must Set content or metadata or status';
+    return null;
   }
 
   MessageStatus _messageTableStatusToEntityStatus(MessageTableStatus status) {

--- a/apps/auravibes_app/lib/data/repositories/tools_groups_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/tools_groups_repository_impl.dart
@@ -40,7 +40,7 @@ class ToolsGroupsRepositoryImpl implements ToolsGroupsRepository {
     String groupId, {
     required bool isEnabled,
   }) async {
-    return _database.toolsGroupsDao.updateToolsGroupEnabled(
+    return _database.toolsGroupsDao.setToolsGroupEnabled(
       groupId,
       isEnabled: isEnabled,
     );

--- a/apps/auravibes_app/lib/data/repositories/workspace_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/workspace_repository_impl.dart
@@ -77,13 +77,13 @@ class WorkspaceRepositoryImpl implements WorkspaceRepository {
   }
 
   @override
-  Future<WorkspaceEntity> updateWorkspace(
+  Future<WorkspaceEntity> patchWorkspace(
     String id,
-    WorkspaceToCreate workspace,
+    WorkspacePatch workspace,
   ) async {
     try {
       // Validate workspace before updating
-      if (!await validateWorkspace(workspace)) {
+      if (!await _validateWorkspacePatch(workspace)) {
         throw const WorkspaceValidationException('Invalid workspace data');
       }
 
@@ -92,11 +92,8 @@ class WorkspaceRepositoryImpl implements WorkspaceRepository {
         throw WorkspaceNotFoundException(id);
       }
 
-      final workspaceCompanion = _mapToWorkspacesCompanion(
-        workspace,
-        forUpdate: true,
-      );
-      final updated = await _database.workspaceDao.updateWorkspace(
+      final workspaceCompanion = _mapPatchToWorkspacesCompanion(workspace);
+      final updated = await _database.workspaceDao.patchWorkspace(
         id,
         workspaceCompanion,
       );
@@ -200,14 +197,14 @@ class WorkspaceRepositoryImpl implements WorkspaceRepository {
   }
 
   @override
-  Future<bool> updateWorkspaceTimestamp(String id) async {
+  Future<bool> patchWorkspaceTimestamp(String id) async {
     try {
       // Check if workspace exists
       if (!await workspaceExists(id)) {
         return false; // Return false instead of throwing for update operations
       }
 
-      final updated = await _database.workspaceDao.updateWorkspaceTimestamp(id);
+      final updated = await _database.workspaceDao.patchWorkspaceTimestamp(id);
       return updated;
     } catch (e) {
       throw WorkspaceException(
@@ -237,17 +234,46 @@ class WorkspaceRepositoryImpl implements WorkspaceRepository {
   /// for database operations.
   ///
   /// [workspace] The workspace entity to map.
-  /// [forUpdate] Whether this mapping is for an update operation.
   /// Returns the corresponding [WorkspacesCompanion].
-  WorkspacesCompanion _mapToWorkspacesCompanion(
-    WorkspaceToCreate workspace, {
-    bool forUpdate = false,
-  }) {
+  WorkspacesCompanion _mapToWorkspacesCompanion(WorkspaceToCreate workspace) {
     return WorkspacesCompanion(
       name: Value(workspace.name),
       type: Value(workspace.type),
       url: Value(workspace.url),
     );
+  }
+
+  Future<bool> _validateWorkspacePatch(WorkspacePatch workspace) async {
+    try {
+      if (!workspace.isValid) {
+        throw WorkspaceValidationException(_getValidationErrorPatch(workspace));
+      }
+      return true;
+    } catch (e) {
+      if (e is WorkspaceValidationException) rethrow;
+      throw WorkspaceValidationException(
+        'Workspace validation failed',
+        e as Exception,
+      );
+    }
+  }
+
+  WorkspacesCompanion _mapPatchToWorkspacesCompanion(WorkspacePatch workspace) {
+    return WorkspacesCompanion(
+      name: Value.absentIfNull(workspace.name),
+      type: Value.absentIfNull(workspace.type),
+      url: Value.absentIfNull(workspace.url),
+    );
+  }
+
+  String _getValidationErrorPatch(WorkspacePatch workspace) {
+    if (workspace.name != null && workspace.name!.isEmpty) {
+      return 'Workspace name cannot be empty';
+    }
+    if (workspace.url != null && workspace.url!.isEmpty) {
+      return 'Workspace URL cannot be empty';
+    }
+    return 'Unknown validation error';
   }
 
   /// Gets validation error message for a workspace.

--- a/apps/auravibes_app/lib/data/repositories/workspace_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/workspace_repository_impl.dart
@@ -82,15 +82,18 @@ class WorkspaceRepositoryImpl implements WorkspaceRepository {
     WorkspacePatch workspace,
   ) async {
     try {
-      // Validate workspace before updating
-      if (!await _validateWorkspacePatch(workspace)) {
-        throw const WorkspaceValidationException('Invalid workspace data');
-      }
-
-      // Check if workspace exists
-      if (!await workspaceExists(id)) {
+      final currentWorkspaceTable = await _database.workspaceDao
+          .getWorkspaceById(
+            id,
+          );
+      if (currentWorkspaceTable == null) {
         throw WorkspaceNotFoundException(id);
       }
+
+      _validateWorkspacePatch(
+        workspace,
+        _mapToWorkspace(currentWorkspaceTable),
+      );
 
       final workspaceCompanion = _mapPatchToWorkspacesCompanion(workspace);
       final updated = await _database.workspaceDao.patchWorkspace(
@@ -99,7 +102,7 @@ class WorkspaceRepositoryImpl implements WorkspaceRepository {
       );
 
       if (!updated) {
-        throw WorkspaceException('Failed to update workspace with ID $id');
+        throw WorkspaceException('Failed to patch workspace with ID $id');
       }
 
       final updatedWorkspace = await _database.workspaceDao.getWorkspaceById(
@@ -115,7 +118,10 @@ class WorkspaceRepositoryImpl implements WorkspaceRepository {
       return _mapToWorkspace(updatedWorkspace);
     } catch (e) {
       if (e is WorkspaceException) rethrow;
-      throw WorkspaceException('Failed to update workspace', e as Exception);
+      throw WorkspaceException(
+        'Failed to patch workspace',
+        e is Exception ? e : Exception('Unexpected workspace patch error: $e'),
+      );
     }
   }
 
@@ -201,14 +207,14 @@ class WorkspaceRepositoryImpl implements WorkspaceRepository {
     try {
       // Check if workspace exists
       if (!await workspaceExists(id)) {
-        return false; // Return false instead of throwing for update operations
+        return false; // Return false instead of throwing for patch operations
       }
 
       final updated = await _database.workspaceDao.patchWorkspaceTimestamp(id);
       return updated;
     } catch (e) {
       throw WorkspaceException(
-        'Failed to update workspace timestamp',
+        'Failed to patch workspace timestamp',
         e as Exception,
       );
     }
@@ -243,18 +249,13 @@ class WorkspaceRepositoryImpl implements WorkspaceRepository {
     );
   }
 
-  Future<bool> _validateWorkspacePatch(WorkspacePatch workspace) async {
-    try {
-      if (!workspace.isValid) {
-        throw WorkspaceValidationException(_getValidationErrorPatch(workspace));
-      }
-      return true;
-    } catch (e) {
-      if (e is WorkspaceValidationException) rethrow;
-      throw WorkspaceValidationException(
-        'Workspace validation failed',
-        e as Exception,
-      );
+  void _validateWorkspacePatch(
+    WorkspacePatch workspace,
+    WorkspaceEntity currentWorkspace,
+  ) {
+    final validationError = workspace.validationErrorFor(currentWorkspace);
+    if (validationError != null) {
+      throw WorkspaceValidationException(validationError);
     }
   }
 
@@ -264,16 +265,6 @@ class WorkspaceRepositoryImpl implements WorkspaceRepository {
       type: Value.absentIfNull(workspace.type),
       url: Value.absentIfNull(workspace.url),
     );
-  }
-
-  String _getValidationErrorPatch(WorkspacePatch workspace) {
-    if (workspace.name != null && workspace.name!.isEmpty) {
-      return 'Workspace name cannot be empty';
-    }
-    if (workspace.url != null && workspace.url!.isEmpty) {
-      return 'Workspace URL cannot be empty';
-    }
-    return 'Unknown validation error';
   }
 
   /// Gets validation error message for a workspace.

--- a/apps/auravibes_app/lib/data/repositories/workspace_tools_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/workspace_tools_repository_impl.dart
@@ -259,9 +259,16 @@ class WorkspaceToolsRepositoryImpl implements WorkspaceToolsRepository {
     String toolType,
     String? config,
   ) async {
-    return _dao
-        .patchWorkspaceToolConfig(workspaceId, toolType, config)
-        .then((value) => value.map(_tableToEntity).toList());
+    try {
+      return await _dao
+          .patchWorkspaceToolConfig(workspaceId, toolType, config)
+          .then((value) => value.map(_tableToEntity).toList());
+    } catch (e) {
+      throw WorkspaceToolsException(
+        'Failed to patch workspace tool config: $e',
+        e is Exception ? e : null,
+      );
+    }
   }
 
   WorkspaceToolEntity _tableToEntity(ToolsTable table) {

--- a/apps/auravibes_app/lib/data/repositories/workspace_tools_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/workspace_tools_repository_impl.dart
@@ -254,13 +254,13 @@ class WorkspaceToolsRepositoryImpl implements WorkspaceToolsRepository {
   }
 
   @override
-  Future<List<WorkspaceToolEntity>> updateWorkspaceToolConfig(
+  Future<List<WorkspaceToolEntity>> patchWorkspaceToolConfig(
     String workspaceId,
     String toolType,
     String? config,
   ) async {
     return _dao
-        .updateWorkspaceToolConfig(workspaceId, toolType, config)
+        .patchWorkspaceToolConfig(workspaceId, toolType, config)
         .then((value) => value.map(_tableToEntity).toList());
   }
 

--- a/apps/auravibes_app/lib/domain/entities/conversation.dart
+++ b/apps/auravibes_app/lib/domain/entities/conversation.dart
@@ -69,8 +69,8 @@ abstract class ConversationToCreate with _$ConversationToCreate {
 }
 
 @freezed
-abstract class ConversationToUpdate with _$ConversationToUpdate {
-  const factory ConversationToUpdate({
+abstract class ConversationPatch with _$ConversationPatch {
+  const factory ConversationPatch({
     /// Human-readable title of the conversation
     String? title,
 
@@ -79,8 +79,8 @@ abstract class ConversationToUpdate with _$ConversationToUpdate {
 
     /// Whether this conversation is pinned
     bool? isPinned,
-  }) = _ConversationToUpdate;
-  const ConversationToUpdate._();
+  }) = _ConversationPatch;
+  const ConversationPatch._();
 
   bool get isValid {
     if (title != null && title!.isEmpty) return false;

--- a/apps/auravibes_app/lib/domain/entities/messages.dart
+++ b/apps/auravibes_app/lib/domain/entities/messages.dart
@@ -170,11 +170,11 @@ abstract class MessageToCreate with _$MessageToCreate {
   }
 }
 
-/// Entity for creating a new message
+/// Entity for patching an existing message
 @freezed
-abstract class MessageToUpdate with _$MessageToUpdate {
-  /// Creates a new MessageToUpdate instance
-  const factory MessageToUpdate({
+abstract class MessagePatch with _$MessagePatch {
+  /// Creates a new MessagePatch instance
+  const factory MessagePatch({
     /// Content of the message (JSON structure based on message type)
     String? content,
 
@@ -182,8 +182,8 @@ abstract class MessageToUpdate with _$MessageToUpdate {
     MessageMetadataEntity? metadata,
 
     MessageStatus? status,
-  }) = _MessageToUpdate;
-  const MessageToUpdate._();
+  }) = _MessagePatch;
+  const MessagePatch._();
 
   /// Returns true if the message is in a valid state
   bool get isValid {

--- a/apps/auravibes_app/lib/domain/entities/workspace.dart
+++ b/apps/auravibes_app/lib/domain/entities/workspace.dart
@@ -67,3 +67,19 @@ abstract class WorkspaceToCreate with _$WorkspaceToCreate {
     return hasValidName && hasValidUrl;
   }
 }
+
+@freezed
+abstract class WorkspacePatch with _$WorkspacePatch {
+  const factory WorkspacePatch({
+    String? name,
+    WorkspaceType? type,
+    String? url,
+  }) = _WorkspacePatch;
+  const WorkspacePatch._();
+
+  bool get isValid {
+    if (name != null && name!.isEmpty) return false;
+    if (url != null && url!.isEmpty) return false;
+    return name != null || type != null || url != null;
+  }
+}

--- a/apps/auravibes_app/lib/domain/entities/workspace.dart
+++ b/apps/auravibes_app/lib/domain/entities/workspace.dart
@@ -77,9 +77,36 @@ abstract class WorkspacePatch with _$WorkspacePatch {
   }) = _WorkspacePatch;
   const WorkspacePatch._();
 
-  bool get isValid {
-    if (name != null && name!.isEmpty) return false;
-    if (url != null && url!.isEmpty) return false;
-    return name != null || type != null || url != null;
+  String? validationErrorFor(WorkspaceEntity current) {
+    if (name == null && type == null && url == null) {
+      return 'At least one field must be provided';
+    }
+
+    if (name != null && name!.isEmpty) {
+      return 'Workspace name cannot be empty';
+    }
+
+    if (url != null && url!.isEmpty) {
+      return 'Workspace URL cannot be empty';
+    }
+
+    final mergedName = name ?? current.name;
+    final mergedType = type ?? current.type;
+    final mergedUrl = url ?? current.url;
+
+    if (mergedName.isEmpty) {
+      return 'Workspace name cannot be empty';
+    }
+
+    if (mergedType == WorkspaceType.local && mergedUrl != null) {
+      return 'Local workspace cannot have a URL';
+    }
+
+    if (mergedType == WorkspaceType.remote &&
+        (mergedUrl == null || mergedUrl.isEmpty)) {
+      return 'Remote workspace must have a URL';
+    }
+
+    return null;
   }
 }

--- a/apps/auravibes_app/lib/domain/repositories/conversation_repository.dart
+++ b/apps/auravibes_app/lib/domain/repositories/conversation_repository.dart
@@ -14,9 +14,9 @@ abstract class ConversationRepository {
     ConversationToCreate conversation,
   );
 
-  Future<ConversationEntity> updateConversation(
+  Future<ConversationEntity> patchConversation(
     String id,
-    ConversationToUpdate conversation,
+    ConversationPatch conversation,
   );
 
   Future<bool> deleteConversation(String id);

--- a/apps/auravibes_app/lib/domain/repositories/message_repository.dart
+++ b/apps/auravibes_app/lib/domain/repositories/message_repository.dart
@@ -79,14 +79,14 @@ abstract class MessageRepository {
   /// Throws [MessageException] if there's an error creating the message.
   Future<MessageEntity> createMessage(MessageToCreate message);
 
-  /// Updates an existing message in the data source.
+  /// Applies a partial update (patch) to an existing message.
   ///
-  /// [id] The ID of the message to update.
-  /// [message] The message with updated values. Must have a valid ID.
+  /// [id] The ID of the message to patch.
+  /// [message] The partial fields to update. Unspecified fields are unchanged.
   /// Returns the updated message.
   /// Throws [MessageValidationException] if message data is invalid.
   /// Throws [MessageNotFoundException] if no message with the given ID exists.
-  /// Throws [MessageException] if there's an error updating the message.
+  /// Throws [MessageException] if there's an error patching the message.
   Future<MessageEntity> patchMessage(String id, MessagePatch message);
 
   /// Deletes a message from the data source.

--- a/apps/auravibes_app/lib/domain/repositories/message_repository.dart
+++ b/apps/auravibes_app/lib/domain/repositories/message_repository.dart
@@ -87,7 +87,7 @@ abstract class MessageRepository {
   /// Throws [MessageValidationException] if message data is invalid.
   /// Throws [MessageNotFoundException] if no message with the given ID exists.
   /// Throws [MessageException] if there's an error updating the message.
-  Future<MessageEntity> updateMessage(String id, MessageToUpdate message);
+  Future<MessageEntity> patchMessage(String id, MessagePatch message);
 
   /// Deletes a message from the data source.
   ///

--- a/apps/auravibes_app/lib/domain/repositories/workspace_repository.dart
+++ b/apps/auravibes_app/lib/domain/repositories/workspace_repository.dart
@@ -39,15 +39,15 @@ abstract class WorkspaceRepository {
   /// Throws [WorkspaceException] if there's an error creating the workspace.
   Future<WorkspaceEntity> createWorkspace(WorkspaceToCreate workspace);
 
-  /// Updates an existing workspace in the data source.
+  /// Applies a partial update (patch) to an existing workspace.
   ///
-  /// [id] id of workspace to update
-  /// [workspace] The workspace with updated values. Must have a valid ID.
-  /// Returns the updated workspace.
+  /// [id] id of workspace to patch.
+  /// [workspace] The partial fields to update.
+  /// Returns the patched workspace.
   /// Throws [WorkspaceValidationException] if the workspace data is invalid.
   /// Throws [WorkspaceNotFoundException] if no workspace with the
   /// given ID exists.
-  /// Throws [WorkspaceException] if there's an error updating the workspace.
+  /// Throws [WorkspaceException] if there's an error patching the workspace.
   Future<WorkspaceEntity> patchWorkspace(
     String id,
     WorkspacePatch workspace,
@@ -89,19 +89,19 @@ abstract class WorkspaceRepository {
   /// Throws [WorkspaceException] if there's an error counting workspaces.
   Future<int> getWorkspaceCountByType(WorkspaceType type);
 
-  /// Validates workspace data before creation or update.
+  /// Validates workspace data before creation.
   ///
   /// [workspace] The workspace to validate.
   /// Returns true if the workspace data is valid.
   /// Throws [WorkspaceValidationException] if the workspace data is invalid.
   Future<bool> validateWorkspace(WorkspaceToCreate workspace);
 
-  /// Updates the last updated timestamp for a workspace.
+  /// Patches the last-updated timestamp for a workspace.
   ///
-  /// [id] The unique identifier of the workspace to update.
-  /// Returns true if the workspace was successfully updated,
+  /// [id] The unique identifier of the workspace to patch.
+  /// Returns true if the workspace timestamp was successfully patched,
   /// false if not found.
-  /// Throws [WorkspaceException] if there's an error updating the timestamp.
+  /// Throws [WorkspaceException] if there's an error patching the timestamp.
   Future<bool> patchWorkspaceTimestamp(String id);
 }
 

--- a/apps/auravibes_app/lib/domain/repositories/workspace_repository.dart
+++ b/apps/auravibes_app/lib/domain/repositories/workspace_repository.dart
@@ -48,9 +48,9 @@ abstract class WorkspaceRepository {
   /// Throws [WorkspaceNotFoundException] if no workspace with the
   /// given ID exists.
   /// Throws [WorkspaceException] if there's an error updating the workspace.
-  Future<WorkspaceEntity> updateWorkspace(
+  Future<WorkspaceEntity> patchWorkspace(
     String id,
-    WorkspaceToCreate workspace,
+    WorkspacePatch workspace,
   );
 
   /// Deletes a workspace from the data source.
@@ -102,7 +102,7 @@ abstract class WorkspaceRepository {
   /// Returns true if the workspace was successfully updated,
   /// false if not found.
   /// Throws [WorkspaceException] if there's an error updating the timestamp.
-  Future<bool> updateWorkspaceTimestamp(String id);
+  Future<bool> patchWorkspaceTimestamp(String id);
 }
 
 /// Base exception for workspace-related operations.

--- a/apps/auravibes_app/lib/domain/repositories/workspace_tools_repository.dart
+++ b/apps/auravibes_app/lib/domain/repositories/workspace_tools_repository.dart
@@ -64,14 +64,13 @@ abstract class WorkspaceToolsRepository {
     required bool isEnabled,
   });
 
-  /// Updates the configuration for a workspace tool.
+  /// Applies a partial update (patch) to workspace tool configuration.
   ///
   /// [workspaceId] The ID of the workspace.
-  /// [toolType] The type of tool to update.
+  /// [toolType] The type of tool to patch.
   /// [config] The new configuration as JSON string.
-  /// Returns true if the operation was successful, false if the tool
-  /// was not found.
-  /// Throws [WorkspaceToolsException] if there's an error updating the tool.
+  /// Returns the updated list of workspace tool settings for the workspace.
+  /// Throws [WorkspaceToolsException] if there's an error patching the tool.
   Future<List<WorkspaceToolEntity>> patchWorkspaceToolConfig(
     String workspaceId,
     String toolType,

--- a/apps/auravibes_app/lib/domain/repositories/workspace_tools_repository.dart
+++ b/apps/auravibes_app/lib/domain/repositories/workspace_tools_repository.dart
@@ -72,7 +72,7 @@ abstract class WorkspaceToolsRepository {
   /// Returns true if the operation was successful, false if the tool
   /// was not found.
   /// Throws [WorkspaceToolsException] if there's an error updating the tool.
-  Future<List<WorkspaceToolEntity>> updateWorkspaceToolConfig(
+  Future<List<WorkspaceToolEntity>> patchWorkspaceToolConfig(
     String workspaceId,
     String toolType,
     String? config,

--- a/apps/auravibes_app/lib/features/chats/notifiers/conversation_chat_notifier.dart
+++ b/apps/auravibes_app/lib/features/chats/notifiers/conversation_chat_notifier.dart
@@ -51,9 +51,9 @@ class ConversationChatNotifier extends _$ConversationChatNotifier {
 
     final updatedConversation = await ref
         .read(conversationRepositoryProvider)
-        .updateConversation(
+        .patchConversation(
           result.conversation.id,
-          ConversationToUpdate(modelId: modelId),
+          ConversationPatch(modelId: modelId),
         );
     state = AsyncData(ConversationFound(updatedConversation));
   }

--- a/apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart
+++ b/apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart
@@ -181,25 +181,44 @@ class ContinueAgentUsecase {
           status: .sent,
         ),
       );
-    } catch (e, _) {
+    } on Object catch (error, stackTrace) {
       if (!hasAcknowledgedPendingUsers && pendingUserMessageIds.isNotEmpty) {
-        for (final pendingUserMessageId in pendingUserMessageIds) {
-          await messageRepository.patchMessage(
-            pendingUserMessageId,
-            const MessagePatch(status: MessageStatus.error),
+        try {
+          for (final pendingUserMessageId in pendingUserMessageIds) {
+            await messageRepository.patchMessage(
+              pendingUserMessageId,
+              const MessagePatch(status: MessageStatus.error),
+            );
+          }
+        } on Object catch (cleanupError, cleanupStackTrace) {
+          monitoringService.trackError(
+            'Failed to persist pending user error state',
+            error: cleanupError,
+            stackTrace: cleanupStackTrace,
           );
         }
       }
 
-      if (firstMessage == null) rethrow;
+      if (firstMessage == null) {
+        Error.throwWithStackTrace(error, stackTrace);
+      }
 
-      await messageRepository.patchMessage(
-        firstMessage.id,
-        const .new(
-          status: .error,
-        ),
-      );
-      rethrow;
+      try {
+        await messageRepository.patchMessage(
+          firstMessage.id,
+          const .new(
+            status: .error,
+          ),
+        );
+      } on Object catch (cleanupError, cleanupStackTrace) {
+        monitoringService.trackError(
+          'Failed to persist assistant error state',
+          error: cleanupError,
+          stackTrace: cleanupStackTrace,
+        );
+      }
+
+      Error.throwWithStackTrace(error, stackTrace);
     } finally {
       conversationStreamingRuntime.remove(conversationId);
       if (firstMessage != null) {

--- a/apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart
+++ b/apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart
@@ -102,7 +102,7 @@ class ContinueAgentUsecase {
       final persistenceFuture = streamingController.stream
           .coalescingSave(
             store: (state) async {
-              await messageRepository.updateMessage(
+              await messageRepository.patchMessage(
                 firstMessage!.id,
                 .new(
                   content: state.outputAsString,
@@ -137,9 +137,9 @@ class ContinueAgentUsecase {
 
         if (!hasAcknowledgedPendingUsers && pendingUserMessageIds.isNotEmpty) {
           for (final pendingUserMessageId in pendingUserMessageIds) {
-            await messageRepository.updateMessage(
+            await messageRepository.patchMessage(
               pendingUserMessageId,
-              const MessageToUpdate(status: MessageStatus.sent),
+              const MessagePatch(status: MessageStatus.sent),
             );
           }
           hasAcknowledgedPendingUsers = true;
@@ -174,7 +174,7 @@ class ContinueAgentUsecase {
 
       lastResult = accumulatedResult;
 
-      await messageRepository.updateMessage(
+      await messageRepository.patchMessage(
         firstMessage.id,
         .new(
           metadata: lastResult.entityMetadata,
@@ -184,16 +184,16 @@ class ContinueAgentUsecase {
     } catch (e, _) {
       if (!hasAcknowledgedPendingUsers && pendingUserMessageIds.isNotEmpty) {
         for (final pendingUserMessageId in pendingUserMessageIds) {
-          await messageRepository.updateMessage(
+          await messageRepository.patchMessage(
             pendingUserMessageId,
-            const MessageToUpdate(status: MessageStatus.error),
+            const MessagePatch(status: MessageStatus.error),
           );
         }
       }
 
       if (firstMessage == null) rethrow;
 
-      await messageRepository.updateMessage(
+      await messageRepository.patchMessage(
         firstMessage.id,
         const .new(
           status: .error,

--- a/apps/auravibes_app/lib/features/chats/usecases/generate_title_usecase.dart
+++ b/apps/auravibes_app/lib/features/chats/usecases/generate_title_usecase.dart
@@ -50,7 +50,7 @@ class GenerateTitleUsecase {
     sharedStream
         .coalescingSave(
           store: (t) async {
-            await conversationRepo.updateConversation(
+            await conversationRepo.patchConversation(
               conversationId,
               .new(
                 title: t,

--- a/apps/auravibes_app/lib/features/tools/providers/workspace_tools_provider.dart
+++ b/apps/auravibes_app/lib/features/tools/providers/workspace_tools_provider.dart
@@ -78,7 +78,7 @@ class WorkspaceToolsNotifier extends _$WorkspaceToolsNotifier {
 
   /// Update workspace tool configuration
   Future<void> updateToolConfig(String toolId, String? config) async {
-    final success = await _repository.updateWorkspaceToolConfig(
+    final success = await _repository.patchWorkspaceToolConfig(
       _workspaceId,
       toolId,
       config,

--- a/apps/auravibes_app/lib/features/tools/usecases/approve_tool_call_usecase.dart
+++ b/apps/auravibes_app/lib/features/tools/usecases/approve_tool_call_usecase.dart
@@ -188,9 +188,9 @@ class ApproveToolCallUsecase {
       );
     }).toList();
 
-    await _messageRepository.updateMessage(
+    await _messageRepository.patchMessage(
       message.id,
-      MessageToUpdate(
+      MessagePatch(
         metadata: metadata.copyWith(toolCalls: updatedToolCalls),
       ),
     );

--- a/apps/auravibes_app/lib/features/tools/usecases/run_allowed_tools_usecase.dart
+++ b/apps/auravibes_app/lib/features/tools/usecases/run_allowed_tools_usecase.dart
@@ -274,9 +274,9 @@ class RunAllowedToolsUsecase {
       );
     }).toList();
 
-    await messageRepository.updateMessage(
+    await messageRepository.patchMessage(
       messageId,
-      MessageToUpdate(
+      MessagePatch(
         metadata: metadata.copyWith(toolCalls: updatedToolCalls),
       ),
     );

--- a/apps/auravibes_app/lib/features/tools/usecases/skip_tool_call_usecase.dart
+++ b/apps/auravibes_app/lib/features/tools/usecases/skip_tool_call_usecase.dart
@@ -31,9 +31,9 @@ class SkipToolCallUsecase {
       );
     }).toList();
 
-    await _messageRepository.updateMessage(
+    await _messageRepository.patchMessage(
       messageId,
-      MessageToUpdate(
+      MessagePatch(
         metadata: metadata.copyWith(toolCalls: updatedToolCalls),
       ),
     );

--- a/apps/auravibes_app/lib/features/tools/usecases/stop_all_pending_tool_calls_usecase.dart
+++ b/apps/auravibes_app/lib/features/tools/usecases/stop_all_pending_tool_calls_usecase.dart
@@ -27,9 +27,9 @@ class StopAllPendingToolCallsUsecase {
     }).toList();
     if (!didUpdate) return;
 
-    await _messageRepository.updateMessage(
+    await _messageRepository.patchMessage(
       messageId,
-      MessageToUpdate(
+      MessagePatch(
         metadata: metadata.copyWith(toolCalls: updatedToolCalls),
       ),
     );

--- a/apps/auravibes_app/test/data/database/workspace_dao_test.dart
+++ b/apps/auravibes_app/test/data/database/workspace_dao_test.dart
@@ -90,7 +90,7 @@ void main() {
       );
 
       // Update the workspace
-      final updated = await workspaceDao.updateWorkspace(
+      final updated = await workspaceDao.patchWorkspace(
         idCreated.id,
         WorkspacesCompanion(
           name: const Value('Updated Name'),

--- a/apps/auravibes_app/test/data/repositories/workspace_repository_impl_test.dart
+++ b/apps/auravibes_app/test/data/repositories/workspace_repository_impl_test.dart
@@ -74,10 +74,10 @@ void main() {
       );
       final createdWorkspace = await repository.createWorkspace(workspace);
 
-      final updatedWorkspace = workspace.copyWith(name: 'Updated Workspace');
+      const updatedWorkspace = WorkspacePatch(name: 'Updated Workspace');
 
       // Act
-      final result = await repository.updateWorkspace(
+      final result = await repository.patchWorkspace(
         createdWorkspace.id,
         updatedWorkspace,
       );

--- a/apps/auravibes_app/test/data/repositories/workspace_repository_impl_test.dart
+++ b/apps/auravibes_app/test/data/repositories/workspace_repository_impl_test.dart
@@ -86,6 +86,60 @@ void main() {
       expect(result.name, 'Updated Workspace');
     });
 
+    test('should reject empty workspace patch', () async {
+      // Arrange
+      const workspace = WorkspaceToCreate(
+        name: 'Test Workspace',
+        type: WorkspaceType.local,
+      );
+      final createdWorkspace = await repository.createWorkspace(workspace);
+
+      // Act + Assert
+      await expectLater(
+        repository.patchWorkspace(createdWorkspace.id, const WorkspacePatch()),
+        throwsA(
+          isA<WorkspaceValidationException>().having(
+            (error) => error.message,
+            'message',
+            'At least one field must be provided',
+          ),
+        ),
+      );
+    });
+
+    test('should reject invalid merged workspace patch invariants', () async {
+      // Arrange
+      const localWorkspace = WorkspaceToCreate(
+        name: 'Local Workspace',
+        type: WorkspaceType.local,
+      );
+      const remoteWorkspace = WorkspaceToCreate(
+        name: 'Remote Workspace',
+        type: WorkspaceType.remote,
+        url: 'https://example.com',
+      );
+      final createdLocal = await repository.createWorkspace(localWorkspace);
+      final createdRemote = await repository.createWorkspace(remoteWorkspace);
+
+      // Act + Assert: local + URL should fail
+      await expectLater(
+        repository.patchWorkspace(
+          createdLocal.id,
+          const WorkspacePatch(url: 'https://invalid-for-local.com'),
+        ),
+        throwsA(isA<WorkspaceValidationException>()),
+      );
+
+      // Act + Assert: changing remote -> local without clearing URL should fail
+      await expectLater(
+        repository.patchWorkspace(
+          createdRemote.id,
+          const WorkspacePatch(type: WorkspaceType.local),
+        ),
+        throwsA(isA<WorkspaceValidationException>()),
+      );
+    });
+
     test('should delete a workspace', () async {
       // Arrange
       const workspace = WorkspaceToCreate(

--- a/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
+++ b/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
@@ -309,7 +309,7 @@ class _FakeMessageRepository implements MessageRepository {
   }
 
   @override
-  Future<MessageEntity> updateMessage(String id, MessageToUpdate message) {
+  Future<MessageEntity> patchMessage(String id, MessagePatch message) {
     throw UnimplementedError();
   }
 

--- a/apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.dart
@@ -103,7 +103,7 @@ void main() {
         messageRepository.createMessage(any),
       ).thenAnswer((_) async => _unfinishedAssistantMessage);
       when(
-        messageRepository.updateMessage(any, any),
+        messageRepository.patchMessage(any, any),
       ).thenAnswer((_) async => _unfinishedAssistantMessage);
     });
 
@@ -165,13 +165,13 @@ void main() {
         expect(removedConversationIds, ['conversation-1']);
 
         final updates = verify(
-          messageRepository.updateMessage(
+          messageRepository.patchMessage(
             'assistant-1',
             captureAny,
           ),
         ).captured;
 
-        final streamingUpdate = updates.cast<MessageToUpdate>().firstWhere(
+        final streamingUpdate = updates.cast<MessagePatch>().firstWhere(
           (update) => update.metadata?.toolCalls.isNotEmpty ?? false,
         );
 
@@ -215,9 +215,9 @@ void main() {
         );
 
         verify(
-          messageRepository.updateMessage(
+          messageRepository.patchMessage(
             'user-1',
-            const MessageToUpdate(status: MessageStatus.sent),
+            const MessagePatch(status: MessageStatus.sent),
           ),
         ).called(1);
 
@@ -259,15 +259,15 @@ void main() {
         );
 
         verify(
-          messageRepository.updateMessage(
+          messageRepository.patchMessage(
             'user-1',
-            const MessageToUpdate(status: MessageStatus.sent),
+            const MessagePatch(status: MessageStatus.sent),
           ),
         ).called(1);
         verify(
-          messageRepository.updateMessage(
+          messageRepository.patchMessage(
             'user-2',
-            const MessageToUpdate(status: MessageStatus.sent),
+            const MessagePatch(status: MessageStatus.sent),
           ),
         ).called(1);
 

--- a/apps/auravibes_app/test/features/tools/providers/conversation_tools_controller_test.dart
+++ b/apps/auravibes_app/test/features/tools/providers/conversation_tools_controller_test.dart
@@ -344,7 +344,7 @@ class _FakeWorkspaceToolsRepository implements WorkspaceToolsRepository {
   }
 
   @override
-  Future<List<WorkspaceToolEntity>> updateWorkspaceToolConfig(
+  Future<List<WorkspaceToolEntity>> patchWorkspaceToolConfig(
     String workspaceId,
     String toolType,
     String? config,

--- a/apps/auravibes_app/test/features/tools/usecases/approve_tool_call_usecase_test.dart
+++ b/apps/auravibes_app/test/features/tools/usecases/approve_tool_call_usecase_test.dart
@@ -95,7 +95,7 @@ void main() {
       when(messageRepository.getMessageById(messageId)).thenAnswer(
         (_) async => message,
       );
-      when(messageRepository.updateMessage(messageId, any)).thenAnswer(
+      when(messageRepository.patchMessage(messageId, any)).thenAnswer(
         (_) async => message,
       );
       when(
@@ -116,9 +116,9 @@ void main() {
 
       final update =
           verify(
-                messageRepository.updateMessage(messageId, captureAny),
+                messageRepository.patchMessage(messageId, captureAny),
               ).captured.single
-              as MessageToUpdate;
+              as MessagePatch;
       expect(
         update.metadata?.toolCalls.single.resultStatus,
         ToolCallResultStatus.toolNotFound,
@@ -166,9 +166,9 @@ void main() {
 
         final update =
             verify(
-                  messageRepository.updateMessage(messageId, captureAny),
+                  messageRepository.patchMessage(messageId, captureAny),
                 ).captured.single
-                as MessageToUpdate;
+                as MessagePatch;
         expect(update.metadata?.toolCalls.single.responseRaw, 'mcp result');
       },
     );
@@ -207,9 +207,9 @@ void main() {
 
         final update =
             verify(
-                  messageRepository.updateMessage(messageId, captureAny),
+                  messageRepository.patchMessage(messageId, captureAny),
                 ).captured.single
-                as MessageToUpdate;
+                as MessagePatch;
         final updatedToolCall = update.metadata?.toolCalls.single;
         expect(updatedToolCall?.resultStatus, ToolCallResultStatus.success);
         expect(updatedToolCall?.responseRaw, '2.0');
@@ -253,9 +253,9 @@ void main() {
 
         final update =
             verify(
-                  messageRepository.updateMessage(messageId, captureAny),
+                  messageRepository.patchMessage(messageId, captureAny),
                 ).captured.single
-                as MessageToUpdate;
+                as MessagePatch;
         expect(
           update.metadata?.toolCalls.single.resultStatus,
           ToolCallResultStatus.executionError,

--- a/apps/auravibes_app/test/features/tools/usecases/run_allowed_tools_usecase_test.dart
+++ b/apps/auravibes_app/test/features/tools/usecases/run_allowed_tools_usecase_test.dart
@@ -179,7 +179,7 @@ void main() {
         ),
       ).thenAnswer((_) async => ToolPermissionResult.granted);
       when(
-        messageRepository.updateMessage('message-1', any),
+        messageRepository.patchMessage('message-1', any),
       ).thenAnswer((_) async => mcpMessage);
       when(
         getAgentIterationDecisionUsecase.call(messageId: 'message-1'),
@@ -265,7 +265,7 @@ void main() {
 
         expect(result, AgentIterationDecision.waitForToolApproval);
         verifyNever(
-          messageRepository.updateMessage(any, any),
+          messageRepository.patchMessage(any, any),
         );
       },
     );
@@ -307,7 +307,7 @@ void main() {
           ),
         ).thenAnswer((_) async => ToolPermissionResult.granted);
         when(
-          messageRepository.updateMessage('message-1', any),
+          messageRepository.patchMessage('message-1', any),
         ).thenAnswer((_) async => toolMessage);
         when(
           getAgentIterationDecisionUsecase.call(messageId: 'message-1'),
@@ -321,9 +321,9 @@ void main() {
         expect(result, AgentIterationDecision.continueIteration);
         final update =
             verify(
-                  messageRepository.updateMessage('message-1', captureAny),
+                  messageRepository.patchMessage('message-1', captureAny),
                 ).captured.single
-                as MessageToUpdate;
+                as MessagePatch;
         final updatedToolCalls = update.metadata?.toolCalls;
         expect(updatedToolCalls, isNotNull);
         expect(
@@ -417,7 +417,7 @@ void main() {
           ),
         ).thenAnswer((_) async => ToolPermissionResult.granted);
         when(
-          messageRepository.updateMessage('message-1', any),
+          messageRepository.patchMessage('message-1', any),
         ).thenAnswer((_) async => multiToolMessage);
         when(
           getAgentIterationDecisionUsecase.call(messageId: 'message-1'),
@@ -431,9 +431,9 @@ void main() {
         expect(result, AgentIterationDecision.continueIteration);
         final update =
             verify(
-                  messageRepository.updateMessage('message-1', captureAny),
+                  messageRepository.patchMessage('message-1', captureAny),
                 ).captured.single
-                as MessageToUpdate;
+                as MessagePatch;
         final updatedToolCalls = update.metadata?.toolCalls;
         expect(updatedToolCalls, isNotNull);
         expect(
@@ -517,7 +517,7 @@ void main() {
           ),
         ).thenAnswer((_) async => ToolPermissionResult.granted);
         when(
-          messageRepository.updateMessage('message-1', any),
+          messageRepository.patchMessage('message-1', any),
         ).thenAnswer((_) async => mixedMessage);
         when(
           getAgentIterationDecisionUsecase.call(messageId: 'message-1'),
@@ -531,9 +531,9 @@ void main() {
         expect(result, AgentIterationDecision.continueIteration);
         final update =
             verify(
-                  messageRepository.updateMessage('message-1', captureAny),
+                  messageRepository.patchMessage('message-1', captureAny),
                 ).captured.single
-                as MessageToUpdate;
+                as MessagePatch;
         final updatedToolCalls = update.metadata?.toolCalls;
         expect(updatedToolCalls, isNotNull);
         expect(
@@ -653,7 +653,7 @@ void main() {
           (_) async => ToolPermissionResult.disabledInWorkspace,
         );
         when(
-          messageRepository.updateMessage('message-1', any),
+          messageRepository.patchMessage('message-1', any),
         ).thenAnswer((_) async => mixedPermMessage);
 
         final result = await usecase.call(
@@ -664,9 +664,9 @@ void main() {
         expect(result, AgentIterationDecision.waitForToolApproval);
         final update =
             verify(
-                  messageRepository.updateMessage('message-1', captureAny),
+                  messageRepository.patchMessage('message-1', captureAny),
                 ).captured.single
-                as MessageToUpdate;
+                as MessagePatch;
         final updatedToolCalls = update.metadata?.toolCalls;
         expect(updatedToolCalls, isNotNull);
         expect(
@@ -750,7 +750,7 @@ void main() {
 
         expect(result, AgentIterationDecision.waitForToolApproval);
         verifyNever(
-          messageRepository.updateMessage(any, any),
+          messageRepository.patchMessage(any, any),
         );
       },
     );

--- a/apps/auravibes_app/test/features/tools/usecases/skip_tool_call_usecase_test.dart
+++ b/apps/auravibes_app/test/features/tools/usecases/skip_tool_call_usecase_test.dart
@@ -51,7 +51,7 @@ void main() {
       when(messageRepository.getMessageById(messageId)).thenAnswer(
         (_) async => message,
       );
-      when(messageRepository.updateMessage(messageId, any)).thenAnswer(
+      when(messageRepository.patchMessage(messageId, any)).thenAnswer(
         (_) async => message,
       );
       when(
@@ -66,9 +66,9 @@ void main() {
 
       final update =
           verify(
-                messageRepository.updateMessage(messageId, captureAny),
+                messageRepository.patchMessage(messageId, captureAny),
               ).captured.single
-              as MessageToUpdate;
+              as MessagePatch;
       expect(
         update.metadata?.toolCalls.first.resultStatus,
         ToolCallResultStatus.skippedByUser,
@@ -87,7 +87,7 @@ void main() {
       await usecase.call(toolCallId: toolCallId, messageId: messageId);
 
       verifyNever(
-        messageRepository.updateMessage(any, any),
+        messageRepository.patchMessage(any, any),
       );
       verifyNever(
         resumeConversationIfReadyUsecase.call(messageId: anyNamed('messageId')),

--- a/apps/auravibes_app/test/features/tools/usecases/stop_all_pending_tool_calls_usecase_test.dart
+++ b/apps/auravibes_app/test/features/tools/usecases/stop_all_pending_tool_calls_usecase_test.dart
@@ -48,7 +48,7 @@ void main() {
       when(messageRepository.getMessageById('message-1')).thenAnswer(
         (_) async => message,
       );
-      when(messageRepository.updateMessage('message-1', any)).thenAnswer(
+      when(messageRepository.patchMessage('message-1', any)).thenAnswer(
         (_) async => message,
       );
 
@@ -60,9 +60,9 @@ void main() {
 
       final updated =
           verify(
-                messageRepository.updateMessage('message-1', captureAny),
+                messageRepository.patchMessage('message-1', captureAny),
               ).captured.single
-              as MessageToUpdate;
+              as MessagePatch;
       final toolCalls = updated.metadata?.toolCalls;
 
       expect(toolCalls, isNotNull);


### PR DESCRIPTION
## Summary
- rename partial-update APIs from `update*` to `patch*` across domain repositories, data repositories, DAOs, feature use cases, and tests
- rename patch payload types to `MessagePatch` and `ConversationPatch`, and add `WorkspacePatch` to support true partial workspace updates
- remove unused DAO methods `updateMcpServer` and `updateProvider`, and rename tools-group toggle DAO method to `setToolsGroupEnabled`

## Validation
- `fvm dart run build_runner build --delete-conflicting-outputs`
- `fvm flutter test test/data/repositories/workspace_repository_impl_test.dart test/features/chats/usecases/continue_agent_usecase_test.dart --no-pub`
- `dart_analyze_files` (no errors)