### PR TITLE
fix(chats): decouple token usage and context lookup

### DIFF
--- a/apps/auravibes_app/lib/data/database/drift/daos/api_models_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/api_models_dao.dart
@@ -25,11 +25,18 @@ class ApiModelsDao extends DatabaseAccessor<AppDatabase>
         .get();
   }
 
-  /// Retrieves a model by its ID.
+  /// Retrieves a model by provider ID + model ID.
   ///
-  /// Returns the model with the given [id], or null if not found.
-  Future<ApiModelsTable?> getModelById(String id) {
-    return (select(apiModels)..where((t) => t.id.equals(id))).getSingleOrNull();
+  /// Returns the model matching [providerId] and [modelId], or null if not
+  /// found.
+  Future<ApiModelsTable?> getModelByProviderAndModelId(
+    String providerId,
+    String modelId,
+  ) {
+    return (select(apiModels)..where(
+          (t) => t.modelProvider.equals(providerId) & t.id.equals(modelId),
+        ))
+        .getSingleOrNull();
   }
 
   /// Retrieves models by their provider ID.

--- a/apps/auravibes_app/lib/data/repositories/api_model_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/api_model_repository_impl.dart
@@ -19,42 +19,43 @@ class ApiModelRepositoryImpl implements ApiModelRepository {
 
   @override
   Future<List<ApiModelProviderEntity>> getAllProviders() async {
-    try {
-      final providerTables = await _database.apiModelProvidersDao
-          .getAllProviders();
-      return providerTables.map(_mapToProviderEntity).toList();
-    } catch (e) {
-      throw ApiModelException(
-        'Failed to retrieve all providers',
-        e as Exception,
-      );
-    }
+    final providerTables = await _database.apiModelProvidersDao
+        .getAllProviders();
+    return providerTables.map(_mapToProviderEntity).toList();
   }
 
   @override
   Future<List<ApiModelProviderEntity>> getProvidersByType(String type) async {
-    try {
-      final providerTables = await _database.apiModelProvidersDao
-          .getProvidersByType(type);
-      return providerTables.map(_mapToProviderEntity).toList();
-    } catch (e) {
-      throw ApiModelException(
-        'Failed to retrieve providers of type $type',
-        e as Exception,
-      );
-    }
+    final providerTables = await _database.apiModelProvidersDao
+        .getProvidersByType(type);
+    return providerTables.map(_mapToProviderEntity).toList();
   }
 
   // Model operations
 
   @override
   Future<List<ApiModelEntity>> getAllModels() async {
-    try {
-      final modelTables = await _database.apiModelsDao.getAllModels();
-      return modelTables.map(_mapToModelEntity).toList();
-    } catch (e) {
-      throw ApiModelException('Failed to retrieve all models', e as Exception);
-    }
+    final modelTables = await _database.apiModelsDao.getAllModels();
+    return modelTables.map(_mapToModelEntity).toList();
+  }
+
+  @override
+  Future<ApiModelEntity?> getModelByProviderAndModelId(
+    String providerId,
+    String modelId,
+  ) async {
+    final modelTable = await _database.apiModelsDao
+        .getModelByProviderAndModelId(providerId, modelId);
+    if (modelTable == null) return null;
+    return _mapToModelEntity(modelTable);
+  }
+
+  @override
+  Future<List<ApiModelEntity>> getModelsByProvider(String providerId) async {
+    final modelTables = await _database.apiModelsDao.getModelsByProvider(
+      providerId,
+    );
+    return modelTables.map(_mapToModelEntity).toList();
   }
 
   // Batch operations
@@ -63,62 +64,40 @@ class ApiModelRepositoryImpl implements ApiModelRepository {
   Future<List<ApiModelProviderEntity>> batchUpsertProviders(
     List<ApiModelProviderEntity> providers,
   ) async {
-    try {
-      final providerCompanions = providers
-          .map(_modelProviderEntityToCompanion)
-          .toList();
+    final providerCompanions = providers
+        .map(_modelProviderEntityToCompanion)
+        .toList();
 
-      final insertedProviders = await _database.apiModelProvidersDao
-          .batchUpsertProviders(providerCompanions);
+    final insertedProviders = await _database.apiModelProvidersDao
+        .batchUpsertProviders(providerCompanions);
 
-      return [
-        for (final insertedProvider in insertedProviders)
-          _mapToProviderEntity(insertedProvider),
-      ];
-    } on Exception catch (e) {
-      throw ApiModelException(
-        'Failed to batch upsert providers',
-        e,
-      );
-    } catch (_) {
-      rethrow;
-      // if (e is ApiModelException) rethrow;
-    }
+    return [
+      for (final insertedProvider in insertedProviders)
+        _mapToProviderEntity(insertedProvider),
+    ];
   }
 
   @override
   Future<List<ApiModelEntity>> batchUpsertModels(
     List<ApiModelEntity> models,
   ) async {
-    try {
-      final modelCompanions = models
-          .map(_mapEntityToCompanion)
-          .nonNulls
-          .toList();
-      final insertedModels = await _database.apiModelsDao.batchUpsertModels(
-        modelCompanions,
-      );
+    final modelCompanions = models.map(_mapEntityToCompanion).nonNulls.toList();
+    final insertedModels = await _database.apiModelsDao.batchUpsertModels(
+      modelCompanions,
+    );
 
-      return [
-        for (final insertedModel in insertedModels)
-          _mapToModelEntity(insertedModel),
-      ];
-    } catch (e) {
-      if (e is ApiModelException) rethrow;
-      throw ApiModelException('Failed to batch upsert models', e as Exception);
-    }
+    return [
+      for (final insertedModel in insertedModels)
+        _mapToModelEntity(insertedModel),
+    ];
   }
 
   @override
   Future<int> deleteAllData() async {
-    try {
-      final deletedModels = await _database.apiModelsDao.deleteAllModels();
-      final deletedProviders = await _database.apiModelProvidersDao
-          .deleteAllProviders();
-      return deletedModels + deletedProviders;
-    } catch (e) {
-      throw ApiModelException('Failed to delete all data', e as Exception);
-    }
+    final deletedModels = await _database.apiModelsDao.deleteAllModels();
+    final deletedProviders = await _database.apiModelProvidersDao
+        .deleteAllProviders();
+    return deletedModels + deletedProviders;
   }
 
   // Helper methods

--- a/apps/auravibes_app/lib/domain/repositories/api_model_repository.dart
+++ b/apps/auravibes_app/lib/domain/repositories/api_model_repository.dart
@@ -31,6 +31,24 @@ abstract class ApiModelRepository {
   /// Throws [ApiModelException] if there's an error retrieving models.
   Future<List<ApiModelEntity>> getAllModels();
 
+  /// Retrieves a model by provider + model ID.
+  ///
+  /// [providerId] Provider ID (for example: openai).
+  /// [modelId] Model ID inside that provider.
+  /// Returns the matching model, or null if not found.
+  /// Throws [ApiModelException] if there's an error retrieving the model.
+  Future<ApiModelEntity?> getModelByProviderAndModelId(
+    String providerId,
+    String modelId,
+  );
+
+  /// Retrieves all models for a specific provider.
+  ///
+  /// [providerId] Provider ID to filter by.
+  /// Returns a list of models ordered by model name.
+  /// Throws [ApiModelException] if there's an error retrieving models.
+  Future<List<ApiModelEntity>> getModelsByProvider(String providerId);
+
   // Batch operations for synchronization
 
   /// Batch inserts or updates multiple providers.

--- a/apps/auravibes_app/lib/features/chats/providers/context_usage_provider.dart
+++ b/apps/auravibes_app/lib/features/chats/providers/context_usage_provider.dart
@@ -1,0 +1,168 @@
+import 'package:auravibes_app/features/chats/providers/messages_providers.dart';
+import 'package:auravibes_ui/ui.dart';
+import 'package:flutter/material.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'context_usage_provider.g.dart';
+
+@Riverpod(
+  dependencies: [conversationUsedTokens, conversationContextLimit],
+)
+ContextUsageData contextUsage(Ref ref) {
+  final usedTokens = ref.watch(conversationUsedTokensProvider);
+  final limitTokens = ref.watch(conversationContextLimitProvider).value;
+  return ContextUsageData.compute(
+    usedTokens: usedTokens,
+    limitTokens: limitTokens,
+  );
+}
+
+enum ContextUsageLevel {
+  normal,
+  elevated,
+  warning,
+  overflow,
+  unknown
+  ;
+
+  static ContextUsageLevel fromPercent(int percent) {
+    if (percent > 100) return ContextUsageLevel.overflow;
+    if (percent >= 85) return ContextUsageLevel.warning;
+    if (percent >= 70) return ContextUsageLevel.elevated;
+    return ContextUsageLevel.normal;
+  }
+
+  AuraBadgeVariant get badgeVariant => switch (this) {
+    ContextUsageLevel.normal => AuraBadgeVariant.success,
+    ContextUsageLevel.elevated => AuraBadgeVariant.info,
+    ContextUsageLevel.warning => AuraBadgeVariant.warning,
+    ContextUsageLevel.overflow => AuraBadgeVariant.error,
+    ContextUsageLevel.unknown => AuraBadgeVariant.neutral,
+  };
+
+  IconData get icon => switch (this) {
+    ContextUsageLevel.normal => Icons.check_circle_outline,
+    ContextUsageLevel.elevated => Icons.info_outline,
+    ContextUsageLevel.warning => Icons.warning_amber_outlined,
+    ContextUsageLevel.overflow => Icons.priority_high,
+    ContextUsageLevel.unknown => Icons.help_outline,
+  };
+
+  AuraColorVariant get iconColor => switch (this) {
+    ContextUsageLevel.normal => AuraColorVariant.success,
+    ContextUsageLevel.elevated => AuraColorVariant.info,
+    ContextUsageLevel.warning => AuraColorVariant.warning,
+    ContextUsageLevel.overflow => AuraColorVariant.error,
+    ContextUsageLevel.unknown => AuraColorVariant.onSurfaceVariant,
+  };
+}
+
+class ContextUsageData {
+  const ContextUsageData({
+    required this.usedTokens,
+    required this.normalizedLimit,
+    required this.hasLimit,
+    required this.percent,
+    required this.progress,
+    required this.level,
+    required this.overflowTokens,
+    required this.usageLabel,
+    required this.percentLabel,
+  });
+
+  factory ContextUsageData.compute({
+    required int usedTokens,
+    required int? limitTokens,
+  }) {
+    final normalizedLimit = (limitTokens ?? 0) < 0 ? 0 : (limitTokens ?? 0);
+    final hasLimit = normalizedLimit > 0;
+    final percent = hasLimit
+        ? ((usedTokens / normalizedLimit) * 100).round()
+        : 0;
+    final progress = percent.clamp(0, 100) / 100;
+
+    final usageLabel = hasLimit
+        ? '${_formatCompactTokens(usedTokens)}/${_formatCompactTokens(normalizedLimit)}'
+        : '${_formatCompactTokens(usedTokens)}/--';
+
+    if (!hasLimit) {
+      return ContextUsageData(
+        usedTokens: usedTokens,
+        normalizedLimit: normalizedLimit,
+        hasLimit: false,
+        percent: 0,
+        progress: 0,
+        level: ContextUsageLevel.unknown,
+        overflowTokens: 0,
+        usageLabel: usageLabel,
+        percentLabel: '--',
+      );
+    }
+
+    final level = ContextUsageLevel.fromPercent(percent);
+    final overflowTokens = usedTokens - normalizedLimit;
+
+    return ContextUsageData(
+      usedTokens: usedTokens,
+      normalizedLimit: normalizedLimit,
+      hasLimit: true,
+      percent: percent,
+      progress: progress,
+      level: level,
+      overflowTokens: overflowTokens,
+      usageLabel: usageLabel,
+      percentLabel: '$percent%',
+    );
+  }
+
+  final int usedTokens;
+  final int normalizedLimit;
+  final bool hasLimit;
+  final int percent;
+  final double progress;
+  final ContextUsageLevel level;
+  final int overflowTokens;
+  final String usageLabel;
+  final String percentLabel;
+
+  Map<String, String> tooltipArgs() => {
+    'used': '$usedTokens',
+    'limit': '$normalizedLimit',
+    'percent': '$percent',
+  };
+
+  Color progressColor(AuraColorScheme colors) => switch (level) {
+    ContextUsageLevel.normal => colors.success,
+    ContextUsageLevel.elevated => colors.info,
+    ContextUsageLevel.warning => colors.warning,
+    ContextUsageLevel.overflow => colors.error,
+    ContextUsageLevel.unknown => colors.onSurfaceVariant,
+  };
+}
+
+String _formatCompactTokens(int value) {
+  if (value >= 1000000) {
+    final formatted = value % 1000000 == 0
+        ? (value / 1000000).toStringAsFixed(0)
+        : (value / 1000000).toStringAsFixed(1);
+    return '${formatted}m';
+  }
+
+  if (value >= 1000) {
+    final k = value / 1000;
+    final formatted = value % 1000 == 0
+        ? k.toStringAsFixed(0)
+        : k.toStringAsFixed(1);
+    final roundedK = double.tryParse(formatted);
+    if (roundedK != null && roundedK >= 1000) {
+      final m = roundedK / 1000;
+      final mFormatted = m.truncateToDouble() == m
+          ? m.toStringAsFixed(0)
+          : m.toStringAsFixed(1);
+      return '${mFormatted}m';
+    }
+    return '${formatted}k';
+  }
+
+  return '$value';
+}

--- a/apps/auravibes_app/lib/features/chats/providers/context_usage_provider.dart
+++ b/apps/auravibes_app/lib/features/chats/providers/context_usage_provider.dart
@@ -25,10 +25,14 @@ enum ContextUsageLevel {
   unknown
   ;
 
-  static ContextUsageLevel fromPercent(int percent) {
-    if (percent > 100) return ContextUsageLevel.overflow;
-    if (percent >= 85) return ContextUsageLevel.warning;
-    if (percent >= 70) return ContextUsageLevel.elevated;
+  static ContextUsageLevel fromUsage({
+    required int usedTokens,
+    required int limitTokens,
+  }) {
+    if (usedTokens > limitTokens) return ContextUsageLevel.overflow;
+    final ratio = limitTokens > 0 ? usedTokens / limitTokens : 0.0;
+    if (ratio >= 0.85) return ContextUsageLevel.warning;
+    if (ratio >= 0.70) return ContextUsageLevel.elevated;
     return ContextUsageLevel.normal;
   }
 
@@ -99,7 +103,10 @@ class ContextUsageData {
       );
     }
 
-    final level = ContextUsageLevel.fromPercent(percent);
+    final level = ContextUsageLevel.fromUsage(
+      usedTokens: usedTokens,
+      limitTokens: normalizedLimit,
+    );
     final overflowTokens = usedTokens - normalizedLimit;
 
     return ContextUsageData(

--- a/apps/auravibes_app/lib/features/chats/providers/messages_providers.dart
+++ b/apps/auravibes_app/lib/features/chats/providers/messages_providers.dart
@@ -4,11 +4,11 @@ import 'package:auravibes_app/domain/entities/messages.dart';
 import 'package:auravibes_app/features/chats/notifiers/conversation_send_queue_notifier.dart';
 import 'package:auravibes_app/features/chats/notifiers/conversation_streaming_notifier.dart';
 import 'package:auravibes_app/features/chats/notifiers/messages_streaming_notifier.dart';
+import 'package:auravibes_app/features/chats/providers/conversation_providers.dart';
 import 'package:auravibes_app/features/chats/providers/conversation_repository_provider.dart';
 import 'package:auravibes_app/features/chats/providers/conversation_selection_provider.dart';
 import 'package:auravibes_app/features/chats/usecases/get_conversation_busy_state_usecase.dart';
-import 'package:auravibes_app/features/models/providers/api_model_repository_providers.dart';
-import 'package:auravibes_app/features/models/providers/model_providers_repository_providers.dart';
+import 'package:auravibes_app/features/models/providers/credentials_providers.dart';
 import 'package:auravibes_app/utils/chat_result_extension.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -24,18 +24,21 @@ final addMessageMutation = Mutation<MessageEntity>();
 final deleteMessageMutation = Mutation<void>();
 final updateMessageMutation = Mutation<MessageEntity>();
 
-@Riverpod(dependencies: [conversationSelected])
-Stream<List<MessageEntity>> persistedChatMessages(Ref ref) {
-  final conversationId = ref.watch(conversationSelectedProvider);
-
+@riverpod
+Stream<List<MessageEntity>> chatMessagesByConversation(
+  Ref ref,
+  String conversationId,
+) {
   return ref
       .watch(messageRepositoryProvider)
       .watchMessagesByConversation(conversationId);
 }
 
-@Riverpod(dependencies: [persistedChatMessages])
-AsyncValue<List<MessageEntity>> chatMessages(Ref ref) {
-  return ref.watch(persistedChatMessagesProvider);
+@Riverpod(dependencies: [conversationSelected])
+Future<List<MessageEntity>> chatMessages(Ref ref) {
+  final conversationId = ref.watch(conversationSelectedProvider);
+
+  return ref.watch(chatMessagesByConversationProvider(conversationId).future);
 }
 
 @Riverpod(dependencies: [chatMessages])
@@ -75,13 +78,13 @@ class MessageIdList extends ListBase<String> {
   int get hashCode => const DeepCollectionEquality().hash(_ids);
 }
 
-@Riverpod(dependencies: [persistedChatMessages, MessagesStreamingNotifier])
+@Riverpod(dependencies: [chatMessages, MessagesStreamingNotifier])
 MessageEntity? messageConversationById(
   Ref ref,
   String messageId,
 ) {
   final messageEntity = ref.watch(
-    persistedChatMessagesProvider.select(
+    chatMessagesProvider.select(
       (value) => value.value?.firstWhereOrNull((c) => c.id == messageId),
     ),
   );
@@ -154,43 +157,6 @@ class PendingToolCall {
   final String messageId;
 }
 
-@immutable
-class ConversationTokenUsageSummary {
-  const ConversationTokenUsageSummary({
-    required this.usedTokens,
-    required this.limitTokens,
-    required this.percent,
-    required this.progress,
-  });
-
-  final int usedTokens;
-  final int limitTokens;
-  // Raw percent can exceed 100 when context overflows.
-  final int percent;
-  // Progress is normalized for meters and clamped to 0..1.
-  final double progress;
-}
-
-@Riverpod(
-  dependencies: [
-    apiModelRepository,
-    credentialsModelsRepository,
-  ],
-)
-Future<int> modelContextLimit(Ref ref, String? credentialsModelId) async {
-  if (credentialsModelId == null) return 0;
-
-  final selectedModel = await ref
-      .watch(credentialsModelsRepositoryProvider)
-      .getCredentialsModelById(credentialsModelId);
-  final modelId = selectedModel?.credentialsModel.modelId;
-  if (modelId == null) return 0;
-
-  final models = await ref.watch(apiModelRepositoryProvider).getAllModels();
-  final apiModel = models.firstWhereOrNull((model) => model.id == modelId);
-  return apiModel?.limitContext ?? 0;
-}
-
 @Riverpod(dependencies: [chatMessages, MessagesStreamingNotifier])
 int conversationUsedTokens(Ref ref) {
   final messages = ref.watch(
@@ -214,13 +180,19 @@ int conversationUsedTokens(Ref ref) {
       0;
 }
 
-@Riverpod(dependencies: [conversationSelected])
-Future<int> conversationContextLimit(Ref ref) async {
+@Riverpod(
+  dependencies: [
+    conversationSelected,
+    conversationByIdStream,
+    modelContextLimit,
+  ],
+)
+Future<int?> conversationContextLimit(Ref ref) async {
   final conversationId = ref.watch(conversationSelectedProvider);
-  final conversation = await ref
-      .watch(conversationRepositoryProvider)
-      .getConversationById(conversationId);
-  final conversationModelId = conversation?.modelId;
+  final conversationModelId = ref
+      .watch(conversationByIdStreamProvider(conversationId: conversationId))
+      .value
+      ?.modelId;
 
   if (conversationModelId == null) return 0;
 
@@ -229,31 +201,6 @@ Future<int> conversationContextLimit(Ref ref) async {
   );
 
   return selectedModel;
-}
-
-@Riverpod(
-  dependencies: [conversationUsedTokens, conversationContextLimit],
-)
-AsyncValue<ConversationTokenUsageSummary> conversationTokenUsageSummary(
-  Ref ref,
-) {
-  final usedTokens = ref.watch(conversationUsedTokensProvider);
-  final limitTokensAsync = ref.watch(conversationContextLimitProvider);
-
-  return limitTokensAsync.whenData((limitTokens) {
-    final normalizedLimit = limitTokens < 0 ? 0 : limitTokens;
-    final rawPercent = normalizedLimit == 0
-        ? 0
-        : ((usedTokens / normalizedLimit) * 100).round();
-    final normalizedProgress = rawPercent.clamp(0, 100) / 100;
-
-    return ConversationTokenUsageSummary(
-      usedTokens: usedTokens,
-      limitTokens: normalizedLimit,
-      percent: rawPercent,
-      progress: normalizedProgress,
-    );
-  });
 }
 
 @Riverpod(dependencies: [chatMessages])

--- a/apps/auravibes_app/lib/features/chats/providers/messages_providers.dart
+++ b/apps/auravibes_app/lib/features/chats/providers/messages_providers.dart
@@ -194,7 +194,7 @@ Future<int?> conversationContextLimit(Ref ref) async {
       .value
       ?.modelId;
 
-  if (conversationModelId == null) return 0;
+  if (conversationModelId == null) return null;
 
   final selectedModel = await ref.watch(
     modelContextLimitProvider(conversationModelId).future,

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -3,18 +3,26 @@ import 'package:auravibes_app/i18n/locale_keys.dart';
 import 'package:auravibes_ui/ui.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class ConversationContextUsagePill extends ConsumerWidget {
+class ConversationContextUsagePill extends HookConsumerWidget {
   const ConversationContextUsagePill({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final usageSummaryAsync = ref.watch(conversationTokenUsageSummaryProvider);
-    final viewModel = switch (usageSummaryAsync) {
-      AsyncData(:final value) => _ContextUsageViewModel.fromSummary(value),
-      AsyncLoading() || AsyncError() => _ContextUsageViewModel.unavailable(),
-    };
+    final usedTokens = ref.watch(conversationUsedTokensProvider);
+    final contextLimitAsync = ref.watch(conversationContextLimitProvider);
+    final viewModel = useMemoized(() {
+      return switch (contextLimitAsync) {
+        AsyncData(:final value) => _ContextUsageViewModel.fromUsage(
+          usedTokens: usedTokens,
+          limitTokens: value,
+        ),
+        AsyncLoading() ||
+        AsyncError() => _ContextUsageViewModel.limitUnavailable(usedTokens),
+      };
+    }, [usedTokens, contextLimitAsync]);
     final auraColors = context.auraColors;
 
     return Padding(
@@ -92,16 +100,23 @@ class _ContextUsageViewModel {
     required this.progress,
   });
 
-  factory _ContextUsageViewModel.fromSummary(
-    ConversationTokenUsageSummary summary,
-  ) {
-    final hasLimit = summary.limitTokens > 0;
+  factory _ContextUsageViewModel.fromUsage({
+    required int usedTokens,
+    required int? limitTokens,
+  }) {
+    final normalizedLimit = (limitTokens ?? 0) < 0 ? 0 : (limitTokens ?? 0);
+    final hasLimit = normalizedLimit > 0;
+    final percent = hasLimit
+        ? ((usedTokens / normalizedLimit) * 100).round()
+        : 0;
+    final progress = percent.clamp(0, 100) / 100;
+
     const _s = LocaleKeys
         // ignore: lines_longer_than_80_chars - generated LocaleKeys name
         .chats_screens_chat_conversation_context_usage_semantic_limit_unavailable;
     final usageLabel = hasLimit
-        ? '${_formatCompactTokens(summary.usedTokens)}/${_formatCompactTokens(summary.limitTokens)}'
-        : '${_formatCompactTokens(summary.usedTokens)}/--';
+        ? '${_formatCompactTokens(usedTokens)}/${_formatCompactTokens(normalizedLimit)}'
+        : '${_formatCompactTokens(usedTokens)}/--';
 
     if (!hasLimit) {
       return _ContextUsageViewModel(
@@ -121,31 +136,47 @@ class _ContextUsageViewModel {
       );
     }
 
-    final level = _ContextUsageLevel.fromPercent(summary.percent);
-    final overflowTokens = summary.usedTokens - summary.limitTokens;
+    final level = _ContextUsageLevel.fromPercent(percent);
+    final overflowTokens = usedTokens - normalizedLimit;
     final tooltip = switch (level) {
       _ContextUsageLevel.normal =>
         LocaleKeys.chats_screens_chat_conversation_context_usage_tooltip_normal
             .tr(
-              namedArgs: _tooltipArgs(summary),
+              namedArgs: _tooltipArgs(
+                usedTokens: usedTokens,
+                limitTokens: normalizedLimit,
+                percent: percent,
+              ),
             ),
       _ContextUsageLevel.elevated =>
         LocaleKeys
             .chats_screens_chat_conversation_context_usage_tooltip_elevated
             .tr(
-              namedArgs: _tooltipArgs(summary),
+              namedArgs: _tooltipArgs(
+                usedTokens: usedTokens,
+                limitTokens: normalizedLimit,
+                percent: percent,
+              ),
             ),
       _ContextUsageLevel.warning =>
         LocaleKeys.chats_screens_chat_conversation_context_usage_tooltip_warning
             .tr(
-              namedArgs: _tooltipArgs(summary),
+              namedArgs: _tooltipArgs(
+                usedTokens: usedTokens,
+                limitTokens: normalizedLimit,
+                percent: percent,
+              ),
             ),
       _ContextUsageLevel.overflow =>
         LocaleKeys
             .chats_screens_chat_conversation_context_usage_tooltip_overflow
             .tr(
               namedArgs: {
-                ..._tooltipArgs(summary),
+                ..._tooltipArgs(
+                  usedTokens: usedTokens,
+                  limitTokens: normalizedLimit,
+                  percent: percent,
+                ),
                 'overflow': '$overflowTokens',
               },
             ),
@@ -161,7 +192,7 @@ class _ContextUsageViewModel {
             .tr(
               namedArgs: {
                 'usage': usageLabel,
-                'percent': '${summary.percent}',
+                'percent': '$percent',
               },
             ),
       _ContextUsageLevel.elevated =>
@@ -170,7 +201,7 @@ class _ContextUsageViewModel {
             .tr(
               namedArgs: {
                 'usage': usageLabel,
-                'percent': '${summary.percent}',
+                'percent': '$percent',
               },
             ),
       _ContextUsageLevel.warning =>
@@ -179,7 +210,7 @@ class _ContextUsageViewModel {
             .tr(
               namedArgs: {
                 'usage': usageLabel,
-                'percent': '${summary.percent}',
+                'percent': '$percent',
               },
             ),
       _ContextUsageLevel.overflow =>
@@ -188,7 +219,7 @@ class _ContextUsageViewModel {
             .tr(
               namedArgs: {
                 'usage': usageLabel,
-                'percent': '${summary.percent}',
+                'percent': '$percent',
                 'overflow': '$overflowTokens',
               },
             ),
@@ -199,19 +230,19 @@ class _ContextUsageViewModel {
 
     return _ContextUsageViewModel(
       usageLabel: usageLabel,
-      percentLabel: '${summary.percent}%',
+      percentLabel: '$percent%',
       tooltip: tooltip,
       semanticValue: semanticValue,
       badgeVariant: level.badgeVariant,
       icon: level.icon,
       iconColor: level.iconColor,
       level: level,
-      progress: summary.progress,
+      progress: progress,
     );
   }
 
-  factory _ContextUsageViewModel.unavailable() {
-    const usageLabel = '--/--';
+  factory _ContextUsageViewModel.limitUnavailable(int usedTokens) {
+    final usageLabel = '${_formatCompactTokens(usedTokens)}/--';
     const semanticLimitUnavailable = LocaleKeys
         // ignore: lines_longer_than_80_chars - generated LocaleKeys name
         .chats_screens_chat_conversation_context_usage_semantic_limit_unavailable;
@@ -254,11 +285,15 @@ class _ContextUsageViewModel {
   }
 }
 
-Map<String, String> _tooltipArgs(ConversationTokenUsageSummary summary) {
+Map<String, String> _tooltipArgs({
+  required int usedTokens,
+  required int limitTokens,
+  required int percent,
+}) {
   return {
-    'used': '${summary.usedTokens}',
-    'limit': '${summary.limitTokens}',
-    'percent': '${summary.percent}',
+    'used': '$usedTokens',
+    'limit': '$limitTokens',
+    'percent': '$percent',
   };
 }
 

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -1,4 +1,4 @@
-import 'package:auravibes_app/features/chats/providers/messages_providers.dart';
+import 'package:auravibes_app/features/chats/providers/context_usage_provider.dart';
 import 'package:auravibes_app/i18n/locale_keys.dart';
 import 'package:auravibes_ui/ui.dart';
 import 'package:easy_localization/easy_localization.dart';
@@ -10,26 +10,19 @@ class ConversationContextUsagePill extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final usedTokens = ref.watch(conversationUsedTokensProvider);
-    final contextLimitAsync = ref.watch(conversationContextLimitProvider);
-    final viewModel = switch (contextLimitAsync) {
-      AsyncData(:final value) => _ContextUsageViewModel.fromUsage(
-        usedTokens: usedTokens,
-        limitTokens: value,
-      ),
-      AsyncLoading() ||
-      AsyncError() => _ContextUsageViewModel.limitUnavailable(usedTokens),
-    };
+    final data = ref.watch(contextUsageProvider);
+    final tooltip = _tooltip(data);
+    final semanticValue = _semanticValue(data);
     final auraColors = context.auraColors;
 
     return Padding(
       padding: const EdgeInsets.only(right: DesignSpacing.sm),
       child: AuraTooltip(
-        message: viewModel.tooltip,
+        message: tooltip,
         child: Semantics(
           label: LocaleKeys.chats_screens_chat_conversation_context_usage_label
               .tr(),
-          value: viewModel.semanticValue,
+          value: semanticValue,
           container: true,
           excludeSemantics: true,
           child: AuraContainer(
@@ -45,9 +38,9 @@ class ConversationContextUsagePill extends ConsumerWidget {
               spacing: AuraSpacing.xs,
               children: [
                 AuraIcon(
-                  viewModel.icon,
+                  data.level.icon,
                   size: AuraIconSize.extraSmall,
-                  color: viewModel.iconColor,
+                  color: data.level.iconColor,
                 ),
                 SizedBox(
                   width: 26,
@@ -57,8 +50,8 @@ class ConversationContextUsagePill extends ConsumerWidget {
                     ),
                     child: LinearProgressIndicator(
                       minHeight: 4,
-                      value: viewModel.progress.clamp(0.0, 1.0),
-                      color: viewModel.progressColor(auraColors),
+                      value: data.progress.clamp(0.0, 1.0),
+                      color: data.progressColor(auraColors),
                       backgroundColor: auraColors.onSurfaceVariant.withValues(
                         alpha: 0.25,
                       ),
@@ -68,12 +61,12 @@ class ConversationContextUsagePill extends ConsumerWidget {
                 AuraText(
                   style: AuraTextStyle.caption,
                   color: AuraColorVariant.onSurfaceVariant,
-                  child: Text(viewModel.usageLabel),
+                  child: Text(data.usageLabel),
                 ),
                 AuraBadge.text(
                   size: AuraBadgeSize.small,
-                  variant: viewModel.badgeVariant,
-                  child: Text(viewModel.percentLabel),
+                  variant: data.level.badgeVariant,
+                  child: Text(data.percentLabel),
                 ),
               ],
             ),
@@ -84,285 +77,74 @@ class ConversationContextUsagePill extends ConsumerWidget {
   }
 }
 
-class _ContextUsageViewModel {
-  const _ContextUsageViewModel({
-    required this.usageLabel,
-    required this.percentLabel,
-    required this.tooltip,
-    required this.semanticValue,
-    required this.badgeVariant,
-    required this.icon,
-    required this.iconColor,
-    required this.level,
-    required this.progress,
-  });
-
-  factory _ContextUsageViewModel.fromUsage({
-    required int usedTokens,
-    required int? limitTokens,
-  }) {
-    final normalizedLimit = (limitTokens ?? 0) < 0 ? 0 : (limitTokens ?? 0);
-    final hasLimit = normalizedLimit > 0;
-    final percent = hasLimit
-        ? ((usedTokens / normalizedLimit) * 100).round()
-        : 0;
-    final progress = percent.clamp(0, 100) / 100;
-
-    const _s = LocaleKeys
-        // ignore: lines_longer_than_80_chars - generated LocaleKeys name
-        .chats_screens_chat_conversation_context_usage_semantic_limit_unavailable;
-    final usageLabel = hasLimit
-        ? '${_formatCompactTokens(usedTokens)}/${_formatCompactTokens(normalizedLimit)}'
-        : '${_formatCompactTokens(usedTokens)}/--';
-
-    if (!hasLimit) {
-      return _ContextUsageViewModel(
-        usageLabel: usageLabel,
-        percentLabel: '--',
-        tooltip: LocaleKeys
-            .chats_screens_chat_conversation_context_usage_limit_unavailable
-            .tr(),
-        semanticValue: _s.tr(
-          namedArgs: {'usage': usageLabel},
-        ),
-        badgeVariant: AuraBadgeVariant.neutral,
-        icon: Icons.help_outline,
-        iconColor: AuraColorVariant.onSurfaceVariant,
-        level: _ContextUsageLevel.unknown,
-        progress: 0,
-      );
-    }
-
-    final level = _ContextUsageLevel.fromPercent(percent);
-    final overflowTokens = usedTokens - normalizedLimit;
-    final tooltip = switch (level) {
-      _ContextUsageLevel.normal =>
-        LocaleKeys.chats_screens_chat_conversation_context_usage_tooltip_normal
-            .tr(
-              namedArgs: _tooltipArgs(
-                usedTokens: usedTokens,
-                limitTokens: normalizedLimit,
-                percent: percent,
-              ),
-            ),
-      _ContextUsageLevel.elevated =>
-        LocaleKeys
-            .chats_screens_chat_conversation_context_usage_tooltip_elevated
-            .tr(
-              namedArgs: _tooltipArgs(
-                usedTokens: usedTokens,
-                limitTokens: normalizedLimit,
-                percent: percent,
-              ),
-            ),
-      _ContextUsageLevel.warning =>
-        LocaleKeys.chats_screens_chat_conversation_context_usage_tooltip_warning
-            .tr(
-              namedArgs: _tooltipArgs(
-                usedTokens: usedTokens,
-                limitTokens: normalizedLimit,
-                percent: percent,
-              ),
-            ),
-      _ContextUsageLevel.overflow =>
-        LocaleKeys
-            .chats_screens_chat_conversation_context_usage_tooltip_overflow
-            .tr(
-              namedArgs: {
-                ..._tooltipArgs(
-                  usedTokens: usedTokens,
-                  limitTokens: normalizedLimit,
-                  percent: percent,
-                ),
-                'overflow': '$overflowTokens',
-              },
-            ),
-      _ContextUsageLevel.unknown =>
-        LocaleKeys
-            .chats_screens_chat_conversation_context_usage_limit_unavailable
-            .tr(),
-    };
-
-    final semanticValue = switch (level) {
-      _ContextUsageLevel.normal =>
-        LocaleKeys.chats_screens_chat_conversation_context_usage_semantic_normal
-            .tr(
-              namedArgs: {
-                'usage': usageLabel,
-                'percent': '$percent',
-              },
-            ),
-      _ContextUsageLevel.elevated =>
-        LocaleKeys
-            .chats_screens_chat_conversation_context_usage_semantic_elevated
-            .tr(
-              namedArgs: {
-                'usage': usageLabel,
-                'percent': '$percent',
-              },
-            ),
-      _ContextUsageLevel.warning =>
-        LocaleKeys
-            .chats_screens_chat_conversation_context_usage_semantic_warning
-            .tr(
-              namedArgs: {
-                'usage': usageLabel,
-                'percent': '$percent',
-              },
-            ),
-      _ContextUsageLevel.overflow =>
-        LocaleKeys
-            .chats_screens_chat_conversation_context_usage_semantic_overflow
-            .tr(
-              namedArgs: {
-                'usage': usageLabel,
-                'percent': '$percent',
-                'overflow': '$overflowTokens',
-              },
-            ),
-      _ContextUsageLevel.unknown => _s.tr(
-        namedArgs: {'usage': usageLabel},
-      ),
-    };
-
-    return _ContextUsageViewModel(
-      usageLabel: usageLabel,
-      percentLabel: '$percent%',
-      tooltip: tooltip,
-      semanticValue: semanticValue,
-      badgeVariant: level.badgeVariant,
-      icon: level.icon,
-      iconColor: level.iconColor,
-      level: level,
-      progress: progress,
-    );
+String _tooltip(ContextUsageData data) {
+  if (!data.hasLimit) {
+    return LocaleKeys
+        .chats_screens_chat_conversation_context_usage_limit_unavailable
+        .tr();
   }
 
-  factory _ContextUsageViewModel.limitUnavailable(int usedTokens) {
-    final usageLabel = '${_formatCompactTokens(usedTokens)}/--';
-    const semanticLimitUnavailable = LocaleKeys
-        // ignore: lines_longer_than_80_chars - generated LocaleKeys name
-        .chats_screens_chat_conversation_context_usage_semantic_limit_unavailable;
-
-    return _ContextUsageViewModel(
-      usageLabel: usageLabel,
-      percentLabel: '--',
-      tooltip: LocaleKeys
-          .chats_screens_chat_conversation_context_usage_limit_unavailable
+  return switch (data.level) {
+    ContextUsageLevel.normal =>
+      LocaleKeys.chats_screens_chat_conversation_context_usage_tooltip_normal
+          .tr(namedArgs: data.tooltipArgs()),
+    ContextUsageLevel.elevated =>
+      LocaleKeys.chats_screens_chat_conversation_context_usage_tooltip_elevated
+          .tr(namedArgs: data.tooltipArgs()),
+    ContextUsageLevel.warning =>
+      LocaleKeys.chats_screens_chat_conversation_context_usage_tooltip_warning
+          .tr(namedArgs: data.tooltipArgs()),
+    ContextUsageLevel.overflow =>
+      LocaleKeys.chats_screens_chat_conversation_context_usage_tooltip_overflow
+          .tr(
+            namedArgs: {
+              ...data.tooltipArgs(),
+              'overflow': '${data.overflowTokens}',
+            },
+          ),
+    ContextUsageLevel.unknown =>
+      LocaleKeys.chats_screens_chat_conversation_context_usage_limit_unavailable
           .tr(),
-      semanticValue: semanticLimitUnavailable.tr(
-        namedArgs: {'usage': usageLabel},
-      ),
-      badgeVariant: AuraBadgeVariant.neutral,
-      icon: Icons.help_outline,
-      iconColor: AuraColorVariant.onSurfaceVariant,
-      level: _ContextUsageLevel.unknown,
-      progress: 0,
-    );
-  }
-
-  final String usageLabel;
-  final String percentLabel;
-  final String tooltip;
-  final String semanticValue;
-  final AuraBadgeVariant badgeVariant;
-  final IconData icon;
-  final AuraColorVariant iconColor;
-  final _ContextUsageLevel level;
-  final double progress;
-
-  Color progressColor(AuraColorScheme colors) {
-    return switch (level) {
-      _ContextUsageLevel.normal => colors.success,
-      _ContextUsageLevel.elevated => colors.info,
-      _ContextUsageLevel.warning => colors.warning,
-      _ContextUsageLevel.overflow => colors.error,
-      _ContextUsageLevel.unknown => colors.onSurfaceVariant,
-    };
-  }
-}
-
-Map<String, String> _tooltipArgs({
-  required int usedTokens,
-  required int limitTokens,
-  required int percent,
-}) {
-  return {
-    'used': '$usedTokens',
-    'limit': '$limitTokens',
-    'percent': '$percent',
   };
 }
 
-enum _ContextUsageLevel {
-  normal,
-  elevated,
-  warning,
-  overflow,
-  unknown
-  ;
+String _semanticValue(ContextUsageData data) {
+  const semanticLimitUnavailable = LocaleKeys
+      .chats_screens_chat_conversation_context_usage_semantic_limit_unavailable;
 
-  static _ContextUsageLevel fromPercent(int percent) {
-    if (percent > 100) return _ContextUsageLevel.overflow;
-    if (percent >= 85) return _ContextUsageLevel.warning;
-    if (percent >= 70) return _ContextUsageLevel.elevated;
-    return _ContextUsageLevel.normal;
+  if (!data.hasLimit) {
+    return semanticLimitUnavailable.tr(
+      namedArgs: {'usage': data.usageLabel},
+    );
   }
 
-  AuraBadgeVariant get badgeVariant {
-    return switch (this) {
-      _ContextUsageLevel.normal => AuraBadgeVariant.success,
-      _ContextUsageLevel.elevated => AuraBadgeVariant.info,
-      _ContextUsageLevel.warning => AuraBadgeVariant.warning,
-      _ContextUsageLevel.overflow => AuraBadgeVariant.error,
-      _ContextUsageLevel.unknown => AuraBadgeVariant.neutral,
-    };
-  }
-
-  IconData get icon {
-    return switch (this) {
-      _ContextUsageLevel.normal => Icons.check_circle_outline,
-      _ContextUsageLevel.elevated => Icons.info_outline,
-      _ContextUsageLevel.warning => Icons.warning_amber_outlined,
-      _ContextUsageLevel.overflow => Icons.priority_high,
-      _ContextUsageLevel.unknown => Icons.help_outline,
-    };
-  }
-
-  AuraColorVariant get iconColor {
-    return switch (this) {
-      _ContextUsageLevel.normal => AuraColorVariant.success,
-      _ContextUsageLevel.elevated => AuraColorVariant.info,
-      _ContextUsageLevel.warning => AuraColorVariant.warning,
-      _ContextUsageLevel.overflow => AuraColorVariant.error,
-      _ContextUsageLevel.unknown => AuraColorVariant.onSurfaceVariant,
-    };
-  }
-}
-
-String _formatCompactTokens(int value) {
-  if (value >= 1000000) {
-    final formatted = value % 1000000 == 0
-        ? (value / 1000000).toStringAsFixed(0)
-        : (value / 1000000).toStringAsFixed(1);
-    return '${formatted}m';
-  }
-
-  if (value >= 1000) {
-    final k = value / 1000;
-    final formatted = value % 1000 == 0
-        ? k.toStringAsFixed(0)
-        : k.toStringAsFixed(1);
-    final roundedK = double.tryParse(formatted);
-    if (roundedK != null && roundedK >= 1000) {
-      final m = roundedK / 1000;
-      final mFormatted = m.truncateToDouble() == m
-          ? m.toStringAsFixed(0)
-          : m.toStringAsFixed(1);
-      return '${mFormatted}m';
-    }
-    return '${formatted}k';
-  }
-
-  return '$value';
+  return switch (data.level) {
+    ContextUsageLevel.normal =>
+      LocaleKeys.chats_screens_chat_conversation_context_usage_semantic_normal
+          .tr(
+            namedArgs: {'usage': data.usageLabel, 'percent': '${data.percent}'},
+          ),
+    ContextUsageLevel.elevated =>
+      LocaleKeys.chats_screens_chat_conversation_context_usage_semantic_elevated
+          .tr(
+            namedArgs: {'usage': data.usageLabel, 'percent': '${data.percent}'},
+          ),
+    ContextUsageLevel.warning =>
+      LocaleKeys.chats_screens_chat_conversation_context_usage_semantic_warning
+          .tr(
+            namedArgs: {'usage': data.usageLabel, 'percent': '${data.percent}'},
+          ),
+    ContextUsageLevel.overflow =>
+      LocaleKeys.chats_screens_chat_conversation_context_usage_semantic_overflow
+          .tr(
+            namedArgs: {
+              'usage': data.usageLabel,
+              'percent': '${data.percent}',
+              'overflow': '${data.overflowTokens}',
+            },
+          ),
+    ContextUsageLevel.unknown => semanticLimitUnavailable.tr(
+      namedArgs: {'usage': data.usageLabel},
+    ),
+  };
 }

--- a/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
+++ b/apps/auravibes_app/lib/features/chats/widgets/conversation_context_usage_pill.dart
@@ -3,26 +3,23 @@ import 'package:auravibes_app/i18n/locale_keys.dart';
 import 'package:auravibes_ui/ui.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class ConversationContextUsagePill extends HookConsumerWidget {
+class ConversationContextUsagePill extends ConsumerWidget {
   const ConversationContextUsagePill({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final usedTokens = ref.watch(conversationUsedTokensProvider);
     final contextLimitAsync = ref.watch(conversationContextLimitProvider);
-    final viewModel = useMemoized(() {
-      return switch (contextLimitAsync) {
-        AsyncData(:final value) => _ContextUsageViewModel.fromUsage(
-          usedTokens: usedTokens,
-          limitTokens: value,
-        ),
-        AsyncLoading() ||
-        AsyncError() => _ContextUsageViewModel.limitUnavailable(usedTokens),
-      };
-    }, [usedTokens, contextLimitAsync]);
+    final viewModel = switch (contextLimitAsync) {
+      AsyncData(:final value) => _ContextUsageViewModel.fromUsage(
+        usedTokens: usedTokens,
+        limitTokens: value,
+      ),
+      AsyncLoading() ||
+      AsyncError() => _ContextUsageViewModel.limitUnavailable(usedTokens),
+    };
     final auraColors = context.auraColors;
 
     return Padding(

--- a/apps/auravibes_app/lib/features/models/providers/api_model_repository_providers.dart
+++ b/apps/auravibes_app/lib/features/models/providers/api_model_repository_providers.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:auravibes_app/data/repositories/api_model_repository_impl.dart';
+import 'package:auravibes_app/domain/entities/api_model.dart';
 import 'package:auravibes_app/domain/entities/api_model_provider.dart';
 import 'package:auravibes_app/domain/repositories/api_model_repository.dart';
 import 'package:auravibes_app/providers/app_providers.dart';
@@ -48,4 +49,28 @@ ModelSyncService modelSyncService(Ref ref) {
 @riverpod
 Future<List<ApiModelProviderEntity>> modelProvidersNotifier(Ref ref) {
   return ref.watch(apiModelRepositoryProvider).getAllProviders();
+}
+
+@Riverpod(keepAlive: true)
+Future<List<ApiModelEntity>> getAllModels(Ref ref) {
+  return ref.watch(apiModelRepositoryProvider).getAllModels();
+}
+
+@riverpod
+Future<ApiModelEntity?> getModelByProviderAndModelId(
+  Ref ref, {
+  required String providerId,
+  required String modelId,
+}) {
+  return ref
+      .watch(apiModelRepositoryProvider)
+      .getModelByProviderAndModelId(providerId, modelId);
+}
+
+@Riverpod(keepAlive: true)
+Future<List<ApiModelEntity>> getModelsByProvider(
+  Ref ref, {
+  required String providerId,
+}) {
+  return ref.watch(apiModelRepositoryProvider).getModelsByProvider(providerId);
 }

--- a/apps/auravibes_app/lib/features/models/providers/credentials_providers.dart
+++ b/apps/auravibes_app/lib/features/models/providers/credentials_providers.dart
@@ -1,0 +1,27 @@
+import 'package:auravibes_app/features/models/providers/api_model_repository_providers.dart';
+import 'package:auravibes_app/features/models/providers/model_providers_repository_providers.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'credentials_providers.g.dart';
+
+@Riverpod(
+  dependencies: [
+    credentialsModelsRepository,
+  ],
+)
+Future<int?> modelContextLimit(Ref ref, String credentialsModelId) async {
+  final selectedModel = await ref
+      .watch(credentialsModelsRepositoryProvider)
+      .getCredentialsModelById(credentialsModelId);
+  final modelId = selectedModel?.credentialsModel.modelId;
+  final providerId = selectedModel?.modelsProvider.id;
+  if (modelId == null || providerId == null) return null;
+
+  final value = await ref.watch(
+    getModelByProviderAndModelIdProvider(
+      providerId: providerId,
+      modelId: modelId,
+    ).future,
+  );
+  return value?.limitContext;
+}

--- a/apps/auravibes_app/lib/features/models/providers/credentials_providers.dart
+++ b/apps/auravibes_app/lib/features/models/providers/credentials_providers.dart
@@ -1,3 +1,4 @@
+import 'package:auravibes_app/domain/entities/credentials_models_entities.dart';
 import 'package:auravibes_app/features/models/providers/api_model_repository_providers.dart';
 import 'package:auravibes_app/features/models/providers/model_providers_repository_providers.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -5,14 +6,24 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'credentials_providers.g.dart';
 
 @Riverpod(
-  dependencies: [
-    credentialsModelsRepository,
-  ],
+  dependencies: [credentialsModelsRepository],
 )
-Future<int?> modelContextLimit(Ref ref, String credentialsModelId) async {
-  final selectedModel = await ref
+Future<CredentialsModelWithProviderEntity?> credentialsModelById(
+  Ref ref,
+  String credentialsModelId,
+) async {
+  return ref
       .watch(credentialsModelsRepositoryProvider)
       .getCredentialsModelById(credentialsModelId);
+}
+
+@Riverpod(
+  dependencies: [credentialsModelById, getModelByProviderAndModelId],
+)
+Future<int?> modelContextLimit(Ref ref, String credentialsModelId) async {
+  final selectedModel = await ref.watch(
+    credentialsModelByIdProvider(credentialsModelId).future,
+  );
   final modelId = selectedModel?.credentialsModel.modelId;
   final providerId = selectedModel?.modelsProvider.id;
   if (modelId == null || providerId == null) return null;

--- a/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
+++ b/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
@@ -1,11 +1,20 @@
 import 'dart:async';
 
+import 'package:auravibes_app/domain/entities/api_model.dart';
+import 'package:auravibes_app/domain/entities/api_model_provider.dart';
+import 'package:auravibes_app/domain/entities/credentials_entities.dart';
+import 'package:auravibes_app/domain/entities/credentials_models_entities.dart';
 import 'package:auravibes_app/domain/entities/messages.dart';
 import 'package:auravibes_app/domain/enums/message_types.dart';
+import 'package:auravibes_app/domain/repositories/api_model_repository.dart';
+import 'package:auravibes_app/domain/repositories/chat_models_repository.dart';
 import 'package:auravibes_app/domain/repositories/message_repository.dart';
 import 'package:auravibes_app/features/chats/notifiers/messages_streaming_notifier.dart';
 import 'package:auravibes_app/features/chats/providers/conversation_repository_provider.dart';
 import 'package:auravibes_app/features/chats/providers/messages_providers.dart';
+import 'package:auravibes_app/features/models/providers/api_model_repository_providers.dart';
+import 'package:auravibes_app/features/models/providers/credentials_providers.dart';
+import 'package:auravibes_app/features/models/providers/model_providers_repository_providers.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:langchain/langchain.dart';
 import 'package:riverpod/riverpod.dart';
@@ -36,7 +45,12 @@ void main() {
     });
 
     test('updates from repository stream without one-shot refetches', () async {
-      container.listen(chatMessagesProvider, (_, _) {}, fireImmediately: true);
+      final secondEmission = Completer<void>();
+      container.listen(chatMessagesProvider, (_, next) {
+        if (next.value?.length == 2 && !secondEmission.isCompleted) {
+          secondEmission.complete();
+        }
+      }, fireImmediately: true);
 
       repository.emit([
         _message(id: 'message-1', content: 'hello', isUser: true),
@@ -57,7 +71,7 @@ void main() {
         _message(id: 'message-1', content: 'hello', isUser: true),
         _message(id: 'message-2', content: 'hi there', isUser: false),
       ]);
-      await Future<void>.delayed(Duration.zero);
+      await secondEmission.future;
 
       expect(
         container.read(chatMessagesProvider).value,
@@ -159,47 +173,74 @@ void main() {
         expect(container.read(conversationUsedTokensProvider), 900);
       },
     );
+  });
 
-    test('computes token usage percentage, clamps progress at 100%', () async {
-      container.dispose();
-      container =
-          ProviderContainer(
-              overrides: [
-                conversationSelectedProvider.overrideWithValue(
-                  'conversation-1',
-                ),
-                messageRepositoryProvider.overrideWithValue(repository),
-                conversationContextLimitProvider.overrideWith(
-                  (ref) async => 1000,
-                ),
-              ],
-            )
-            ..listen(chatMessagesProvider, (_, _) {}, fireImmediately: true)
-            ..listen(
-              conversationTokenUsageSummaryProvider,
-              (_, _) {},
-              fireImmediately: true,
-            );
-
-      repository.emit([
-        _message(
-          id: 'message-1',
-          content: 'first',
-          isUser: false,
-          metadata: const MessageMetadataEntity(totalTokens: 1900),
+  group('modelContextLimitProvider', () {
+    test('prefers provider-specific model when IDs collide', () async {
+      final fakeCredentialsRepo = _FakeCredentialsModelsRepository(
+        selectedModel: _credentialsModelWithProvider(
+          credentialModelId: 'cm-1',
+          modelId: 'shared-model',
+          providerId: 'provider-b',
         ),
-      ]);
-      await Future<void>.delayed(Duration.zero);
-
-      final summaryAsync = container.read(
-        conversationTokenUsageSummaryProvider,
       );
-      final summary = summaryAsync.value;
+      final fakeApiRepo = _FakeApiModelRepository(
+        models: [
+          _apiModel(id: 'shared-model', providerId: 'provider-a', limit: 1000),
+          _apiModel(id: 'shared-model', providerId: 'provider-b', limit: 2500),
+        ],
+      );
 
-      expect(summary?.usedTokens, 1900);
-      expect(summary?.limitTokens, 1000);
-      expect(summary?.percent, 190);
-      expect(summary?.progress, 1);
+      final container = ProviderContainer(
+        overrides: [
+          credentialsModelsRepositoryProvider.overrideWithValue(
+            fakeCredentialsRepo,
+          ),
+          apiModelRepositoryProvider.overrideWithValue(fakeApiRepo),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final limit = await container.read(
+        modelContextLimitProvider('cm-1').future,
+      );
+
+      expect(limit, 2500);
+    });
+
+    test('does not normalize model IDs when resolving context limit', () async {
+      final fakeCredentialsRepo = _FakeCredentialsModelsRepository(
+        selectedModel: _credentialsModelWithProvider(
+          credentialModelId: 'cm-2',
+          modelId: 'openrouter/gpt-5.3-chat-latest',
+          providerId: 'openrouter',
+        ),
+      );
+      final fakeApiRepo = _FakeApiModelRepository(
+        models: [
+          _apiModel(
+            id: 'gpt-5.3-chat',
+            providerId: 'openrouter',
+            limit: 272000,
+          ),
+        ],
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          credentialsModelsRepositoryProvider.overrideWithValue(
+            fakeCredentialsRepo,
+          ),
+          apiModelRepositoryProvider.overrideWithValue(fakeApiRepo),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final limit = await container.read(
+        modelContextLimitProvider('cm-2').future,
+      );
+
+      expect(limit, isNull);
     });
   });
 }
@@ -222,6 +263,53 @@ MessageEntity _message({
     createdAt: now,
     updatedAt: now,
     metadata: metadata,
+  );
+}
+
+ApiModelEntity _apiModel({
+  required String id,
+  required String providerId,
+  required int limit,
+}) {
+  return ApiModelEntity(
+    id: id,
+    name: id,
+    modelProvider: providerId,
+    limitContext: limit,
+    limitOutput: 4096,
+    modalitiesInput: const ['text'],
+    modalitiesOuput: const ['text'],
+  );
+}
+
+CredentialsModelWithProviderEntity _credentialsModelWithProvider({
+  required String credentialModelId,
+  required String modelId,
+  required String providerId,
+}) {
+  final now = DateTime(2026);
+  return CredentialsModelWithProviderEntity(
+    credentialsModel: CredentialsModelEntity(
+      id: credentialModelId,
+      modelId: modelId,
+      credentialsId: 'cred-1',
+      createdAt: now,
+      updatedAt: now,
+    ),
+    credentials: CredentialsEntity(
+      id: 'cred-1',
+      name: 'Test Provider',
+      key: 'encrypted',
+      workspaceId: 'workspace-1',
+      modelId: providerId,
+      createdAt: now,
+      updatedAt: now,
+    ),
+    modelsProvider: ApiModelProviderEntity(
+      id: providerId,
+      name: providerId,
+      type: ModelProvidersType.openai,
+    ),
   );
 }
 
@@ -324,5 +412,88 @@ class _FakeMessageRepository implements MessageRepository {
   ) {
     watchedConversationIds.add(conversationId);
     return _controller.stream;
+  }
+}
+
+class _FakeCredentialsModelsRepository implements CredentialsModelsRepository {
+  _FakeCredentialsModelsRepository({this.selectedModel});
+
+  final CredentialsModelWithProviderEntity? selectedModel;
+
+  @override
+  Future<void> createCredentialsModels(
+    List<CredentialModelToCreate> credentialsModels,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<CredentialsModelWithProviderEntity?> getCredentialsModelById(
+    String id,
+  ) async {
+    return selectedModel;
+  }
+
+  @override
+  Future<List<CredentialsModelWithProviderEntity>> getCredentialsModels(
+    CredentialsModelsFilter filter,
+  ) {
+    throw UnimplementedError();
+  }
+}
+
+class _FakeApiModelRepository implements ApiModelRepository {
+  _FakeApiModelRepository({required this.models});
+
+  final List<ApiModelEntity> models;
+
+  @override
+  Future<List<ApiModelEntity>> getAllModels() async => models;
+
+  @override
+  Future<ApiModelEntity?> getModelByProviderAndModelId(
+    String providerId,
+    String modelId,
+  ) async {
+    return models
+        .where(
+          (model) => model.modelProvider == providerId && model.id == modelId,
+        )
+        .firstOrNull;
+  }
+
+  @override
+  Future<List<ApiModelEntity>> getModelsByProvider(String providerId) async {
+    return [
+      for (final model in models)
+        if (model.modelProvider == providerId) model,
+    ];
+  }
+
+  @override
+  Future<List<ApiModelProviderEntity>> getAllProviders() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<ApiModelProviderEntity>> getProvidersByType(String type) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<ApiModelProviderEntity>> batchUpsertProviders(
+    List<ApiModelProviderEntity> providers,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<ApiModelEntity>> batchUpsertModels(List<ApiModelEntity> models) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<int> deleteAllData() {
+    throw UnimplementedError();
   }
 }


### PR DESCRIPTION
## Summary
- remove the combined conversation token usage summary provider and compute pill state in the widget from independent used-token and context-limit providers
- add provider+model based API-model repository/provider APIs and a dedicated credentials context-limit provider to avoid model-id-only resolution
- update chat/provider tests for provider-specific context limit behavior and stabilize stream emission assertions

## Validation
- fvm dart analyze lib/features/models/providers/api_model_repository_providers.dart lib/features/models/providers/credentials_providers.dart lib/features/chats/providers/messages_providers.dart
- fvm flutter test test/features/chats/providers/chat_messages_provider_test.dart --no-pub