### PR TITLE
feat(chatbot): migrate from LangChain to dartantic_ai

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/004-migrate-langchain-dartantic"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,29 +1,37 @@
 # AuraVibes Flutter Monorepo - Agent Guidelines
 
 ## Project Overview
+
 Flutter monorepo for AuraVibes AI Assistant using Melos for package management.
+
 ### Apps:
+
 - AuraVibes: `apps/auravibes_app/`
 
 ### Packages:
+
 - `packages/*/`
 
 ## Packages
 
 ### auravibes_ui
+
 UI component library following const-first design.
 
 **Important:** Read `packages/auravibes_ui/STYLE_GUIDE.md` before modifying UI components.
+
 - Use `AuraColorVariant` enum instead of `Color?` for const compatibility
 - Only children/dropdown lists can be variable parameters
 - Maximize compile-time constants via enums
 
 ## Commands
+
 all dart related commands should prefix with `fvm ` to ensure correct SDK version is used.
 
 e.g. `fvm dart run melos bootstrap`
 
 ### Melos Commands
+
 ```bash
 melos bs                    # Install dependencies & link packages
 melos clean                 # Clean all packages
@@ -31,13 +39,14 @@ melos list                  # List all packages
 ```
 
 ### Dependency Management
+
 **IMPORTANT**: Always use these commands instead of manually editing pubspec.yaml files.
 
 ```bash
 # Add runtime dependencies
 fvm flutter pub add package_name
 
-# Add development dependencies  
+# Add development dependencies
 fvm flutter pub add dev:package_name
 
 # Add dependencies with version constraints
@@ -49,7 +58,9 @@ fvm flutter pub add dev:build_runner dev:json_serializable
 ```
 
 ### Quality & Testing
+
 valid on melos >7
+
 ```bash
 melos analyze            # Analyze code quality
 melos format             # Check code formatting
@@ -59,13 +70,17 @@ melos run validate           # Full CI validation
 ```
 
 ### Running Specific Tests
+
 in the package directory, use:
+
 ```bash
-flutter test test/test_file_one.dart test/test_file_two.dart --no-pub 
+flutter test test/test_file_one.dart test/test_file_two.dart --no-pub
 ```
 
 ### Code Generation
+
 Run code generation commands in the package directory:
+
 ```bash
 # General build runner command
 dart run build_runner build --delete-conflicting-outputs
@@ -77,11 +92,13 @@ dart run build_runner build --delete-conflicting-outputs --build-filter="lib/bri
 ## Version Conventions
 
 ### Badge Versions vs FVM Pinned Version
+
 - **Badge versions** in README.md reflect the **exact FVM pinned version** (e.g., `3.41.4+`)
 - This aligns with `.fvmrc` configuration for consistency
 - The `+` suffix indicates "this version or compatible updates"
 
 ### SDK Constraints in pubspec.yaml
+
 - Use caret syntax for minimum version: `sdk: ^3.11.0`
 - This allows any compatible version within the major version range
 
@@ -90,10 +107,12 @@ dart run build_runner build --delete-conflicting-outputs --build-filter="lib/bri
 ### When to Use `// ignore:` vs `// ignore_for_file:`
 
 **Prefer line-level ignores** (`// ignore: rule_name`) when:
+
 - Only specific lines trigger the warning
 - The warning is localized to a known pattern
 
 **Use file-level ignores** (`// ignore_for_file: rule_name`) only when:
+
 - Multiple lines throughout the file trigger the same warning
 - The ignore is justified by project architecture
 
@@ -112,31 +131,35 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 
 ### Common Ignore Scenarios
 
-| Rule | When Acceptable | Example |
-|------|-----------------|---------|
+| Rule                      | When Acceptable                              | Example           |
+| ------------------------- | -------------------------------------------- | ----------------- |
 | `experimental_member_use` | Using `@experimental` APIs from dependencies | Widgetbook addons |
-| `avoid_print` | CLI tools, debug utilities | Debug scripts |
-| `public_member_api_docs` | Internal packages | Private utilities |
+| `avoid_print`             | CLI tools, debug utilities                   | Debug scripts     |
+| `public_member_api_docs`  | Internal packages                            | Private utilities |
 
 ## AI Assistant Notes
 
 ### Understanding Project Context
+
 - This is a **Flutter monorepo** using Melos for workspace management
 - **Always use `fvm` prefix** for Dart/Flutter commands to ensure correct SDK version
 - The project uses `very_good_analysis` for linting with strict rules
 - Prefer Dart dot shorthand syntax when possible in Dart 3.11+ code if the context type is clear, especially for enums, constructors, and obvious static members
 
 ### Dart Style
+
 - Use Dart dot shorthand syntax from `https://dart.dev/language/dot-shorthands` when it improves readability and the context type is obvious
 - Prefer shorthand most strongly for enum values and typed constructor initialization such as `.new()`
 - Use the explicit type instead when shorthand would be ambiguous, surprising, or harder to scan
 
 ### When Reviewing Code
+
 - Check if ignore directives are documented and justified
 - Prefer scoped solutions over broad ignores
 - Verify version references are consistent across README, pubspec, and FVM config
 
 ## Active Technologies
+
 - Dart 3.x (FVM pinned to 3.41.4+) + Flutter, Riverpod (with code generation), Freezed, auravibes_ui (001-two-step-model-selector)
 - Drift database (existing, no schema changes needed) (001-two-step-model-selector)
 - Dart 3.11+ (Flutter 3.41.4+ via FVM) + Flutter SDK, flutter_portal, gpt_markdown, riverpod (existing) (001-ui-library-widgets)
@@ -144,10 +167,14 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 - Existing Drift `messages` table metadata JSON (no schema migration planned) (003-token-usage-context)
 
 ## Recent Changes
+
 - 001-two-step-model-selector: Added Dart 3.x (FVM pinned to 3.41.4+) + Flutter, Riverpod (with code generation), Freezed, auravibes_ui
 - 001-ui-library-widgets: Added Dart 3.11+ (Flutter 3.41.4+ via FVM) + Flutter SDK, flutter_portal, gpt_markdown, riverpod (existing)
 
 <!-- SPECKIT START -->
+
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
+at `specs/004-migrate-langchain-dartantic/plan.md`
+
 <!-- SPECKIT END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ e.g. `fvm dart run melos bootstrap`
 ### Melos Commands
 
 ```bash
-melos bs                    # Install dependencies & link packages
-melos clean                 # Clean all packages
-melos list                  # List all packages
+fvm dart run melos bs                    # Install dependencies & link packages
+fvm dart run melos clean                 # Clean all packages
+fvm dart run melos list                  # List all packages
 ```
 
 ### Dependency Management
@@ -62,11 +62,11 @@ fvm flutter pub add dev:build_runner dev:json_serializable
 valid on melos >7
 
 ```bash
-melos analyze            # Analyze code quality
-melos format             # Check code formatting
-melos run test               # Run all tests
-melos run validate:quick     # Quick development check
-melos run validate           # Full CI validation
+fvm dart run melos analyze            # Analyze code quality
+fvm dart run melos format             # Check code formatting
+fvm dart run melos run test               # Run all tests
+fvm dart run melos run validate:quick     # Quick development check
+fvm dart run melos run validate           # Full CI validation
 ```
 
 ### Running Specific Tests
@@ -74,7 +74,7 @@ melos run validate           # Full CI validation
 in the package directory, use:
 
 ```bash
-flutter test test/test_file_one.dart test/test_file_two.dart --no-pub
+fvm flutter test test/test_file_one.dart test/test_file_two.dart --no-pub
 ```
 
 ### Code Generation
@@ -83,10 +83,10 @@ Run code generation commands in the package directory:
 
 ```bash
 # General build runner command
-dart run build_runner build --delete-conflicting-outputs
+fvm dart run build_runner build --delete-conflicting-outputs
 
 # Single file generation example
-dart run build_runner build --delete-conflicting-outputs --build-filter="lib/brick/db_types.g.dart"
+fvm dart run build_runner build --delete-conflicting-outputs --build-filter="lib/brick/db_types.g.dart"
 ```
 
 ## Version Conventions
@@ -163,7 +163,7 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 - Dart 3.x (FVM pinned to 3.41.4+) + Flutter, Riverpod (with code generation), Freezed, auravibes_ui (001-two-step-model-selector)
 - Drift database (existing, no schema changes needed) (001-two-step-model-selector)
 - Dart 3.11+ (Flutter 3.41.4+ via FVM) + Flutter SDK, flutter_portal, gpt_markdown, riverpod (existing) (001-ui-library-widgets)
-- Dart 3.11+ with Flutter 3.41.4+ (FVM pinned) + Flutter, Riverpod, Drift, LangChain (`ChatResult` / `LanguageModelUsage`), auravibes_ui (003-token-usage-context)
+- Dart 3.11+ with Flutter 3.41.4+ (FVM pinned) + Flutter, Riverpod, Drift, dartantic_ai (`ChatResult<ChatMessage>` / `LanguageModelUsage`), auravibes_ui (003-token-usage-context)
 - Existing Drift `messages` table metadata JSON (no schema migration planned) (003-token-usage-context)
 
 ## Recent Changes

--- a/apps/auravibes_app/lib/domain/entities/tool_spec.dart
+++ b/apps/auravibes_app/lib/domain/entities/tool_spec.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+class ToolSpec extends Equatable {
+  const ToolSpec({
+    required this.name,
+    required this.description,
+    required this.inputJsonSchema,
+  });
+
+  final String name;
+  final String description;
+  final Map<String, dynamic> inputJsonSchema;
+
+  @override
+  List<Object?> get props => [name, description, inputJsonSchema];
+}

--- a/apps/auravibes_app/lib/domain/usecases/tools/mcp/build_combined_tool_specs_usecase.dart
+++ b/apps/auravibes_app/lib/domain/usecases/tools/mcp/build_combined_tool_specs_usecase.dart
@@ -1,9 +1,9 @@
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 import 'package:auravibes_app/domain/entities/tools_group.dart';
 import 'package:auravibes_app/domain/entities/workspace_tool.dart';
 import 'package:auravibes_app/domain/usecases/tools/conversation/generate_built_in_composite_id.dart';
 import 'package:auravibes_app/services/tools/native_tool_service.dart';
 import 'package:auravibes_app/services/tools/tool_service.dart';
-import 'package:langchain/langchain.dart';
 
 class BuildCombinedToolSpecsUseCase {
   const BuildCombinedToolSpecsUseCase({

--- a/apps/auravibes_app/lib/features/chats/notifiers/messages_streaming_notifier.dart
+++ b/apps/auravibes_app/lib/features/chats/notifiers/messages_streaming_notifier.dart
@@ -35,7 +35,7 @@ class MessagesStreamingNotifier extends _$MessagesStreamingNotifier {
     final currentState = state[messageId];
     if (currentState == null) {
       throw Exception(
-        'No subscription found for conversation id: $messageId',
+        'No subscription found for message id: $messageId',
       );
     }
     state = {

--- a/apps/auravibes_app/lib/features/chats/notifiers/messages_streaming_notifier.dart
+++ b/apps/auravibes_app/lib/features/chats/notifiers/messages_streaming_notifier.dart
@@ -1,5 +1,5 @@
+import 'package:dartantic_ai/dartantic_ai.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:langchain/langchain.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -10,7 +10,7 @@ part 'messages_streaming_notifier.g.dart';
 abstract class MessagesStreamingState with _$MessagesStreamingState {
   const factory MessagesStreamingState({
     required CompositeSubscription streamSubscription,
-    ChatResult? lastResult,
+    ChatResult<ChatMessage>? lastResult,
   }) = _MessagesStreamingState;
 }
 
@@ -31,7 +31,7 @@ class MessagesStreamingNotifier extends _$MessagesStreamingNotifier {
     };
   }
 
-  void updateResult(ChatResult result, String messageId) {
+  void updateResult(ChatResult<ChatMessage> result, String messageId) {
     final currentState = state[messageId];
     if (currentState == null) {
       throw Exception(

--- a/apps/auravibes_app/lib/features/chats/providers/messages_providers.dart
+++ b/apps/auravibes_app/lib/features/chats/providers/messages_providers.dart
@@ -97,7 +97,7 @@ MessageEntity? messageConversationById(
 
   if (streamingResult == null) return messageEntity;
 
-  return messageEntity.copyWith(content: streamingResult.outputAsString);
+  return messageEntity.copyWith(content: streamingResult.output.text);
 }
 
 @Riverpod(dependencies: [MessagesStreamingNotifier])

--- a/apps/auravibes_app/lib/features/chats/providers/streaming_runtime_provider.dart
+++ b/apps/auravibes_app/lib/features/chats/providers/streaming_runtime_provider.dart
@@ -1,19 +1,10 @@
 import 'package:auravibes_app/features/chats/notifiers/conversation_streaming_notifier.dart';
 import 'package:auravibes_app/features/chats/notifiers/messages_streaming_notifier.dart';
 import 'package:auravibes_app/features/chats/notifiers/titles_streams_notifier.dart';
-import 'package:langchain/langchain.dart';
+import 'package:dartantic_ai/dartantic_ai.dart' hide Provider;
 import 'package:riverpod/riverpod.dart';
 import 'package:rxdart/rxdart.dart';
 
-/// Runtime adapter that captures notifier method references behind plain
-/// callback interfaces, so use cases stay decoupled from Riverpod notifier
-/// classes.
-///
-/// Safety note: method references are captured once per provider rebuild.
-/// The adapter stays valid as long as the underlying notifier instance is not
-/// disposed and recreated between uses. For keepAlive notifiers this is
-/// guaranteed. For auto-dispose notifiers, the adapter's `ref.watch`
-/// subscription keeps the notifier alive while the adapter is watched.
 class ConversationStreamingRuntime {
   const ConversationStreamingRuntime({
     required this.start,
@@ -35,7 +26,8 @@ class MessagesStreamingRuntime {
 
   final void Function(CompositeSubscription subscription, String messageId)
   startSubscription;
-  final void Function(ChatResult result, String messageId) updateResult;
+  final void Function(ChatResult<ChatMessage> result, String messageId)
+  updateResult;
   final Future<void> Function(String messageId) remove;
 }
 

--- a/apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart
+++ b/apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart
@@ -11,11 +11,12 @@ import 'package:auravibes_app/features/chats/usecases/agent_iteration_context.da
 import 'package:auravibes_app/features/models/providers/model_connection_repositories_providers.dart';
 import 'package:auravibes_app/features/tools/usecases/load_conversation_tool_specs_usecase.dart';
 import 'package:auravibes_app/providers/chatbot_service_provider.dart';
+import 'package:auravibes_app/services/chatbot_service/build_prompt_chat_messages.dart';
 import 'package:auravibes_app/services/chatbot_service/chatbot_service.dart';
 import 'package:auravibes_app/services/monitoring_service.dart';
 import 'package:auravibes_app/utils/chat_result_extension.dart';
 import 'package:auravibes_app/utils/coalescing_save_extension.dart';
-import 'package:langchain/langchain.dart';
+import 'package:dartantic_ai/dartantic_ai.dart' hide Provider;
 import 'package:riverpod/riverpod.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -65,8 +66,6 @@ class ContinueAgentUsecase {
       conversationId,
     );
 
-    // TODO: check messages are good
-
     final modelId = conversation.modelId;
     if (modelId == null) {
       throw Exception('Conversation has no model id');
@@ -85,14 +84,17 @@ class ContinueAgentUsecase {
       workspaceId: conversation.workspaceId,
     );
 
+    final chatHistory = const BuildPromptChatMessages()(messages);
+
     final subs = CompositeSubscription();
     conversationStreamingRuntime.start(conversationId);
-    late ChatResult lastResult;
+    ChatResult<ChatMessage>? accumulatedResult;
     MessageEntity? firstMessage;
     final pendingUserMessageIds = context?.ackMessageIds ?? const <String>[];
     var hasAcknowledgedPendingUsers = false;
     try {
-      final streamingController = StreamController<ChatResult>.broadcast();
+      final streamingController =
+          StreamController<ChatResult<ChatMessage>>.broadcast();
 
       final persistenceFuture = streamingController.stream
           .coalescingSave(
@@ -100,7 +102,7 @@ class ContinueAgentUsecase {
               await messageRepository.patchMessage(
                 firstMessage!.id,
                 .new(
-                  content: state.outputAsString,
+                  content: state.entityText,
                   metadata: state.entityMetadata,
                   status: .unfinished,
                 ),
@@ -109,12 +111,10 @@ class ContinueAgentUsecase {
           )
           .drain<void>();
 
-      ChatResult? accumulatedResult;
-
       final responseStream = chatbotService
           .sendMessage(
             foundModel,
-            messages,
+            chatHistory,
             tools: tools,
           )
           .doOnError((error, stackTrace) {
@@ -125,10 +125,8 @@ class ContinueAgentUsecase {
             );
           });
 
-      await for (final ChatResult chunk in responseStream) {
-        accumulatedResult = accumulatedResult == null
-            ? chunk
-            : accumulatedResult.concat(chunk);
+      await for (final ChatResult<ChatMessage> chunk in responseStream) {
+        accumulatedResult = accumulatedResult?.concat(chunk) ?? chunk;
 
         if (!hasAcknowledgedPendingUsers && pendingUserMessageIds.isNotEmpty) {
           for (final pendingUserMessageId in pendingUserMessageIds) {
@@ -144,7 +142,7 @@ class ContinueAgentUsecase {
           firstMessage = await messageRepository.createMessage(
             .new(
               conversationId: conversationId,
-              content: accumulatedResult.outputAsString,
+              content: accumulatedResult.output.text,
               messageType: .text,
               isUser: false,
               status: .unfinished,
@@ -167,12 +165,10 @@ class ContinueAgentUsecase {
         throw StateError('Agent stream completed without any result');
       }
 
-      lastResult = accumulatedResult;
-
       await messageRepository.patchMessage(
         firstMessage.id,
         .new(
-          metadata: lastResult.entityMetadata,
+          metadata: accumulatedResult.entityMetadata,
           status: .sent,
         ),
       );
@@ -224,7 +220,7 @@ class ContinueAgentUsecase {
 
     return ContinueAgentResult(
       messageId: firstMessage.id,
-      hasToolCalls: lastResult.entityTools.isNotEmpty,
+      hasToolCalls: accumulatedResult.entityTools.isNotEmpty,
     );
   }
 }

--- a/apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart
+++ b/apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart
@@ -92,11 +92,13 @@ class ContinueAgentUsecase {
     MessageEntity? firstMessage;
     final pendingUserMessageIds = context?.ackMessageIds ?? const <String>[];
     var hasAcknowledgedPendingUsers = false;
+    StreamController<ChatResult<ChatMessage>>? streamingController;
+    Future<void>? persistenceFuture;
     try {
-      final streamingController =
+      streamingController =
           StreamController<ChatResult<ChatMessage>>.broadcast();
 
-      final persistenceFuture = streamingController.stream
+      persistenceFuture = streamingController.stream
           .coalescingSave(
             store: (state) async {
               await messageRepository.patchMessage(
@@ -158,9 +160,6 @@ class ContinueAgentUsecase {
         );
       }
 
-      await streamingController.close();
-      await persistenceFuture;
-
       if (accumulatedResult == null || firstMessage == null) {
         throw StateError('Agent stream completed without any result');
       }
@@ -211,6 +210,8 @@ class ContinueAgentUsecase {
 
       Error.throwWithStackTrace(error, stackTrace);
     } finally {
+      await streamingController?.close();
+      await persistenceFuture;
       conversationStreamingRuntime.remove(conversationId);
       if (firstMessage != null) {
         await messagesStreamingRuntime.remove(firstMessage.id);

--- a/apps/auravibes_app/lib/features/tools/providers/mcp_tool_spec_lookup_provider.dart
+++ b/apps/auravibes_app/lib/features/tools/providers/mcp_tool_spec_lookup_provider.dart
@@ -1,5 +1,5 @@
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 import 'package:auravibes_app/notifiers/mcp_connection_notifier.dart';
-import 'package:langchain/langchain.dart';
 import 'package:riverpod/riverpod.dart';
 
 /// Runtime adapter wrapping a notifier method behind a plain callback.

--- a/apps/auravibes_app/lib/features/tools/usecases/load_conversation_tool_specs_usecase.dart
+++ b/apps/auravibes_app/lib/features/tools/usecases/load_conversation_tool_specs_usecase.dart
@@ -1,9 +1,9 @@
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 import 'package:auravibes_app/domain/repositories/conversation_tools_repository.dart';
 import 'package:auravibes_app/domain/usecases/tools/mcp/build_combined_tool_specs_usecase.dart';
 import 'package:auravibes_app/features/tools/notifiers/conversation_tools_notifier.dart';
 import 'package:auravibes_app/features/tools/notifiers/grouped_tools_notifier.dart';
 import 'package:auravibes_app/features/tools/providers/mcp_tool_spec_lookup_provider.dart';
-import 'package:langchain/langchain.dart';
 import 'package:riverpod/riverpod.dart';
 
 class LoadConversationToolSpecsUsecase {

--- a/apps/auravibes_app/lib/notifiers/mcp_connection_notifier.dart
+++ b/apps/auravibes_app/lib/notifiers/mcp_connection_notifier.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:auravibes_app/domain/entities/mcp_server.dart';
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 import 'package:auravibes_app/domain/models/mcp_tool_info.dart';
 import 'package:auravibes_app/domain/usecases/tools/mcp/build_mcp_server_to_create_usecase.dart';
 import 'package:auravibes_app/features/tools/providers/mcp_repository_provider.dart';
@@ -11,7 +12,6 @@ import 'package:auravibes_app/services/mcp_service/mcp_service.dart';
 import 'package:auravibes_app/services/mcp_service/oauth_authenticate.dart';
 import 'package:collection/collection.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:langchain/langchain.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'mcp_connection_notifier.freezed.dart';

--- a/apps/auravibes_app/lib/services/chatbot_service/build_prompt_chat_messages.dart
+++ b/apps/auravibes_app/lib/services/chatbot_service/build_prompt_chat_messages.dart
@@ -1,5 +1,5 @@
 import 'package:auravibes_app/domain/entities/messages.dart';
-import 'package:langchain/langchain.dart';
+import 'package:dartantic_ai/dartantic_ai.dart';
 
 class BuildPromptChatMessages {
   const BuildPromptChatMessages();
@@ -12,31 +12,40 @@ class BuildPromptChatMessages {
 
   List<ChatMessage> _mapMessage(MessageEntity message) {
     if (message.isUser) {
-      return [ChatMessage.humanText(message.content)];
+      return [ChatMessage.user(message.content)];
     }
 
     final toolCalls =
         message.metadata?.toolCalls ?? const <MessageToolCallEntity>[];
 
-    return [
-      ChatMessage.ai(
-        message.content,
-        toolCalls: [
-          for (final toolCall in toolCalls)
-            AIChatMessageToolCall(
-              id: toolCall.id,
-              name: toolCall.name,
-              argumentsRaw: toolCall.argumentsRaw,
-              arguments: toolCall.arguments,
-            ),
-        ],
-      ),
+    final parts = <Part>[
+      TextPart(message.content),
       for (final toolCall in toolCalls)
-        if (toolCall.isResolved)
-          ChatMessage.tool(
-            toolCallId: toolCall.id,
-            content: toolCall.getResponseForAI(),
-          ),
+        ToolPart.call(
+          callId: toolCall.id,
+          toolName: toolCall.name,
+          arguments: toolCall.arguments,
+        ),
     ];
+
+    final results = <ChatMessage>[];
+    for (final toolCall in toolCalls) {
+      if (toolCall.isResolved) {
+        results.add(
+          ChatMessage.model(
+            '',
+            parts: [
+              ToolPart.result(
+                callId: toolCall.id,
+                toolName: toolCall.name,
+                result: toolCall.getResponseForAI(),
+              ),
+            ],
+          ),
+        );
+      }
+    }
+
+    return [ChatMessage.model('', parts: parts), ...results];
   }
 }

--- a/apps/auravibes_app/lib/services/chatbot_service/chatbot_service.dart
+++ b/apps/auravibes_app/lib/services/chatbot_service/chatbot_service.dart
@@ -1,42 +1,41 @@
-import 'package:auravibes_app/domain/entities/messages.dart';
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 import 'package:auravibes_app/domain/entities/workspace_model_selection_entities.dart';
 import 'package:auravibes_app/domain/repositories/model_connection_repository.dart';
-import 'package:auravibes_app/services/chatbot_service/build_prompt_chat_messages.dart';
+import 'package:auravibes_app/services/chatbot_service/provider_factory.dart';
+import 'package:auravibes_app/services/chatbot_service/tool_adapter.dart';
 import 'package:auravibes_app/services/encryption_service.dart';
-import 'package:langchain/langchain.dart';
-import 'package:langchain_anthropic/langchain_anthropic.dart';
-import 'package:langchain_openai/langchain_openai.dart';
+import 'package:dartantic_ai/dartantic_ai.dart';
 import 'package:rxdart/rxdart.dart';
 
 class ChatbotService {
   ChatbotService({
     required this.modelConnectionRepository,
     required this.encryptionService,
-    BuildPromptChatMessages? buildPromptChatMessages,
-  }) : _buildPromptChatMessages =
-           buildPromptChatMessages ?? const BuildPromptChatMessages();
+    ProviderFactory? providerFactory,
+    ToolAdapter? toolAdapter,
+  }) : _providerFactory = providerFactory ?? const ProviderFactory(),
+       _toolAdapter = toolAdapter ?? const ToolAdapter();
+
   ModelConnectionRepository modelConnectionRepository;
   EncryptionService encryptionService;
-  final BuildPromptChatMessages _buildPromptChatMessages;
+  final ProviderFactory _providerFactory;
+  final ToolAdapter _toolAdapter;
 
-  Stream<ChatResult> sendMessage(
+  Stream<ChatResult<ChatMessage>> sendMessage(
     WorkspaceModelSelectionWithConnectionEntity chatProvider,
-    List<MessageEntity> messages, {
+    List<ChatMessage> history, {
     List<ToolSpec>? tools,
   }) async* {
-    final chatMessages = _buildPromptChatMessages.call(messages);
+    final dartanticTools = tools != null
+        ? _toolAdapter(
+            tools,
+            onCall: (toolName, args) async => {},
+          )
+        : null;
 
-    final workspaceModelSelection = await _getWorkspaceModelSelection(
-      chatProvider,
-      tools: tools,
-    );
+    final chatModel = await _getChatModel(chatProvider, tools: dartanticTools);
 
-    yield* workspaceModelSelection
-        .stream(
-          PromptValue.chat(chatMessages),
-          options: _getModelOptions(chatProvider),
-        )
-        .distinct();
+    yield* chatModel.sendStream(history).distinct();
   }
 
   Future<String> generateTitle(
@@ -50,52 +49,53 @@ class ChatbotService {
     WorkspaceModelSelectionWithConnectionEntity chatProvider,
     String firstMessage,
   ) async* {
-    final workspaceModelSelection = await _getWorkspaceModelSelection(
-      chatProvider,
-    );
+    final agent = await _getAgent(chatProvider);
 
-    final prompt = PromptValue.chat([
-      ChatMessage.humanText(
-        '''
-Generate a short, concise title (max 5 words) for a conversation that starts with this message: "$firstMessage".
-The title should capture the main topic or theme. Respond with only the title, no quotes or extra text.
-''',
-      ),
-    ]);
+    final prompt =
+        'Generate a short, concise title (max 5 words) for a conversation '
+        'that starts with this message: "$firstMessage". '
+        'The title should capture the main topic or theme. '
+        'Respond with only the title, no quotes or extra text.';
 
     try {
-      final result = workspaceModelSelection.stream(
+      final result = agent.sendStream(
         prompt,
-        options: _getModelOptions(chatProvider),
+        history: [ChatMessage.system('You generate conversation titles.')],
       );
 
       yield* result
-          .map((event) => event.outputAsString.trim())
+          .map((event) => event.output.trim())
           .scan((accumulated, value, index) => accumulated + value, '')
           .map((title) {
-            // Clean up the title
-            var _title = title.trim();
-            if (_title.startsWith('"') && _title.endsWith('"')) {
-              _title = _title.substring(1, _title.length - 1);
+            var processedTitle = title.trim();
+            if (processedTitle.startsWith('"') &&
+                processedTitle.endsWith('"')) {
+              processedTitle = processedTitle.substring(
+                1,
+                processedTitle.length - 1,
+              );
             }
-            if (_title.startsWith("'") && _title.endsWith("'")) {
-              _title = _title.substring(1, _title.length - 1);
+            if (processedTitle.startsWith("'") &&
+                processedTitle.endsWith("'")) {
+              processedTitle = processedTitle.substring(
+                1,
+                processedTitle.length - 1,
+              );
             }
-            if (_title.startsWith('Title:')) {
-              _title = _title.substring(6).trim();
+            if (processedTitle.startsWith('Title:')) {
+              processedTitle = processedTitle.substring(6).trim();
             }
-            if (_title.startsWith('Conversation:')) {
-              _title = _title.substring(13).trim();
+            if (processedTitle.startsWith('Conversation:')) {
+              processedTitle = processedTitle.substring(13).trim();
             }
 
-            // Ensure title is not empty and not too long
-            if (_title.isEmpty) {
+            if (processedTitle.isEmpty) {
               return _generateFallbackTitle(firstMessage);
-            } else if (_title.length > 50) {
-              return '${_title.substring(0, 47)}...';
+            } else if (processedTitle.length > 50) {
+              return '${processedTitle.substring(0, 47)}...';
             }
 
-            return _title;
+            return processedTitle;
           });
     } on Exception catch (_) {
       yield _generateFallbackTitle(firstMessage);
@@ -111,51 +111,26 @@ The title should capture the main topic or theme. Respond with only the title, n
     return words.length > 30 ? '${words.substring(0, 27)}...' : words;
   }
 
-  ChatModelOptions _getModelOptions(
-    WorkspaceModelSelectionWithConnectionEntity chatProvider,
-  ) {
-    final type = chatProvider.modelsProvider.type;
-    if (type == null) throw UnimplementedError();
-    return switch (type) {
-      .openai => ChatOpenAIOptions(
-        model: chatProvider.workspaceModelSelection.modelId,
-      ),
-      .anthropic => ChatAnthropicOptions(
-        model: chatProvider.workspaceModelSelection.modelId,
-      ),
-    };
-  }
-
-  Future<BaseChatModel> _getWorkspaceModelSelection(
+  Future<ChatModel> _getChatModel(
     WorkspaceModelSelectionWithConnectionEntity chatProvider, {
-    List<ToolSpec>? tools,
+    List<Tool>? tools,
   }) async {
-    final type = chatProvider.modelsProvider.type;
-    if (type == null) throw UnimplementedError();
-    final url =
-        chatProvider.modelConnection.url ?? chatProvider.modelsProvider.url;
-
-    // Decrypt the API key
     final encrypted = chatProvider.modelConnection.key;
     final apiKey = await encryptionService.decrypt(encrypted);
 
-    return switch (type) {
-      .openai => ChatOpenAI(
-        apiKey: apiKey,
-        baseUrl: url ?? 'https://api.openai.com/v1',
-        defaultOptions: ChatOpenAIOptions(
-          model: chatProvider.workspaceModelSelection.modelId,
-          tools: tools,
-        ),
-      ),
-      .anthropic => ChatAnthropic(
-        apiKey: apiKey,
-        baseUrl: url ?? 'https://api.anthropic.com/v1',
-        defaultOptions: ChatAnthropicOptions(
-          model: chatProvider.workspaceModelSelection.modelId,
-          tools: tools,
-        ),
-      ),
-    };
+    return _providerFactory(
+      chatProvider,
+      apiKey: apiKey,
+      tools: tools,
+    );
+  }
+
+  Future<Agent> _getAgent(
+    WorkspaceModelSelectionWithConnectionEntity chatProvider,
+  ) async {
+    final encrypted = chatProvider.modelConnection.key;
+    final apiKey = await encryptionService.decrypt(encrypted);
+
+    return _providerFactory.createAgent(chatProvider, apiKey: apiKey);
   }
 }

--- a/apps/auravibes_app/lib/services/chatbot_service/chatbot_service.dart
+++ b/apps/auravibes_app/lib/services/chatbot_service/chatbot_service.dart
@@ -26,16 +26,25 @@ class ChatbotService {
     List<ChatMessage> history, {
     List<ToolSpec>? tools,
   }) async* {
+    // Tools are passed to ChatModel for definition-only purposes.
+    // ChatModel.sendStream() never auto-executes tools; the app's
+    // RunAgentIterationUsecase manages execution via the approval pipeline.
+    // If onCall is ever invoked (e.g. future API change), fail loudly.
     final dartanticTools = tools != null
         ? _toolAdapter(
             tools,
-            onCall: (toolName, args) async => {},
+            onCall: (toolName, args) async {
+              throw StateError(
+                'Tool "$toolName" execution should go through the approval '
+                'pipeline, not through dartantic onCall',
+              );
+            },
           )
         : null;
 
     final chatModel = await _getChatModel(chatProvider, tools: dartanticTools);
 
-    yield* chatModel.sendStream(history).distinct();
+    yield* chatModel.sendStream(history);
   }
 
   Future<String> generateTitle(

--- a/apps/auravibes_app/lib/services/chatbot_service/models/chat_message_models.dart
+++ b/apps/auravibes_app/lib/services/chatbot_service/models/chat_message_models.dart
@@ -1,5 +1,4 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:langchain/langchain.dart';
 
 part 'chat_message_models.freezed.dart';
 
@@ -12,14 +11,4 @@ abstract class ChatbotToolCall with _$ChatbotToolCall {
     required String argumentsRaw,
     String? responseRaw,
   }) = _ChatbotToolCall;
-  const ChatbotToolCall._();
-
-  AIChatMessageToolCall toAIChat() {
-    return AIChatMessageToolCall(
-      arguments: arguments,
-      argumentsRaw: argumentsRaw,
-      id: id,
-      name: name,
-    );
-  }
 }

--- a/apps/auravibes_app/lib/services/chatbot_service/provider_factory.dart
+++ b/apps/auravibes_app/lib/services/chatbot_service/provider_factory.dart
@@ -102,6 +102,9 @@ class ProviderFactory {
     ModelProvidersType? providerType,
     String? baseUrl,
   }) {
+    // AnthropicProvider doesn't accept baseUrl in its constructor.
+    // When a custom URL is set, fall through to OpenAIProvider which
+    // supports custom endpoints (most Anthropic proxies are OpenAI-compatible).
     if (providerType == ModelProvidersType.anthropic && baseUrl == null) {
       return AnthropicProvider(apiKey: apiKey);
     }

--- a/apps/auravibes_app/lib/services/chatbot_service/provider_factory.dart
+++ b/apps/auravibes_app/lib/services/chatbot_service/provider_factory.dart
@@ -1,0 +1,122 @@
+import 'package:auravibes_app/domain/entities/api_model_provider.dart';
+import 'package:auravibes_app/domain/entities/workspace_model_selection_entities.dart';
+import 'package:dartantic_ai/dartantic_ai.dart';
+
+class ProviderFactory {
+  const ProviderFactory();
+
+  ChatModel call(
+    WorkspaceModelSelectionWithConnectionEntity config, {
+    required String apiKey,
+    List<Tool>? tools,
+  }) {
+    final type = config.modelsProvider.type;
+    final modelId = config.workspaceModelSelection.modelId;
+    final baseUrl = config.modelConnection.url ?? config.modelsProvider.url;
+
+    if (type == null) {
+      if (baseUrl != null) {
+        return _createChatModel(
+          apiKey: apiKey,
+          baseUrl: baseUrl,
+          modelId: modelId,
+          tools: tools,
+        );
+      }
+      throw ArgumentError('Provider type is null and no baseUrl provided');
+    }
+
+    final resolvedBaseUrl =
+        (_hasCustomUrl(config) ? baseUrl : null) ?? config.modelsProvider.url;
+
+    return _createChatModel(
+      apiKey: apiKey,
+      modelId: modelId,
+      providerType: type,
+      baseUrl: resolvedBaseUrl,
+      tools: tools,
+    );
+  }
+
+  Agent createAgent(
+    WorkspaceModelSelectionWithConnectionEntity config, {
+    required String apiKey,
+  }) {
+    final type = config.modelsProvider.type;
+    final modelId = config.workspaceModelSelection.modelId;
+    final baseUrl = config.modelConnection.url ?? config.modelsProvider.url;
+
+    if (type == null) {
+      if (baseUrl == null) {
+        throw ArgumentError('Provider type is null and no baseUrl provided');
+      }
+      return _createAgentOnly(
+        apiKey: apiKey,
+        baseUrl: baseUrl,
+        modelId: modelId,
+      );
+    }
+
+    final resolvedBaseUrl =
+        (_hasCustomUrl(config) ? baseUrl : null) ?? config.modelsProvider.url;
+
+    return _createAgentOnly(
+      apiKey: apiKey,
+      modelId: modelId,
+      providerType: type,
+      baseUrl: resolvedBaseUrl,
+    );
+  }
+
+  ChatModel _createChatModel({
+    required String apiKey,
+    required String modelId,
+    ModelProvidersType? providerType,
+    String? baseUrl,
+    List<Tool>? tools,
+  }) {
+    final provider = _createProvider(
+      providerType: providerType,
+      apiKey: apiKey,
+      baseUrl: baseUrl,
+    );
+    return provider.createChatModel(name: modelId, tools: tools);
+  }
+
+  Agent _createAgentOnly({
+    required String apiKey,
+    required String modelId,
+    ModelProvidersType? providerType,
+    String? baseUrl,
+  }) {
+    final provider = _createProvider(
+      providerType: providerType,
+      apiKey: apiKey,
+      baseUrl: baseUrl,
+    );
+    return Agent.forProvider(provider, chatModelName: modelId);
+  }
+
+  Provider _createProvider({
+    required String apiKey,
+    ModelProvidersType? providerType,
+    String? baseUrl,
+  }) {
+    if (providerType == ModelProvidersType.anthropic && baseUrl == null) {
+      return AnthropicProvider(apiKey: apiKey);
+    }
+
+    return OpenAIProvider(
+      apiKey: apiKey,
+      baseUrl: baseUrl != null ? Uri.parse(baseUrl) : null,
+    );
+  }
+
+  bool _hasCustomUrl(
+    WorkspaceModelSelectionWithConnectionEntity config,
+  ) {
+    final connectionUrl = config.modelConnection.url;
+    final providerUrl = config.modelsProvider.url;
+    return connectionUrl != null && connectionUrl != providerUrl;
+  }
+}

--- a/apps/auravibes_app/lib/services/chatbot_service/tool_adapter.dart
+++ b/apps/auravibes_app/lib/services/chatbot_service/tool_adapter.dart
@@ -1,0 +1,40 @@
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
+import 'package:dartantic_ai/dartantic_ai.dart';
+
+typedef ToolCallHandler =
+    Future<Map<String, dynamic>> Function(
+      String toolName,
+      Map<String, dynamic> args,
+    );
+
+class ToolAdapter {
+  const ToolAdapter();
+
+  List<Tool> call(
+    List<ToolSpec> specs, {
+    required ToolCallHandler onCall,
+  }) {
+    return specs
+        .map(
+          (spec) => _convertTool(spec, onCall: onCall),
+        )
+        .toList();
+  }
+
+  Tool _convertTool(
+    ToolSpec spec, {
+    required ToolCallHandler onCall,
+  }) {
+    return Tool(
+      name: spec.name,
+      description: spec.description,
+      inputSchema: Schema.fromMap(
+        spec.inputJsonSchema.cast<String, Object?>(),
+      ),
+      onCall: (args) => onCall(
+        spec.name,
+        args is Map<String, dynamic> ? args : <String, dynamic>{},
+      ),
+    );
+  }
+}

--- a/apps/auravibes_app/lib/services/chatbot_service/tool_adapter.dart
+++ b/apps/auravibes_app/lib/services/chatbot_service/tool_adapter.dart
@@ -31,10 +31,14 @@ class ToolAdapter {
       inputSchema: Schema.fromMap(
         spec.inputJsonSchema.cast<String, Object?>(),
       ),
-      onCall: (args) => onCall(
-        spec.name,
-        args is Map<String, dynamic> ? args : <String, dynamic>{},
-      ),
+      onCall: (args) {
+        if (args is! Map<String, dynamic>) {
+          throw ArgumentError(
+            'Tool "${spec.name}" received non-map args: ${args.runtimeType}',
+          );
+        }
+        return onCall(spec.name, Map<String, dynamic>.from(args));
+      },
     );
   }
 }

--- a/apps/auravibes_app/lib/services/model_provider_services/model_provider_services.dart
+++ b/apps/auravibes_app/lib/services/model_provider_services/model_provider_services.dart
@@ -18,10 +18,13 @@ class ModelProviderServices {
     ModelProvider provider,
   ) async {
     if (provider.type == CredentialsModelType.openai) {
-      final client = OpenAIClient(apiKey: provider.key, baseUrl: provider.url);
+      final client = OpenAIClient.withApiKey(
+        provider.key,
+        baseUrl: provider.url ?? 'https://api.openai.com/v1',
+      );
 
-      final models = await client.listModels();
-      return models.data
+      final modelsResponse = await client.models.list();
+      return modelsResponse.data
           .map(
             (model) => WorkspaceModelSelectionToCreate(
               modelId: model.id,

--- a/apps/auravibes_app/lib/services/tools/native_tool_entity.dart
+++ b/apps/auravibes_app/lib/services/tools/native_tool_entity.dart
@@ -1,5 +1,5 @@
 import 'package:async/async.dart';
-import 'package:langchain/langchain.dart';
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 
 enum NativeToolType {
   url('url')

--- a/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
+++ b/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
@@ -2,11 +2,11 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:async/async.dart';
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 import 'package:auravibes_app/services/tools/native_tool_entity.dart';
 import 'package:auravibes_app/services/url/models/url_request.dart';
 import 'package:auravibes_app/services/url/models/url_response.dart';
 import 'package:auravibes_app/services/url/url_service.dart';
-import 'package:langchain/langchain.dart';
 
 final class UrlTool extends NativeToolEntity<String, String> {
   UrlTool({UrlService? urlService}) : _urlService = urlService;
@@ -14,8 +14,8 @@ final class UrlTool extends NativeToolEntity<String, String> {
   final UrlService? _urlService;
 
   @override
-  Tool<Object, ToolOptions, Object> getTool() {
-    return Tool.fromFunction<String, String>(
+  ToolSpec getTool() {
+    return const ToolSpec(
       name: 'url',
       description:
           'Fetches content from a URL. '
@@ -38,7 +38,6 @@ final class UrlTool extends NativeToolEntity<String, String> {
         },
         'required': ['input'],
       },
-      func: _execute,
     );
   }
 
@@ -73,14 +72,6 @@ final class UrlTool extends NativeToolEntity<String, String> {
     });
 
     return completer.operation;
-  }
-
-  Future<String> _execute(String toolInput) async {
-    final service = _urlService ?? UrlService();
-    final request = await _buildRequest(toolInput);
-    final response = await service.execute(request).value;
-
-    return _formatResponse(response);
   }
 
   String _formatResponse(UrlResponse response) {

--- a/apps/auravibes_app/lib/services/tools/user_tools/calculator_tool.dart
+++ b/apps/auravibes_app/lib/services/tools/user_tools/calculator_tool.dart
@@ -1,6 +1,6 @@
 import 'package:async/async.dart';
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 import 'package:auravibes_app/services/tools/user_tools_entity.dart';
-import 'package:langchain/langchain.dart';
 import 'package:math_expressions/math_expressions.dart';
 
 /// Represents an available tool in the app
@@ -8,10 +8,8 @@ final class CalculatorTool extends UserToolEntity<String, Object, String> {
   const CalculatorTool();
 
   @override
-  Tool<Object, ToolOptions, Object> getTool() {
-    final parser = GrammarParser();
-    final evaluator = RealEvaluator();
-    return Tool.fromFunction<String, String>(
+  ToolSpec getTool() {
+    return const ToolSpec(
       name: 'calculator',
       description:
           'Useful for getting the result of a math expression '
@@ -27,14 +25,6 @@ final class CalculatorTool extends UserToolEntity<String, Object, String> {
           },
         },
         'required': ['input'],
-      },
-      func: (toolInput) async {
-        try {
-          final exp = parser.parse(toolInput);
-          return evaluator.evaluate(exp).toString();
-        } on Exception catch (_) {
-          return "I don't know how to do that.";
-        }
       },
     );
   }

--- a/apps/auravibes_app/lib/services/tools/user_tools_entity.dart
+++ b/apps/auravibes_app/lib/services/tools/user_tools_entity.dart
@@ -1,5 +1,5 @@
 import 'package:async/async.dart';
-import 'package:langchain/langchain.dart';
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 
 enum UserToolType {
   calculator('calculator')

--- a/apps/auravibes_app/lib/utils/chat_result_extension.dart
+++ b/apps/auravibes_app/lib/utils/chat_result_extension.dart
@@ -1,44 +1,63 @@
 import 'package:auravibes_app/domain/entities/messages.dart';
-import 'package:langchain/langchain.dart';
+import 'package:dartantic_ai/dartantic_ai.dart';
 
-extension ChatResultEntities on ChatResult {
+extension ChatResultConcat on ChatResult<ChatMessage> {
+  ChatResult<ChatMessage> concat(ChatResult<ChatMessage> delta) {
+    return ChatResult<ChatMessage>(
+      output: output.concatenate(delta.output),
+      finishReason: delta.finishReason != FinishReason.unspecified
+          ? delta.finishReason
+          : finishReason,
+      usage: usage != null && delta.usage != null
+          ? usage!.concat(delta.usage!)
+          : delta.usage ?? usage,
+      messages: [...messages, ...delta.messages],
+      metadata: {...metadata, ...delta.metadata},
+    );
+  }
+}
+
+extension ChatResultEntities on ChatResult<ChatMessage> {
   List<MessageToolCallEntity> get entityTools {
-    if (output.toolCalls.isEmpty) {
-      return [];
-    }
+    final allToolCalls = output.toolCalls;
+    if (allToolCalls.isEmpty) return [];
 
-    return output.toolCalls.map((e) {
-      return MessageToolCallEntity(
-        argumentsRaw: e.argumentsRaw,
-        id: e.id,
-        name: e.name,
-      );
-    }).toList();
+    return allToolCalls
+        .map(
+          (tc) => MessageToolCallEntity(
+            argumentsRaw: tc.argumentsRaw,
+            id: tc.callId,
+            name: tc.toolName,
+          ),
+        )
+        .toList();
   }
 
-  int get entityPromptTokens => usage.promptTokens ?? 0;
+  int get entityPromptTokens => usage?.promptTokens ?? 0;
 
-  int get entityCompletionTokens => usage.responseTokens ?? 0;
+  int get entityCompletionTokens => usage?.responseTokens ?? 0;
 
   int get entityTotalTokens {
-    return usage.totalTokens ?? (entityPromptTokens + entityCompletionTokens);
+    return usage?.totalTokens ?? (entityPromptTokens + entityCompletionTokens);
   }
+
+  String get entityText => output.text;
 
   MessageMetadataEntity? get entityMetadata {
     final hasUsage =
-        usage.promptTokens != null ||
-        usage.responseTokens != null ||
-        usage.totalTokens != null;
+        usage?.promptTokens != null ||
+        usage?.responseTokens != null ||
+        usage?.totalTokens != null;
 
-    if (output.toolCalls.isEmpty && !hasUsage) {
+    if (entityTools.isEmpty && !hasUsage) {
       return null;
     }
 
     return MessageMetadataEntity(
       toolCalls: entityTools,
-      promptTokens: usage.promptTokens,
-      completionTokens: usage.responseTokens,
-      totalTokens: usage.totalTokens,
+      promptTokens: usage?.promptTokens,
+      completionTokens: usage?.responseTokens,
+      totalTokens: usage?.totalTokens,
     );
   }
 }

--- a/apps/auravibes_app/pubspec.yaml
+++ b/apps/auravibes_app/pubspec.yaml
@@ -3,7 +3,7 @@ resolution: workspace
 description: "A new Flutter project."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 version: 0.0.2
 
@@ -35,16 +35,16 @@ dependencies:
   go_router: ^17.1.0
   hooks_riverpod: ^3.0.3
 
+  # AI Orchestration
+  dartantic_ai: ^3.4.0
+
   # Networking
   http: ^1.6.0
   json_annotation: ^4.9.0
-  langchain: ^0.8.1
-  langchain_anthropic: ^0.3.0+1
-  langchain_openai: ^0.8.1
   logging: ^1.3.0
   math_expressions: ^3.1.0
   mcp_client: ^1.1.0
-  openai_dart: ^0.6.2
+  openai_dart: ^1.1.0
 
   # Other dependencies
   riverpod: ^3.0.3
@@ -71,7 +71,7 @@ dev_dependencies:
 
 dependency_validator:
   exclude:
-    - 'test/**/*.mocks.dart'
+    - "test/**/*.mocks.dart"
 
 flutter:
   assets:

--- a/apps/auravibes_app/test/domain/usecases/tools/mcp/build_combined_tool_specs_usecase_test.dart
+++ b/apps/auravibes_app/test/domain/usecases/tools/mcp/build_combined_tool_specs_usecase_test.dart
@@ -1,9 +1,9 @@
 import 'package:auravibes_app/data/database/drift/enums/permission_access.dart';
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 import 'package:auravibes_app/domain/entities/tools_group.dart';
 import 'package:auravibes_app/domain/entities/workspace_tool.dart';
 import 'package:auravibes_app/domain/usecases/tools/mcp/build_combined_tool_specs_usecase.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:langchain/langchain.dart';
 
 WorkspaceToolEntity _tool({
   required String id,

--- a/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
+++ b/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
@@ -15,8 +15,8 @@ import 'package:auravibes_app/features/chats/providers/messages_providers.dart';
 import 'package:auravibes_app/features/models/providers/api_model_repository_providers.dart';
 import 'package:auravibes_app/features/models/providers/model_connection_repositories_providers.dart';
 import 'package:auravibes_app/features/models/providers/workspace_model_selection_providers.dart';
+import 'package:dartantic_ai/dartantic_ai.dart' hide Provider;
 import 'package:flutter_test/flutter_test.dart';
-import 'package:langchain/langchain.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -100,13 +100,9 @@ void main() {
       container.read(messagesStreamingProvider.notifier)
         ..startSubscription(CompositeSubscription(), 'message-1')
         ..updateResult(
-          const ChatResult(
-            id: 'chunk-1',
-            output: AIChatMessage(content: 'streaming'),
-            finishReason: FinishReason.unspecified,
-            metadata: {},
-            usage: LanguageModelUsage(),
-            streaming: true,
+          ChatResult<ChatMessage>(
+            output: ChatMessage.model('streaming'),
+            usage: const LanguageModelUsage(),
           ),
           'message-1',
         );
@@ -158,13 +154,9 @@ void main() {
         container.read(messagesStreamingProvider.notifier)
           ..startSubscription(CompositeSubscription(), 'message-2')
           ..updateResult(
-            const ChatResult(
-              id: 'chunk-2',
-              output: AIChatMessage(content: 'streaming'),
-              finishReason: FinishReason.unspecified,
-              metadata: {},
-              usage: LanguageModelUsage(totalTokens: 900),
-              streaming: true,
+            ChatResult<ChatMessage>(
+              output: ChatMessage.model('streaming'),
+              usage: const LanguageModelUsage(totalTokens: 900),
             ),
             'message-2',
           );

--- a/apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.dart
@@ -13,8 +13,8 @@ import 'package:auravibes_app/features/chats/usecases/continue_agent_usecase.dar
 import 'package:auravibes_app/features/tools/usecases/load_conversation_tool_specs_usecase.dart';
 import 'package:auravibes_app/services/chatbot_service/chatbot_service.dart';
 import 'package:auravibes_app/services/monitoring_service.dart';
+import 'package:dartantic_ai/dartantic_ai.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:langchain/langchain.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
@@ -42,7 +42,7 @@ void main() {
     late List<String> startedConversationIds;
     late List<String> removedConversationIds;
     late List<String> updatedMessageIds;
-    late List<ChatResult> updatedResults;
+    late List<ChatResult<ChatMessage>> updatedResults;
     late List<String> startedSubscriptionMessageIds;
 
     setUp(() {
@@ -118,41 +118,33 @@ void main() {
         when(
           chatbotService.sendMessage(
             _model,
-            [_userMessage],
+            any,
             tools: const [],
           ),
         ).thenAnswer(
           (_) => Stream.fromIterable([
-            const ChatResult(
-              id: 'chunk-1',
-              output: AIChatMessage(content: 'Working'),
-              finishReason: FinishReason.unspecified,
-              metadata: {},
-              usage: LanguageModelUsage(
+            ChatResult<ChatMessage>(
+              output: ChatMessage.model('Working'),
+              usage: const LanguageModelUsage(
                 promptTokens: 10,
                 responseTokens: 5,
               ),
-              streaming: true,
             ),
-            const ChatResult(
-              id: 'chunk-2',
-              output: AIChatMessage(
-                content: '',
-                toolCalls: [
-                  AIChatMessageToolCall(
-                    id: 'tool-1',
-                    name: 'calculator',
-                    argumentsRaw: '{"input":"2+2"}',
+            ChatResult<ChatMessage>(
+              output: ChatMessage.model(
+                '',
+                parts: const [
+                  ToolPart.call(
+                    callId: 'tool-1',
+                    toolName: 'calculator',
                     arguments: {'input': '2+2'},
                   ),
                 ],
               ),
               finishReason: FinishReason.toolCalls,
-              metadata: {},
-              usage: LanguageModelUsage(
+              usage: const LanguageModelUsage(
                 responseTokens: 7,
               ),
-              streaming: true,
             ),
           ]),
         );
@@ -194,18 +186,15 @@ void main() {
         when(
           chatbotService.sendMessage(
             _model,
-            [_userMessage],
+            any,
             tools: const [],
           ),
         ).thenAnswer(
           (_) => Stream.fromIterable([
-            const ChatResult(
-              id: 'chunk-1',
-              output: AIChatMessage(content: 'Working'),
+            ChatResult<ChatMessage>(
+              output: ChatMessage.model('Working'),
               finishReason: FinishReason.stop,
-              metadata: {},
-              usage: LanguageModelUsage(),
-              streaming: true,
+              usage: const LanguageModelUsage(),
             ),
           ]),
         );
@@ -238,18 +227,15 @@ void main() {
         when(
           chatbotService.sendMessage(
             _model,
-            [_userMessage],
+            any,
             tools: const [],
           ),
         ).thenAnswer(
           (_) => Stream.fromIterable([
-            const ChatResult(
-              id: 'chunk-1',
-              output: AIChatMessage(content: 'Working'),
+            ChatResult<ChatMessage>(
+              output: ChatMessage.model('Working'),
               finishReason: FinishReason.stop,
-              metadata: {},
-              usage: LanguageModelUsage(),
-              streaming: true,
+              usage: const LanguageModelUsage(),
             ),
           ]),
         );

--- a/apps/auravibes_app/test/features/tools/usecases/load_conversation_tool_specs_usecase_test.dart
+++ b/apps/auravibes_app/test/features/tools/usecases/load_conversation_tool_specs_usecase_test.dart
@@ -1,9 +1,9 @@
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
 import 'package:auravibes_app/domain/entities/workspace_tool.dart';
 import 'package:auravibes_app/domain/repositories/conversation_tools_repository.dart';
 import 'package:auravibes_app/domain/usecases/tools/mcp/build_combined_tool_specs_usecase.dart';
 import 'package:auravibes_app/features/tools/usecases/load_conversation_tool_specs_usecase.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:langchain/langchain.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 

--- a/apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart
+++ b/apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart
@@ -3,7 +3,6 @@ import 'package:auravibes_app/domain/enums/message_types.dart';
 import 'package:auravibes_app/domain/enums/tool_call_result_status.dart';
 import 'package:auravibes_app/services/chatbot_service/build_prompt_chat_messages.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:langchain/langchain.dart';
 
 void main() {
   group('BuildPromptChatMessages', () {
@@ -47,16 +46,21 @@ void main() {
       final result = usecase.call(messages);
 
       expect(result, hasLength(3));
-      expect(result[0], isA<HumanChatMessage>());
+      expect(result[0].role.name, 'user');
 
-      final aiMessage = result[1] as AIChatMessage;
-      expect(aiMessage.toolCalls, hasLength(1));
-      expect(aiMessage.toolCalls.single.id, 'tool-1');
-      expect(aiMessage.toolCalls.single.name, 'built_in_calc_calculator');
+      final modelMessage = result[1];
+      expect(modelMessage.role.name, 'model');
+      expect(modelMessage.toolCalls, hasLength(1));
+      expect(modelMessage.toolCalls.single.callId, 'tool-1');
+      expect(
+        modelMessage.toolCalls.single.toolName,
+        'built_in_calc_calculator',
+      );
 
-      final toolMessage = result[2] as ToolChatMessage;
-      expect(toolMessage.toolCallId, 'tool-1');
-      expect(toolMessage.content, '4');
+      final resultMessage = result[2];
+      expect(resultMessage.role.name, 'model');
+      expect(resultMessage.toolResults, hasLength(1));
+      expect(resultMessage.toolResults.single.callId, 'tool-1');
     });
 
     test(
@@ -88,9 +92,10 @@ void main() {
         final result = usecase.call(messages);
 
         expect(result, hasLength(2));
-        final toolMessage = result[1] as ToolChatMessage;
+        final resultMessage = result[1];
+        expect(resultMessage.toolResults, hasLength(1));
         expect(
-          toolMessage.content,
+          resultMessage.toolResults.single.result,
           ToolCallResultStatus.toolNotFound.toResponseString(),
         );
       },

--- a/apps/auravibes_app/test/services/chatbot_service/chat_message_adapter_test.dart
+++ b/apps/auravibes_app/test/services/chatbot_service/chat_message_adapter_test.dart
@@ -1,0 +1,153 @@
+import 'package:auravibes_app/domain/entities/messages.dart';
+import 'package:auravibes_app/domain/enums/message_types.dart';
+import 'package:auravibes_app/domain/enums/tool_call_result_status.dart';
+import 'package:auravibes_app/services/chatbot_service/build_prompt_chat_messages.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BuildPromptChatMessages', () {
+    const adapter = BuildPromptChatMessages();
+
+    test('converts user message', () {
+      final messages = [
+        MessageEntity(
+          id: 'u1',
+          conversationId: 'c1',
+          content: 'Hello',
+          messageType: MessageType.text,
+          isUser: true,
+          status: MessageStatus.sent,
+          createdAt: DateTime(2025),
+          updatedAt: DateTime(2025),
+        ),
+      ];
+
+      final result = adapter(messages);
+
+      expect(result, hasLength(1));
+      expect(result.single.role.name, 'user');
+    });
+
+    test('converts assistant message without tool calls', () {
+      final messages = [
+        MessageEntity(
+          id: 'a1',
+          conversationId: 'c1',
+          content: 'Hi there',
+          messageType: MessageType.text,
+          isUser: false,
+          status: MessageStatus.sent,
+          createdAt: DateTime(2025),
+          updatedAt: DateTime(2025),
+        ),
+      ];
+
+      final result = adapter(messages);
+
+      expect(result, hasLength(1));
+      expect(result.single.role.name, 'model');
+    });
+
+    test('converts assistant message with resolved tool calls', () {
+      final messages = [
+        MessageEntity(
+          id: 'a1',
+          conversationId: 'c1',
+          content: '',
+          messageType: MessageType.text,
+          isUser: false,
+          status: MessageStatus.sent,
+          createdAt: DateTime(2025),
+          updatedAt: DateTime(2025),
+          metadata: const MessageMetadataEntity(
+            toolCalls: [
+              MessageToolCallEntity(
+                id: 'tc1',
+                name: 'calculator',
+                argumentsRaw: '{"expr":"2+2"}',
+                responseRaw: '4',
+                resultStatus: ToolCallResultStatus.success,
+              ),
+            ],
+          ),
+        ),
+      ];
+
+      final result = adapter(messages);
+
+      expect(result, hasLength(2));
+
+      final modelMsg = result[0];
+      expect(modelMsg.role.name, 'model');
+      expect(modelMsg.toolCalls, hasLength(1));
+      expect(modelMsg.toolCalls.single.callId, 'tc1');
+      expect(modelMsg.toolCalls.single.toolName, 'calculator');
+
+      final resultMsg = result[1];
+      expect(resultMsg.role.name, 'model');
+      expect(resultMsg.toolResults, hasLength(1));
+      expect(resultMsg.toolResults.single.callId, 'tc1');
+    });
+
+    test('skips unresolved tool call results', () {
+      final messages = [
+        MessageEntity(
+          id: 'a1',
+          conversationId: 'c1',
+          content: '',
+          messageType: MessageType.text,
+          isUser: false,
+          status: MessageStatus.sent,
+          createdAt: DateTime(2025),
+          updatedAt: DateTime(2025),
+          metadata: const MessageMetadataEntity(
+            toolCalls: [
+              MessageToolCallEntity(
+                id: 'tc1',
+                name: 'calculator',
+                argumentsRaw: '{"expr":"2+2"}',
+              ),
+            ],
+          ),
+        ),
+      ];
+
+      final result = adapter(messages);
+
+      expect(result, hasLength(1));
+      expect(result.single.toolCalls, hasLength(1));
+      expect(result.single.toolResults, isEmpty);
+    });
+
+    test('converts multiple messages in order', () {
+      final messages = [
+        MessageEntity(
+          id: 'u1',
+          conversationId: 'c1',
+          content: 'Hi',
+          messageType: MessageType.text,
+          isUser: true,
+          status: MessageStatus.sent,
+          createdAt: DateTime(2025),
+          updatedAt: DateTime(2025),
+        ),
+        MessageEntity(
+          id: 'a1',
+          conversationId: 'c1',
+          content: 'Hello!',
+          messageType: MessageType.text,
+          isUser: false,
+          status: MessageStatus.sent,
+          createdAt: DateTime(2025),
+          updatedAt: DateTime(2025),
+        ),
+      ];
+
+      final result = adapter(messages);
+
+      expect(result, hasLength(2));
+      expect(result[0].role.name, 'user');
+      expect(result[1].role.name, 'model');
+    });
+  });
+}

--- a/apps/auravibes_app/test/services/chatbot_service/provider_factory_test.dart
+++ b/apps/auravibes_app/test/services/chatbot_service/provider_factory_test.dart
@@ -72,6 +72,23 @@ void main() {
       expect(chatModel, isA<ChatModel>());
     });
 
+    test(
+      'creates ChatModel via OpenAIProvider when anthropic has custom baseUrl',
+      () {
+        // AnthropicProvider constructor doesn't accept baseUrl,
+        // so custom URLs fall through to OpenAIProvider (OpenAI-compatible).
+        final config = makeConfig(
+          type: ModelProvidersType.anthropic,
+          modelId: 'claude-sonnet-4-0',
+          connectionUrl: 'https://custom-proxy.example.com/v1',
+          providerUrl: 'https://api.anthropic.com/v1',
+        );
+        final chatModel = factory(config, apiKey: 'sk-ant-test');
+
+        expect(chatModel, isA<ChatModel>());
+      },
+    );
+
     test('throws when type is null and no baseUrl', () {
       final config = makeConfig();
 

--- a/apps/auravibes_app/test/services/chatbot_service/provider_factory_test.dart
+++ b/apps/auravibes_app/test/services/chatbot_service/provider_factory_test.dart
@@ -1,0 +1,108 @@
+import 'package:auravibes_app/domain/entities/api_model_provider.dart';
+import 'package:auravibes_app/domain/entities/model_connection_entities.dart';
+import 'package:auravibes_app/domain/entities/workspace_model_selection_entities.dart';
+import 'package:auravibes_app/services/chatbot_service/provider_factory.dart';
+import 'package:dartantic_ai/dartantic_ai.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ProviderFactory', () {
+    const factory = ProviderFactory();
+
+    WorkspaceModelSelectionWithConnectionEntity makeConfig({
+      ModelProvidersType? type,
+      String modelId = 'gpt-4o',
+      String? connectionUrl,
+      String? providerUrl,
+    }) {
+      return WorkspaceModelSelectionWithConnectionEntity(
+        workspaceModelSelection: WorkspaceModelSelectionEntity(
+          id: 'ws1',
+          modelId: modelId,
+          createdAt: DateTime(2025),
+          updatedAt: DateTime(2025),
+          modelConnectionId: 'mc1',
+        ),
+        modelConnection: ModelConnectionEntity(
+          id: 'mc1',
+          name: 'Test',
+          key: 'encrypted-key',
+          modelId: modelId,
+          createdAt: DateTime(2025),
+          updatedAt: DateTime(2025),
+          workspaceId: 'w1',
+          url: connectionUrl,
+        ),
+        modelsProvider: ApiModelProviderEntity(
+          id: 'p1',
+          name: 'TestProvider',
+          type: type,
+          url: providerUrl,
+        ),
+      );
+    }
+
+    test('creates ChatModel for openai provider', () {
+      final config = makeConfig(type: ModelProvidersType.openai);
+      final chatModel = factory(config, apiKey: 'sk-test');
+
+      expect(chatModel, isA<ChatModel>());
+      expect(chatModel.name, 'gpt-4o');
+    });
+
+    test('creates ChatModel for anthropic provider', () {
+      final config = makeConfig(
+        type: ModelProvidersType.anthropic,
+        modelId: 'claude-sonnet-4-0',
+      );
+      final chatModel = factory(config, apiKey: 'sk-ant-test');
+
+      expect(chatModel, isA<ChatModel>());
+      expect(chatModel.name, 'claude-sonnet-4-0');
+    });
+
+    test('creates custom ChatModel when connection has custom baseUrl', () {
+      final config = makeConfig(
+        type: ModelProvidersType.openai,
+        connectionUrl: 'https://custom.example.com/v1',
+        providerUrl: 'https://api.openai.com/v1',
+      );
+      final chatModel = factory(config, apiKey: 'sk-test');
+
+      expect(chatModel, isA<ChatModel>());
+    });
+
+    test('throws when type is null and no baseUrl', () {
+      final config = makeConfig();
+
+      expect(
+        () => factory(config, apiKey: 'sk-test'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('creates custom ChatModel when type is null but baseUrl exists', () {
+      final config = makeConfig(
+        connectionUrl: 'https://custom.example.com/v1',
+      );
+      final chatModel = factory(config, apiKey: 'sk-test');
+
+      expect(chatModel, isA<ChatModel>());
+    });
+
+    test('passes tools to ChatModel', () {
+      final config = makeConfig(type: ModelProvidersType.openai);
+      final tools = [
+        Tool<Map<String, dynamic>>(
+          name: 'test_tool',
+          description: 'A test tool',
+          onCall: (_) async => 'ok',
+        ),
+      ];
+
+      final chatModel = factory(config, apiKey: 'sk-test', tools: tools);
+
+      expect(chatModel, isA<ChatModel>());
+    });
+  });
+}

--- a/apps/auravibes_app/test/services/chatbot_service/tool_adapter_test.dart
+++ b/apps/auravibes_app/test/services/chatbot_service/tool_adapter_test.dart
@@ -1,0 +1,92 @@
+import 'package:auravibes_app/domain/entities/tool_spec.dart';
+import 'package:auravibes_app/services/chatbot_service/tool_adapter.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ToolAdapter', () {
+    const adapter = ToolAdapter();
+
+    test('converts ToolSpec to dartantic Tool', () async {
+      final specs = [
+        const ToolSpec(
+          name: 'calculator',
+          description: 'Perform calculations',
+          inputJsonSchema: {
+            'type': 'object',
+            'properties': {
+              'expression': {'type': 'string'},
+            },
+            'required': ['expression'],
+          },
+        ),
+      ];
+
+      final tools = adapter(specs, onCall: (_, _) async => {});
+
+      expect(tools, hasLength(1));
+      expect(tools.first.name, 'calculator');
+      expect(tools.first.description, 'Perform calculations');
+      expect(tools.first.inputSchema, isNotNull);
+    });
+
+    test('wires onCall callback with tool name and args', () async {
+      String? capturedName;
+      Map<String, dynamic>? capturedArgs;
+
+      final specs = [
+        const ToolSpec(
+          name: 'search',
+          description: 'Search',
+          inputJsonSchema: {
+            'type': 'object',
+            'properties': {
+              'query': {'type': 'string'},
+            },
+          },
+        ),
+      ];
+
+      final tools = adapter(
+        specs,
+        onCall: (name, args) async {
+          capturedName = name;
+          capturedArgs = args;
+          return {'result': 'found'};
+        },
+      );
+
+      final result = await tools.first.onCall({'query': 'test'});
+
+      expect(capturedName, 'search');
+      expect(capturedArgs, {'query': 'test'});
+      expect(result, {'result': 'found'});
+    });
+
+    test('converts empty specs list', () {
+      final tools = adapter([], onCall: (_, _) async => {});
+
+      expect(tools, isEmpty);
+    });
+
+    test('converts multiple specs', () {
+      final specs = [
+        const ToolSpec(
+          name: 'tool_a',
+          description: 'Tool A',
+          inputJsonSchema: {'type': 'object'},
+        ),
+        const ToolSpec(
+          name: 'tool_b',
+          description: 'Tool B',
+          inputJsonSchema: {'type': 'object'},
+        ),
+      ];
+
+      final tools = adapter(specs, onCall: (_, _) async => {});
+
+      expect(tools, hasLength(2));
+      expect(tools[0].name, 'tool_a');
+      expect(tools[1].name, 'tool_b');
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: anthropic_sdk_dart
-      sha256: "30162d70384f38f98f22e2402776f28d260b721fef684893dbed2a3108e72428"
+      sha256: b0e91039942930341b24e3871d5b9481b6d31528b711eb752f413f4d1f5980eb
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1"
+    version: "1.5.0"
   archive:
     dependency: transitive
     description:
@@ -273,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.9.0"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   csv:
     dependency: transitive
     description:
@@ -289,6 +297,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  dartantic_ai:
+    dependency: transitive
+    description:
+      name: dartantic_ai
+      sha256: "2c6cf66ef2ee081a2b863c11b7d8343e0f760380ba1a367df567a537c520bd14"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
+  dartantic_interface:
+    dependency: transitive
+    description:
+      name: dartantic_interface
+      sha256: b21a1867da49335b1004cae5b97abeff75e3421ec7c3fee144bcc5e6f463dc63
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   dbus:
     dependency: transitive
     description:
@@ -297,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  decimal:
+    dependency: transitive
+    description:
+      name: decimal
+      sha256: fc706a5618b81e5b367b01dd62621def37abc096f2b46a9bd9068b64c1fa36d0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.4"
   dependency_validator:
     dependency: "direct dev"
     description:
@@ -393,6 +425,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.2"
+  email_validator:
+    dependency: transitive
+    description:
+      name: email_validator
+      sha256: b19aa5d92fdd76fbc65112060c94d45ba855105a28bb6e462de7ff03b12fa1fb
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   equatable:
     dependency: transitive
     description:
@@ -605,6 +645,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  genai_primitives:
+    dependency: transitive
+    description:
+      name: genai_primitives
+      sha256: "2468ecd2984f32232ab199315e384821c61a198e356828e34b9a5bcf0fda863e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3"
   glob:
     dependency: transitive
     description:
@@ -637,6 +685,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.0.2"
+  googleai_dart:
+    dependency: transitive
+    description:
+      name: googleai_dart
+      sha256: b7283c2d0d0aefb8feb735b1a8bcaa5cd1eaeb18fef86d500e9644564586d762
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   gpt_markdown:
     dependency: transitive
     description:
@@ -669,6 +725,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.1"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   http:
     dependency: transitive
     description:
@@ -741,6 +805,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
+  json_schema_builder:
+    dependency: transitive
+    description:
+      name: json_schema_builder
+      sha256: "65035d48d028401ad0ffc8c2f173209c7b1441e465a942a0f909070fae33170c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   json_serializable:
     dependency: transitive
     description:
@@ -749,46 +821,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.13.0"
-  langchain:
-    dependency: transitive
-    description:
-      name: langchain
-      sha256: b7035e0903953cb065734499296e66d9fa0f6e15934aa2f57389b9fb6b001aab
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.1"
-  langchain_anthropic:
-    dependency: transitive
-    description:
-      name: langchain_anthropic
-      sha256: e78c81064733f6dbc67b5ea06cc62454581bede69a4f06abe7ebf1347716be78
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.1"
-  langchain_core:
-    dependency: transitive
-    description:
-      name: langchain_core
-      sha256: fce3cd0e31dcbac80d209f6361207936a58b05506b800f13227cbe83f6e3e721
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.1"
-  langchain_openai:
-    dependency: transitive
-    description:
-      name: langchain_openai
-      sha256: "23ed96ece5bc27ec95d1b720bce61267e6db578d24134ddf80b715184e932330"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.1+1"
-  langchain_tiktoken:
-    dependency: transitive
-    description:
-      name: langchain_tiktoken
-      sha256: c1804f4b3e56574ca67e562305d9f11e3eabe3c8aa87fea8635992f7efc66674
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -869,6 +901,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  mcp_dart:
+    dependency: transitive
+    description:
+      name: mcp_dart
+      sha256: "30ab03147fec3fd72e98172475cd720cd4e3aec7d5f8944ef36dbfabc75a353c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   melos:
     dependency: "direct dev"
     description:
@@ -893,6 +933,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mistralai_dart:
+    dependency: transitive
+    description:
+      name: mistralai_dart
+      sha256: ee6a06c6cac399fc3f4a707f379acd3afea79775033fe4b605da6a8c2dfd3768
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   mockito:
     dependency: transitive
     description:
@@ -949,14 +997,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
+  ollama_dart:
+    dependency: transitive
+    description:
+      name: ollama_dart
+      sha256: d301154465e07810bd0c6ebb4ebc24f1e0f51372a299ae6b28433ac3bea91031
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.1"
   openai_dart:
     dependency: transitive
     description:
       name: openai_dart
-      sha256: "037605a210cb3b1d8ac72b11a4ace26f25ee9267aaf981d2af1d7f0524adcbf5"
+      sha256: "4731f94ea9a09cd9e92333debcfb87efda2764718e506538206df9f540e9ab60"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "1.4.0"
   package_config:
     dependency: transitive
     description:
@@ -1117,6 +1173,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   recase:
     dependency: transitive
     description:
@@ -1338,6 +1402,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.43.1"
+  sse:
+    dependency: transitive
+    description:
+      name: sse
+      sha256: a9a804dbde8bfd369da3b4aa241d44d63a6486a97388c54ec166073d88c52302
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
+  sse_channel:
+    dependency: transitive
+    description:
+      name: sse_channel
+      sha256: ad85fda353fae12533fd762dbd3ff275e710f216644e39459bf11a138124acad
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   stack_trace:
     dependency: transitive
     description:

--- a/specs/004-migrate-langchain-dartantic/checklists/requirements.md
+++ b/specs/004-migrate-langchain-dartantic/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Migrate AI Orchestration Framework
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-21
+**Feature**: [specs/004-migrate-langchain-dartantic/spec.md](specs/004-migrate-langchain-dartantic/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/004-migrate-langchain-dartantic/contracts/chatbot_service.md
+++ b/specs/004-migrate-langchain-dartantic/contracts/chatbot_service.md
@@ -1,0 +1,104 @@
+# Contract: ChatbotService Interface
+
+**Scope**: Service layer contract for AI chat interactions  
+**Consumer**: `ContinueAgentUsecase`, `MessagesStreamingNotifier`, title generation
+
+---
+
+## Interface
+
+```dart
+abstract class ChatbotService {
+  /// Sends a message and returns a stream of response chunks.
+  ///
+  /// [message] - The user's input text
+  /// [history] - Previous conversation messages (domain entities)
+  /// [tools] - Available tools for this conversation
+  /// [providerConfig] - Selected provider and model configuration
+  ///
+  /// Returns a stream of [ChatResult] chunks that can be concatenated
+  /// to form the complete response.
+  Stream<ChatResult> sendMessage({
+    required String message,
+    required List<MessageEntity> history,
+    required List<Tool> tools,
+    required ProviderConfiguration providerConfig,
+  });
+
+  /// Generates a title for a new conversation based on the first message.
+  ///
+  /// [message] - The first user message
+  /// [providerConfig] - Provider configuration for title generation
+  ///
+  /// Returns the generated title string.
+  Future<String> generateTitle({
+    required String message,
+    required ProviderConfiguration providerConfig,
+  });
+}
+```
+
+---
+
+## Key Changes from LangChain
+
+| Aspect         | Before (LangChain)                          | After (dartantic_ai)                                  |
+| -------------- | ------------------------------------------- | ----------------------------------------------------- |
+| Model type     | `BaseChatModel`                             | `Agent`                                               |
+| Model creation | `ChatOpenAI(...)`, `ChatAnthropic(...)`     | `Agent('provider:model')` or `Agent.forProvider(...)` |
+| Options        | `ChatOpenAIOptions`, `ChatAnthropicOptions` | Constructor parameters on `Agent`                     |
+| Prompt wrapper | `PromptValue.chat(messages)`                | Pass `List<ChatMessage>` directly to `sendStream()`   |
+| Streaming      | `model.stream(promptValue)`                 | `agent.sendStream(prompt, history: messages)`         |
+
+---
+
+## Invariants
+
+1. **Provider initialization MUST NOT block** the UI thread
+2. **Stream MUST emit at least one chunk** for every valid request
+3. **Usage metadata MUST be available** on the final chunk of the stream
+4. **Error in stream MUST be catchable** by the consumer without crashing the app
+5. **History MUST be immutable** — the service must not mutate the input list
+
+---
+
+## Error Contract
+
+The service MUST handle these errors and surface them via the stream:
+
+| Error Condition        | Behavior                                                        |
+| ---------------------- | --------------------------------------------------------------- |
+| Invalid API key        | Stream emits error with clear message                           |
+| Network timeout        | Stream emits error after configured timeout                     |
+| Invalid model ID       | Stream emits error before first chunk                           |
+| Tool execution failure | Error context passed back to AI, stream continues               |
+| Rate limit             | Automatic retry with exponential backoff (handled by dartantic) |
+
+---
+
+## Provider Configuration Mapping
+
+```dart
+class ProviderConfiguration {
+  final String providerType;      // e.g., 'openai', 'anthropic', 'google'
+  final String modelId;           // e.g., 'gpt-4o', 'claude-sonnet-4-0'
+  final String? baseUrl;          // Custom endpoint (optional)
+  final Map<String, String>? customHeaders;  // Custom headers (optional)
+  final String apiKey;            // Decrypted API key
+}
+```
+
+**Mapping to dartantic**:
+
+- Built-in providers: `Agent('${providerType}:${modelId}')`
+- Custom endpoint: `Agent.forProvider(OpenAIProvider(apiKey: ..., baseUrl: Uri.parse(baseUrl!)))`
+- Custom headers: Passed to provider constructor
+
+---
+
+## Performance Contract
+
+- **First-token latency**: <2 seconds for standard prompts
+- **Stream chunk interval**: Tokens emitted as received from provider
+- **Memory per stream**: Bounded by conversation context window
+- **Concurrent streams**: Single stream per conversation (serialized by UI)

--- a/specs/004-migrate-langchain-dartantic/contracts/chatbot_service.md
+++ b/specs/004-migrate-langchain-dartantic/contracts/chatbot_service.md
@@ -16,9 +16,9 @@ abstract class ChatbotService {
   /// [tools] - Available tools for this conversation
   /// [providerConfig] - Selected provider and model configuration
   ///
-  /// Returns a stream of [ChatResult] chunks that can be concatenated
-  /// to form the complete response.
-  Stream<ChatResult> sendMessage({
+  /// Returns a stream of [ChatResult<ChatMessage>] chunks that can be
+  /// concatenated via [ChatResultConcat] to form the complete response.
+  Stream<ChatResult<ChatMessage>> sendMessage({
     required String message,
     required List<MessageEntity> history,
     required List<Tool> tools,
@@ -42,13 +42,14 @@ abstract class ChatbotService {
 
 ## Key Changes from LangChain
 
-| Aspect         | Before (LangChain)                          | After (dartantic_ai)                                  |
-| -------------- | ------------------------------------------- | ----------------------------------------------------- |
-| Model type     | `BaseChatModel`                             | `Agent`                                               |
-| Model creation | `ChatOpenAI(...)`, `ChatAnthropic(...)`     | `Agent('provider:model')` or `Agent.forProvider(...)` |
-| Options        | `ChatOpenAIOptions`, `ChatAnthropicOptions` | Constructor parameters on `Agent`                     |
-| Prompt wrapper | `PromptValue.chat(messages)`                | Pass `List<ChatMessage>` directly to `sendStream()`   |
-| Streaming      | `model.stream(promptValue)`                 | `agent.sendStream(prompt, history: messages)`         |
+| Aspect         | Before (LangChain)                          | After (dartantic_ai)                                   |
+| -------------- | ------------------------------------------- | ------------------------------------------------------ |
+| Model type     | `BaseChatModel`                             | `ChatModel` (via `ProviderFactory.call()`)             |
+| Model creation | `ChatOpenAI(...)`, `ChatAnthropic(...)`     | `ProviderFactory.call(providerType, modelId, apiKey)`  |
+| Options        | `ChatOpenAIOptions`, `ChatAnthropicOptions` | Provider-specific options via `ProviderFactory`        |
+| Prompt builder | `PromptValue.chat(messages)`                | `BuildPromptChatMessages` → `List<ChatMessage>`        |
+| Streaming      | `model.stream(promptValue)`                 | `chatModel.sendStream(prompt, history: messages)`      |
+| Tool adapter   | N/A                                         | `ToolAdapter` converts domain tools → dartantic `Tool` |
 
 ---
 
@@ -90,9 +91,9 @@ class ProviderConfiguration {
 
 **Mapping to dartantic**:
 
-- Built-in providers: `Agent('${providerType}:${modelId}')`
-- Custom endpoint: `Agent.forProvider(OpenAIProvider(apiKey: ..., baseUrl: Uri.parse(baseUrl!)))`
-- Custom headers: Passed to provider constructor
+- Built-in providers: `ProviderFactory.call(providerType, modelId, apiKey)`
+- Custom endpoint: `ProviderFactory.call(..., baseUrl: Uri.parse(baseUrl!))`
+- Custom headers: Passed to `ProviderFactory.call(..., headers: customHeaders)`
 
 ---
 

--- a/specs/004-migrate-langchain-dartantic/contracts/message_conversion.md
+++ b/specs/004-migrate-langchain-dartantic/contracts/message_conversion.md
@@ -1,0 +1,159 @@
+# Contract: Message Conversion Interface
+
+**Scope**: Conversion between domain entities and framework chat messages  
+**Consumer**: `ChatbotService`, `BuildPromptChatMessagesUsecase`, tests
+
+---
+
+## Interface
+
+```dart
+/// Converts domain message entities to framework-specific chat messages.
+///
+/// This abstraction isolates the framework from the domain layer,
+/// allowing the framework to be replaced without changing domain entities.
+class MessageConverter {
+  /// Converts a list of domain messages to framework chat messages.
+  ///
+  /// [messages] - Domain entities from the conversation history
+  /// [systemPrompt] - Optional system prompt to prepend
+  ///
+  /// Returns ordered list of framework chat messages ready for the model.
+  List<ChatMessage> toFrameworkMessages(
+    List<MessageEntity> messages, {
+    String? systemPrompt,
+  });
+
+  /// Converts a framework chat result to a domain message entity.
+  ///
+  /// [result] - The completed chat result from the framework
+  /// [conversationId] - Parent conversation identifier
+  ///
+  /// Returns a domain message entity ready for persistence.
+  MessageEntity toDomainMessage(
+    ChatResult result, {
+    required String conversationId,
+  });
+
+  /// Extracts token usage from a framework result.
+  ///
+  /// [result] - Chat result containing usage metadata
+  ///
+  /// Returns token usage statistics or null if unavailable.
+  TokenUsage? extractTokenUsage(ChatResult result);
+}
+
+/// Token usage statistics.
+class TokenUsage {
+  final int? promptTokens;
+  final int? responseTokens;
+  final int? totalTokens;
+
+  TokenUsage({
+    this.promptTokens,
+    this.responseTokens,
+    this.totalTokens,
+  });
+}
+```
+
+---
+
+## Conversion Rules
+
+### Domain → Framework
+
+| Domain Role | Domain Properties                       | Framework Type                                      |
+| ----------- | --------------------------------------- | --------------------------------------------------- |
+| `user`      | `content: String`                       | `ChatMessage.user(content)`                         |
+| `assistant` | `content: String`, no tool calls        | `ChatMessage.assistant(content)`                    |
+| `assistant` | `content: String`, `toolCalls: [...]`   | `ChatMessage.assistant(content, toolCalls: mapped)` |
+| `tool`      | `content: String`, `toolCallId: String` | `ChatMessage.tool(content, toolCallId: id)`         |
+| `system`    | `content: String`                       | `ChatMessage.system(content)`                       |
+
+### Tool Call Mapping
+
+```dart
+List<ToolCall> mapToolCalls(List<MessageToolCallEntity> entities) {
+  return entities.map((e) => ToolCall(
+    id: e.id,
+    name: e.name,
+    arguments: e.arguments,
+  )).toList();
+}
+```
+
+### Framework → Domain
+
+| Framework Output          | Domain Properties                               |
+| ------------------------- | ----------------------------------------------- |
+| `result.output` (text)    | `content: output`, `role: assistant`            |
+| `result.output.toolCalls` | `toolCalls: mapped`                             |
+| `result.usage`            | `promptTokens`, `responseTokens`, `totalTokens` |
+
+---
+
+## Framework-Specific Details
+
+### LangChain (Before)
+
+```dart
+// Message creation
+ChatMessage.humanText('Hello');
+ChatMessage.ai(content: 'Hi!', toolCalls: [...]);
+ChatMessage.tool('Result', toolCallId: 'call_123');
+
+// Prompt wrapper
+final prompt = PromptValue.chat(messages);
+
+// Result extraction
+final text = result.outputAsString;
+final toolCalls = result.output.toolCalls;
+final usage = result.usage;
+```
+
+### dartantic_ai (After)
+
+```dart
+// Message creation
+ChatMessage.user('Hello');
+ChatMessage.assistant('Hi!', toolCalls: [...]);
+ChatMessage.tool('Result', toolCallId: 'call_123');
+
+// No prompt wrapper needed — pass list directly
+final stream = agent.sendStream('Hello', history: messages);
+
+// Result extraction
+final text = result.output;
+final toolCalls = result.toolCalls; // or from messages
+final usage = result.usage;
+```
+
+---
+
+## Invariants
+
+1. **Order preservation**: Messages MUST maintain chronological order after conversion
+2. **Idempotency**: Same domain input MUST produce same framework output
+3. **Immutability**: Converter MUST NOT mutate input lists or entities
+4. **Completeness**: All domain message types MUST have a framework mapping
+5. **Reversibility**: Framework output MUST contain enough information to create a valid domain entity
+
+---
+
+## Error Contract
+
+| Error Condition      | Behavior                                         |
+| -------------------- | ------------------------------------------------ |
+| Unknown message role | Throw `ArgumentError` with clear message         |
+| Malformed tool call  | Skip tool call, log warning, continue conversion |
+| Missing tool call ID | Generate synthetic ID, log warning               |
+| Null content         | Convert to empty string `""`                     |
+
+---
+
+## Performance Contract
+
+- **Conversion time**: O(n) where n = message count, must complete in <10ms for 100 messages
+- **Memory**: No intermediate copies of message content (pass by reference where possible)
+- **Streaming**: Incremental conversion not needed — full history converted once per request

--- a/specs/004-migrate-langchain-dartantic/contracts/message_conversion.md
+++ b/specs/004-migrate-langchain-dartantic/contracts/message_conversion.md
@@ -31,7 +31,7 @@ class MessageConverter {
   ///
   /// Returns a domain message entity ready for persistence.
   MessageEntity toDomainMessage(
-    ChatResult result, {
+    ChatResult<ChatMessage> result, {
     required String conversationId,
   });
 
@@ -40,7 +40,7 @@ class MessageConverter {
   /// [result] - Chat result containing usage metadata
   ///
   /// Returns token usage statistics or null if unavailable.
-  TokenUsage? extractTokenUsage(ChatResult result);
+  TokenUsage? extractTokenUsage(ChatResult<ChatMessage> result);
 }
 
 /// Token usage statistics.
@@ -120,12 +120,12 @@ ChatMessage.user('Hello');
 ChatMessage.assistant('Hi!', toolCalls: [...]);
 ChatMessage.tool('Result', toolCallId: 'call_123');
 
-// No prompt wrapper needed — pass list directly
-final stream = agent.sendStream('Hello', history: messages);
+// No prompt wrapper needed — pass list directly via BuildPromptChatMessages
+final stream = chatModel.sendStream('Hello', history: messages);
 
 // Result extraction
-final text = result.output;
-final toolCalls = result.toolCalls; // or from messages
+final text = result.output.text;
+final toolCalls = result.output.toolCalls;
 final usage = result.usage;
 ```
 

--- a/specs/004-migrate-langchain-dartantic/contracts/tool_definition.md
+++ b/specs/004-migrate-langchain-dartantic/contracts/tool_definition.md
@@ -1,0 +1,179 @@
+# Contract: Tool Definition Interface
+
+**Scope**: Tool system contract for AI-invoked capabilities  
+**Consumer**: `ChatbotService`, `BuildCombinedToolSpecsUsecase`, MCP integration
+
+---
+
+## Interface
+
+```dart
+/// Abstract base for all tools exposed to the AI.
+///
+/// Tools are capabilities that the AI can invoke autonomously
+/// during a conversation to perform actions or retrieve data.
+abstract class ToolDefinition {
+  /// Unique identifier for the tool (snake_case recommended)
+  String get name;
+
+  /// Human-readable description of what the tool does.
+  /// This is shown to the AI to help it decide when to use the tool.
+  String get description;
+
+  /// JSON Schema describing the tool's input parameters.
+  /// The AI uses this to generate valid tool call arguments.
+  Map<String, dynamic> get inputSchema;
+
+  /// Executes the tool with the given arguments.
+  ///
+  /// [args] - Map of argument names to values, validated against inputSchema
+  /// Returns a map representing the tool result (serializable to JSON)
+  Future<Map<String, dynamic>> execute(Map<String, dynamic> args);
+}
+```
+
+---
+
+## Framework Mapping
+
+### LangChain (Before)
+
+```dart
+// Schema definition
+final toolSpec = ToolSpec(
+  name: 'get_weather',
+  description: 'Get weather for a location',
+  inputJsonSchema: {
+    'type': 'object',
+    'properties': {
+      'location': {'type': 'string'},
+    },
+    'required': ['location'],
+  },
+);
+
+// Executable tool
+final tool = Tool.fromFunction<WeatherInput, WeatherOutput>(
+  name: 'get_weather',
+  description: 'Get weather for a location',
+  inputJsonSchema: schema,
+  func: (input) async => WeatherOutput(temp: 72),
+);
+```
+
+### dartantic_ai (After)
+
+```dart
+// Unified tool definition
+final tool = Tool(
+  name: 'get_weather',
+  description: 'Get weather for a location',
+  inputSchema: Schema.fromMap({
+    'type': 'object',
+    'properties': {
+      'location': {'type': 'string'},
+    },
+    'required': ['location'],
+  }),
+  onCall: (args) async => {'temp': 72, 'location': args['location']},
+);
+```
+
+---
+
+## Tool Categories
+
+### 1. Built-in Tools
+
+Tools shipped with the application (e.g., calculator, URL fetcher).
+
+```dart
+class CalculatorTool implements ToolDefinition {
+  @override
+  String get name => 'calculator';
+
+  @override
+  String get description => 'Perform mathematical calculations';
+
+  @override
+  Map<String, dynamic> get inputSchema => {
+    'type': 'object',
+    'properties': {
+      'expression': {'type': 'string'},
+    },
+    'required': ['expression'],
+  };
+
+  @override
+  Future<Map<String, dynamic>> execute(Map<String, dynamic> args) async {
+    // Implementation
+  }
+}
+```
+
+### 2. Native Tools
+
+Platform-specific tools that require native capabilities.
+
+**Contract**: Same interface as built-in tools, but may use platform channels or native APIs in `execute()`.
+
+### 3. MCP Tools
+
+Tools sourced from external Model Context Protocol servers.
+
+**Contract**:
+
+- MCP infrastructure remains unchanged (per FR-014)
+- `ToolSpec` from MCP is converted to dartantic `Tool` at the boundary
+- MCP connection manager handles server lifecycle independently
+
+```dart
+// Conversion at the boundary
+List<Tool> convertMcpTools(List<ToolSpec> mcpSpecs) {
+  return mcpSpecs.map((spec) => Tool(
+    name: spec.name,
+    description: spec.description,
+    inputSchema: Schema.fromMap(spec.inputJsonSchema),
+    onCall: (args) async => mcpClient.callTool(spec.name, args),
+  )).toList();
+}
+```
+
+---
+
+## Invariants
+
+1. **Tool names MUST be unique** within a conversation context
+2. **Input schema MUST be valid JSON Schema** (draft-07 or later)
+3. **Execute MUST be idempotent** where possible (safe to retry)
+4. **Execute MUST NOT throw unhandled exceptions** — all errors returned as error maps
+5. **Tool results MUST be JSON-serializable** (Map<String, dynamic> with primitive values)
+
+---
+
+## Error Contract
+
+```dart
+// Success result
+{'result': '42', 'status': 'ok'}
+
+// Error result (returned to AI, not thrown)
+{'error': 'Division by zero', 'status': 'error'}
+```
+
+**Note**: Errors in tool execution are returned as results, not thrown. The AI receives the error context and decides how to respond.
+
+---
+
+## Schema Validation
+
+The framework validates tool call arguments against `inputSchema` before calling `onCall`. If validation fails, the framework returns an error to the AI without invoking `onCall`.
+
+---
+
+## Performance Contract
+
+- **Tool execution timeout**: 30 seconds default (configurable per tool)
+- **Synchronous tools**: Should complete in <100ms
+- **Async tools** (network): Should complete in <10s
+- **Concurrent tool calls**: Supported by dartantic_ai framework

--- a/specs/004-migrate-langchain-dartantic/data-model.md
+++ b/specs/004-migrate-langchain-dartantic/data-model.md
@@ -1,0 +1,152 @@
+# Data Model: LangChain → dartantic_ai Migration
+
+**Date**: 2026-04-21  
+**Feature**: Migrate AI Orchestration Framework
+
+---
+
+## Entity Mapping Overview
+
+This migration replaces framework-level types while preserving all domain entities. No database schema changes are required.
+
+### Preserved Domain Entities (No Changes)
+
+| Entity                                          | Storage        | Status    |
+| ----------------------------------------------- | -------------- | --------- |
+| **Conversation**                                | Drift (SQLite) | Unchanged |
+| **MessageEntity**                               | Drift (SQLite) | Unchanged |
+| **MessageToolCallEntity**                       | Drift (SQLite) | Unchanged |
+| **WorkspaceModelSelectionWithConnectionEntity** | Drift (SQLite) | Unchanged |
+| **Provider Configuration**                      | Drift (SQLite) | Unchanged |
+
+### Replaced Framework Types
+
+| Domain Concept    | Old Type (LangChain)                        | New Type (dartantic_ai)                           |
+| ----------------- | ------------------------------------------- | ------------------------------------------------- |
+| Chat model        | `BaseChatModel`                             | `Agent`                                           |
+| Provider instance | `ChatOpenAI`, `ChatAnthropic`               | `Agent('openai')`, `Agent('anthropic')`           |
+| Chat message      | `ChatMessage`                               | `ChatMessage`                                     |
+| User message      | `ChatMessage.humanText()`                   | `ChatMessage.user()`                              |
+| Assistant message | `ChatMessage.ai()`                          | `ChatMessage.assistant()`                         |
+| Tool message      | `ChatMessage.tool()`                        | `ChatMessage.tool()`                              |
+| Tool call         | `AIChatMessageToolCall`                     | `ToolCall`                                        |
+| Tool spec         | `ToolSpec`                                  | `Tool` (unified)                                  |
+| Executable tool   | `Tool.fromFunction()`                       | `Tool(name, description, inputSchema, onCall)`    |
+| Prompt wrapper    | `PromptValue.chat()`                        | `List<ChatMessage>` (passed directly)             |
+| Stream result     | `ChatResult`                                | `ChatResult`                                      |
+| Token usage       | `LanguageModelUsage`                        | `LanguageModelUsage`                              |
+| Finish reason     | `FinishReason`                              | Inferred from output                              |
+| Model options     | `ChatOpenAIOptions`, `ChatAnthropicOptions` | Provider-specific options via `Agent` constructor |
+
+---
+
+## Message Conversion Flow
+
+```
+MessageEntity (domain)
+  → ChatMessage (dartantic)
+    → Agent.sendStream(history: [...])
+      → ChatResult (stream chunk)
+        → MessageEntity (domain, persisted)
+```
+
+### Conversion Rules
+
+1. **User message** (`isUser == true`):
+   - Input: `MessageEntity` with role `user`
+   - Output: `ChatMessage.user(content: entity.content)`
+
+2. **Assistant message** (`isUser == false`, no tool calls):
+   - Input: `MessageEntity` with role `assistant`
+   - Output: `ChatMessage.assistant(content: entity.content)`
+
+3. **Assistant message with tool calls**:
+   - Input: `MessageEntity` with `toolCalls` list
+   - Output: `ChatMessage.assistant(content: entity.content, toolCalls: mappedCalls)`
+
+4. **Tool result message**:
+   - Input: `MessageEntity` with role `tool`
+   - Output: `ChatMessage.tool(content: entity.content, toolCallId: entity.toolCallId)`
+
+5. **System message**:
+   - Input: System prompt string
+   - Output: `ChatMessage.system(content: prompt)`
+
+---
+
+## Tool Conversion Flow
+
+### Built-in Tools
+
+```
+NativeToolEntity
+  → ToolSpec (existing, from LangChain)
+    → Tool (dartantic)
+```
+
+**Mapping**:
+
+- `name` → `name`
+- `description` → `description`
+- `inputJsonSchema` → `inputSchema` (via `Schema.fromMap()`)
+- `execute()` function → `onCall` callback
+
+### MCP Tools
+
+```
+McpServer
+  → getToolSpec() → ToolSpec (existing)
+    → Tool (dartantic)
+```
+
+**Note**: MCP tool specs are converted to dartantic `Tool` at the boundary where they are passed to the agent.
+
+---
+
+## Provider Configuration Mapping
+
+### Built-in Provider Prefixes
+
+| Provider      | dartantic Prefix | Default Model                 | API Key Env          |
+| ------------- | ---------------- | ----------------------------- | -------------------- |
+| OpenAI        | `openai`         | `gpt-4o`                      | `OPENAI_API_KEY`     |
+| Anthropic     | `anthropic`      | `claude-sonnet-4-0`           | `ANTHROPIC_API_KEY`  |
+| Google        | `google`         | `gemini-2.5-flash`            | `GEMINI_API_KEY`     |
+| Mistral       | `mistral`        | `mistral-small-latest`        | `MISTRAL_API_KEY`    |
+| Cohere        | `cohere`         | `command-r-08-2024`           | `COHERE_API_KEY`     |
+| Ollama        | `ollama`         | `qwen2.5:7b-instruct`         | None (local)         |
+| OpenRouter    | `openrouter`     | `google/gemini-2.5-flash`     | `OPENROUTER_API_KEY` |
+| xAI           | `xai`            | `grok-4-1-fast-non-reasoning` | `XAI_API_KEY`        |
+| xAI Responses | `xai-responses`  | `grok-4-1-fast-non-reasoning` | `XAI_API_KEY`        |
+
+### Custom Provider
+
+```dart
+final provider = OpenAIProvider(
+  apiKey: apiKey,
+  baseUrl: Uri.parse(customUrl),
+  headers: customHeaders,
+);
+final agent = Agent.forProvider(provider);
+```
+
+---
+
+## State Transitions (Conversation Lifecycle)
+
+No state transitions change. The same lifecycle applies:
+
+1. **Created**: Conversation initialized with provider config
+2. **Active**: Messages streaming, tools executing
+3. **Completed**: Response finished, tokens recorded
+4. **Error**: Failure handled, error context passed to AI
+
+---
+
+## Validation Rules
+
+- Provider prefix MUST map to a dartantic_ai built-in provider or a registered custom provider
+- Model ID MUST be valid for the selected provider
+- Custom base URL MUST be a valid HTTP/HTTPS URI
+- Tool schemas MUST conform to JSON Schema draft-07
+- API keys MUST be decrypted before passing to provider constructors

--- a/specs/004-migrate-langchain-dartantic/data-model.md
+++ b/specs/004-migrate-langchain-dartantic/data-model.md
@@ -21,22 +21,23 @@ This migration replaces framework-level types while preserving all domain entiti
 
 ### Replaced Framework Types
 
-| Domain Concept    | Old Type (LangChain)                        | New Type (dartantic_ai)                           |
-| ----------------- | ------------------------------------------- | ------------------------------------------------- |
-| Chat model        | `BaseChatModel`                             | `Agent`                                           |
-| Provider instance | `ChatOpenAI`, `ChatAnthropic`               | `Agent('openai')`, `Agent('anthropic')`           |
-| Chat message      | `ChatMessage`                               | `ChatMessage`                                     |
-| User message      | `ChatMessage.humanText()`                   | `ChatMessage.user()`                              |
-| Assistant message | `ChatMessage.ai()`                          | `ChatMessage.assistant()`                         |
-| Tool message      | `ChatMessage.tool()`                        | `ChatMessage.tool()`                              |
-| Tool call         | `AIChatMessageToolCall`                     | `ToolCall`                                        |
-| Tool spec         | `ToolSpec`                                  | `Tool` (unified)                                  |
-| Executable tool   | `Tool.fromFunction()`                       | `Tool(name, description, inputSchema, onCall)`    |
-| Prompt wrapper    | `PromptValue.chat()`                        | `List<ChatMessage>` (passed directly)             |
-| Stream result     | `ChatResult`                                | `ChatResult`                                      |
-| Token usage       | `LanguageModelUsage`                        | `LanguageModelUsage`                              |
-| Finish reason     | `FinishReason`                              | Inferred from output                              |
-| Model options     | `ChatOpenAIOptions`, `ChatAnthropicOptions` | Provider-specific options via `Agent` constructor |
+| Domain Concept    | Old Type (LangChain)                        | New Type (dartantic_ai)                                  |
+| ----------------- | ------------------------------------------- | -------------------------------------------------------- |
+| Chat model        | `BaseChatModel`                             | `ChatModel` (via `ProviderFactory.call()`)               |
+| Provider instance | `ChatOpenAI`, `ChatAnthropic`               | `ProviderFactory.call(providerType, modelId, apiKey)`    |
+| Chat message      | `ChatMessage`                               | `ChatMessage`                                            |
+| User message      | `ChatMessage.humanText()`                   | `ChatMessage.user()`                                     |
+| Assistant message | `ChatMessage.ai()`                          | `ChatMessage.assistant()`                                |
+| Tool message      | `ChatMessage.tool()`                        | `ChatMessage.tool()`                                     |
+| Tool call         | `AIChatMessageToolCall`                     | `ToolCall`                                               |
+| Tool spec         | `ToolSpec`                                  | `Tool` (unified)                                         |
+| Executable tool   | `Tool.fromFunction()`                       | `Tool(name, description, inputSchema, onCall)`           |
+| Prompt builder    | `PromptValue.chat()`                        | `BuildPromptChatMessages` → `List<ChatMessage>`          |
+| Stream result     | `ChatResult`                                | `ChatResult<ChatMessage>`                                |
+| Token usage       | `LanguageModelUsage`                        | `LanguageModelUsage`                                     |
+| Finish reason     | `FinishReason`                              | Inferred from output                                     |
+| Model options     | `ChatOpenAIOptions`, `ChatAnthropicOptions` | Provider-specific options via `ProviderFactory`          |
+| Tool adapter      | N/A                                         | `ToolAdapter` (converts domain tools → dartantic `Tool`) |
 
 ---
 
@@ -44,9 +45,9 @@ This migration replaces framework-level types while preserving all domain entiti
 
 ```
 MessageEntity (domain)
-  → ChatMessage (dartantic)
-    → Agent.sendStream(history: [...])
-      → ChatResult (stream chunk)
+  → BuildPromptChatMessages → List<ChatMessage> (dartantic)
+    → ChatModel.sendStream(prompt, history: messages)
+      → ChatResult<ChatMessage> (stream chunk, accumulated via ChatResultConcat)
         → MessageEntity (domain, persisted)
 ```
 
@@ -99,7 +100,7 @@ McpServer
     → Tool (dartantic)
 ```
 
-**Note**: MCP tool specs are converted to dartantic `Tool` at the boundary where they are passed to the agent.
+**Note**: MCP tool specs are converted to dartantic `Tool` at the boundary via `ToolAdapter` where they are passed to the chat model.
 
 ---
 
@@ -122,12 +123,12 @@ McpServer
 ### Custom Provider
 
 ```dart
-final provider = OpenAIProvider(
+final chatModel = ProviderFactory.call(
   apiKey: apiKey,
-  baseUrl: Uri.parse(customUrl),
+  baseUrl: customUrl != null ? Uri.parse(customUrl) : null,
   headers: customHeaders,
+  // ...other provider config
 );
-final agent = Agent.forProvider(provider);
 ```
 
 ---

--- a/specs/004-migrate-langchain-dartantic/plan.md
+++ b/specs/004-migrate-langchain-dartantic/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Migrate AI Orchestration Framework
+
+**Branch**: `004-migrate-langchain-dartantic` | **Date**: 2026-04-21 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/004-migrate-langchain-dartantic/spec.md`
+
+## Summary
+
+Replace all LangChain Dart usage (`langchain`, `langchain_openai`, `langchain_anthropic`) with `dartantic_ai` across the AuraVibes Flutter monorepo. This is a big-bang migration that preserves all user-facing behavior including chat, streaming, tool calling, MCP integration, token usage tracking, and multi-provider support, while enabling all dartantic_ai built-in providers via models.dev integration.
+
+## Technical Context
+
+**Language/Version**: Dart 3.11+ (FVM pinned to 3.41.4+)  
+**Primary Dependencies**: Flutter SDK, Riverpod (with code generation), dartantic_ai, Drift  
+**Storage**: Drift (SQLite) — no schema changes required  
+**Testing**: flutter_test, mockito, very_good_analysis linting  
+**Target Platform**: iOS, Android, macOS, Windows, Linux, Web  
+**Project Type**: Flutter monorepo (cross-platform AI assistant app)  
+**Performance Goals**: First-token latency <2s, end-to-end response time within 10% of current baseline, 60 fps during streaming  
+**Constraints**: Must pass `very_good_analysis` with zero warnings, 80%+ coverage for new tests, single commit big-bang migration  
+**Scale/Scope**: 22 files directly affected across service layer, tool system, streaming pipeline, and test suite
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle                         | Status  | Notes                                                |
+| --------------------------------- | ------- | ---------------------------------------------------- |
+| I. Start with User Needs          | ✅ PASS | 5 prioritized user stories with acceptance scenarios |
+| II. Design with Data              | ✅ PASS | Key entities defined; no schema changes needed       |
+| III. Package-First Architecture   | ✅ PASS | Migration stays within existing app structure        |
+| IV. UI Kit Mandate                | ✅ PASS | No UI changes required                               |
+| V. Test-Driven Development        | ✅ PASS | 100% existing tests + new targeted tests required    |
+| VI. Fail Fast + Explicit Errors   | ✅ PASS | Edge cases cover error scenarios                     |
+| VII. Simplicity + YAGNI           | ✅ PASS | Big-bang approach minimizes complexity               |
+| VIII. Observability + Performance | ✅ PASS | Latency targets defined (within 10%)                 |
+| IX. Security + Privacy            | ✅ PASS | API key handling unchanged (secure storage)          |
+| X. Code Quality Standards         | ✅ PASS | Must pass very_good_analysis with zero warnings      |
+
+**Result**: All gates pass. Proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-migrate-langchain-dartantic/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+apps/auravibes_app/
+├── lib/
+│   ├── services/
+│   │   ├── chatbot_service/           # Chat model init, streaming, title gen
+│   │   │   ├── chatbot_service.dart
+│   │   │   ├── build_prompt_chat_messages.dart
+│   │   │   └── models/
+│   │   │       └── chat_message_models.dart
+│   │   └── tools/                     # Tool definitions and specs
+│   │       ├── native_tool_entity.dart
+│   │       ├── user_tools_entity.dart
+│   │       └── native_tools/
+│   │           ├── calculator_tool.dart
+│   │           └── url_tool.dart
+│   ├── features/
+│   │   └── chats/
+│   │       ├── usecases/
+│   │       │   └── continue_agent_usecase.dart
+│   │       └── notifiers/
+│   │           └── messages_streaming_notifier.dart
+│   ├── domain/
+│   │   └── usecases/
+│   │       └── tools/
+│   │           └── mcp/
+│   │               └── build_combined_tool_specs_usecase.dart
+│   └── utils/
+│       └── chat_result_extension.dart
+└── test/
+    ├── services/chatbot_service/
+    ├── features/chats/usecases/
+    └── domain/usecases/tools/mcp/
+```
+
+**Structure Decision**: This migration is confined to the existing `apps/auravibes_app` service and feature layers. No new packages or directories are created. LangChain dependencies are removed from `pubspec.yaml` and replaced with `dartantic_ai`.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations detected. All constitution gates pass.
+
+---
+
+## Generated Artifacts
+
+| Artifact         | Path                                                               | Phase   |
+| ---------------- | ------------------------------------------------------------------ | ------- |
+| Research         | [research.md](research.md)                                         | Phase 0 |
+| Data Model       | [data-model.md](data-model.md)                                     | Phase 1 |
+| Quickstart       | [quickstart.md](quickstart.md)                                     | Phase 1 |
+| Service Contract | [contracts/chatbot_service.md](contracts/chatbot_service.md)       | Phase 1 |
+| Tool Contract    | [contracts/tool_definition.md](contracts/tool_definition.md)       | Phase 1 |
+| Message Contract | [contracts/message_conversion.md](contracts/message_conversion.md) | Phase 1 |

--- a/specs/004-migrate-langchain-dartantic/plan.md
+++ b/specs/004-migrate-langchain-dartantic/plan.md
@@ -61,12 +61,14 @@ apps/auravibes_app/
 │   │   ├── chatbot_service/           # Chat model init, streaming, title gen
 │   │   │   ├── chatbot_service.dart
 │   │   │   ├── build_prompt_chat_messages.dart
+│   │   │   ├── provider_factory.dart  # Creates ChatModel from provider config
+│   │   │   ├── tool_adapter.dart      # Converts domain tools → dartantic Tool
 │   │   │   └── models/
 │   │   │       └── chat_message_models.dart
 │   │   └── tools/                     # Tool definitions and specs
 │   │       ├── native_tool_entity.dart
 │   │       ├── user_tools_entity.dart
-│   │       └── native_tools/
+│   │       └── user_tools/
 │   │           ├── calculator_tool.dart
 │   │           └── url_tool.dart
 │   ├── features/
@@ -88,7 +90,7 @@ apps/auravibes_app/
     └── domain/usecases/tools/mcp/
 ```
 
-**Structure Decision**: This migration is confined to the existing `apps/auravibes_app` service and feature layers. No new packages or directories are created. LangChain dependencies are removed from `pubspec.yaml` and replaced with `dartantic_ai`.
+**Structure Decision**: This migration is confined to the existing `apps/auravibes_app` service and feature layers. `provider_factory.dart` and `tool_adapter.dart` are added under `services/chatbot_service/`. LangChain dependencies are removed from `pubspec.yaml` and replaced with `dartantic_ai`. The orchestration flow is: `ProviderFactory` → `ChatModel.sendStream()` → `ChatResultConcat` → approval pipeline.
 
 ## Complexity Tracking
 

--- a/specs/004-migrate-langchain-dartantic/quickstart.md
+++ b/specs/004-migrate-langchain-dartantic/quickstart.md
@@ -1,0 +1,199 @@
+# Quickstart: LangChain → dartantic_ai Migration
+
+**Date**: 2026-04-21  
+**Feature**: Migrate AI Orchestration Framework
+
+---
+
+## Prerequisites
+
+- Flutter SDK 3.41.4+ (via FVM)
+- Dart 3.11+
+- Melos configured (`fvm dart run melos bootstrap`)
+- All existing tests passing on current branch
+
+---
+
+## Migration Steps
+
+### Step 1: Update Dependencies
+
+In `apps/auravibes_app/pubspec.yaml`:
+
+**Remove**:
+
+```yaml
+langchain: ^0.8.1
+langchain_anthropic: ^0.3.0+1
+langchain_openai: ^0.8.1
+```
+
+**Add**:
+
+```yaml
+dartantic_ai: ^3.4.0
+```
+
+Run:
+
+```bash
+fvm flutter pub get
+```
+
+### Step 2: Migrate ChatbotService
+
+Replace `BaseChatModel` initialization with `Agent` creation:
+
+**Before**:
+
+```dart
+final model = ChatOpenAI(
+  apiKey: decryptedKey,
+  defaultOptions: ChatOpenAIOptions(model: modelId, tools: toolSpecs),
+);
+```
+
+**After**:
+
+```dart
+final agent = Agent(
+  'openai:$modelId',
+  tools: tools, // List<Tool>
+);
+```
+
+For custom endpoints:
+
+```dart
+final provider = OpenAIProvider(
+  apiKey: decryptedKey,
+  baseUrl: Uri.parse(customUrl),
+  headers: customHeaders,
+);
+final agent = Agent.forProvider(provider);
+```
+
+### Step 3: Migrate Message Conversion
+
+**Before**:
+
+```dart
+ChatMessage.humanText(content);
+ChatMessage.ai(content: content, toolCalls: calls);
+ChatMessage.tool(content, toolCallId: id);
+```
+
+**After**:
+
+```dart
+ChatMessage.user(content);
+ChatMessage.assistant(content, toolCalls: calls);
+ChatMessage.tool(content, toolCallId: id);
+```
+
+### Step 4: Migrate Tool Definitions
+
+**Before**:
+
+```dart
+final toolSpec = ToolSpec(
+  name: 'get_weather',
+  description: 'Get weather',
+  inputJsonSchema: {'type': 'object', 'properties': {...}},
+);
+final tool = Tool.fromFunction<Input, Output>(
+  name: 'get_weather',
+  description: 'Get weather',
+  inputJsonSchema: schema,
+  func: (input) async => {...},
+);
+```
+
+**After**:
+
+```dart
+final tool = Tool(
+  name: 'get_weather',
+  description: 'Get weather',
+  inputSchema: Schema.fromMap({'type': 'object', 'properties': {...}}),
+  onCall: (args) async => {'temp': 72},
+);
+```
+
+### Step 5: Migrate Streaming
+
+**Before**:
+
+```dart
+final stream = model.stream(PromptValue.chat(messages));
+await for (final chunk in stream) {
+  final text = chunk.outputAsString;
+  final usage = chunk.usage;
+}
+```
+
+**After**:
+
+```dart
+final stream = agent.sendStream(prompt, history: messages);
+await for (final chunk in stream) {
+  final text = chunk.output;
+  final usage = chunk.usage;
+}
+```
+
+### Step 6: Migrate Token Usage Extraction
+
+No changes needed — `LanguageModelUsage` structure is the same:
+
+```dart
+final usage = result.usage;
+print('Prompt: ${usage.promptTokens}');
+print('Response: ${usage.responseTokens}');
+print('Total: ${usage.totalTokens}');
+```
+
+### Step 7: Update Tests
+
+1. Remove LangChain-specific mocks
+2. Add dartantic_ai-specific test utilities
+3. Verify all existing assertions still pass
+
+Run tests:
+
+```bash
+fvm flutter test --no-pub
+```
+
+### Step 8: Validate
+
+```bash
+# Format
+fvm dart format --set-exit-if-changed .
+
+# Analyze
+fvm dart analyze --fatal-infos
+
+# Tests
+fvm flutter test
+
+# Full validation
+fvm dart run melos run validate
+```
+
+---
+
+## Verification Checklist
+
+- [ ] All LangChain imports removed
+- [ ] dartantic_ai imports added
+- [ ] `Agent` created for all provider types
+- [ ] Custom URLs configured via `OpenAIProvider`
+- [ ] Messages converted to dartantic `ChatMessage`
+- [ ] Tools converted to dartantic `Tool`
+- [ ] Streaming uses `agent.sendStream()`
+- [ ] Token usage extracted from `ChatResult.usage`
+- [ ] 100% existing tests pass
+- [ ] New targeted tests added
+- [ ] Zero analysis warnings
+- [ ] No performance regression (>10%)

--- a/specs/004-migrate-langchain-dartantic/quickstart.md
+++ b/specs/004-migrate-langchain-dartantic/quickstart.md
@@ -37,12 +37,13 @@ dartantic_ai: ^3.4.0
 Run:
 
 ```bash
-fvm flutter pub get
+fvm flutter pub remove langchain langchain_anthropic langchain_openai
+fvm flutter pub add dartantic_ai:^3.4.0
 ```
 
 ### Step 2: Migrate ChatbotService
 
-Replace `BaseChatModel` initialization with `Agent` creation:
+Replace `BaseChatModel` initialization with `ChatModel` via `ProviderFactory`:
 
 **Before**:
 
@@ -56,21 +57,20 @@ final model = ChatOpenAI(
 **After**:
 
 ```dart
-final agent = Agent(
-  'openai:$modelId',
-  tools: tools, // List<Tool>
+final chatModel = ProviderFactory.call(
+  apiKey: decryptedKey,
+  // ...provider configuration
 );
 ```
 
 For custom endpoints:
 
 ```dart
-final provider = OpenAIProvider(
+final chatModel = ProviderFactory.call(
   apiKey: decryptedKey,
   baseUrl: Uri.parse(customUrl),
   headers: customHeaders,
 );
-final agent = Agent.forProvider(provider);
 ```
 
 ### Step 3: Migrate Message Conversion
@@ -120,6 +120,8 @@ final tool = Tool(
 );
 ```
 
+**Note**: In the actual codebase, `ToolAdapter` handles converting domain tool definitions to dartantic `Tool` objects.
+
 ### Step 5: Migrate Streaming
 
 **Before**:
@@ -135,12 +137,16 @@ await for (final chunk in stream) {
 **After**:
 
 ```dart
-final stream = agent.sendStream(prompt, history: messages);
+final stream = chatModel.sendStream(prompt, history: messages);
 await for (final chunk in stream) {
-  final text = chunk.output;
+  // chunk is ChatResult<ChatMessage> — accumulate deltas with ChatResultConcat
+  final text = chunk.output.text;
+  final toolCalls = chunk.output.toolCalls;
   final usage = chunk.usage;
 }
 ```
+
+**Note**: The app manages the agent loop (tool call → tool result → continue), NOT dartantic. Use `ChatResultConcat` extension to accumulate streaming deltas into a complete result.
 
 ### Step 6: Migrate Token Usage Extraction
 
@@ -187,12 +193,13 @@ fvm dart run melos run validate
 
 - [ ] All LangChain imports removed
 - [ ] dartantic_ai imports added
-- [ ] `Agent` created for all provider types
-- [ ] Custom URLs configured via `OpenAIProvider`
+- [ ] `ChatModel` created via `ProviderFactory` for all provider types
+- [ ] Custom URLs configured via `ProviderFactory` parameters
 - [ ] Messages converted to dartantic `ChatMessage`
-- [ ] Tools converted to dartantic `Tool`
-- [ ] Streaming uses `agent.sendStream()`
-- [ ] Token usage extracted from `ChatResult.usage`
+- [ ] Tools converted via `ToolAdapter` to dartantic `Tool`
+- [ ] Streaming uses `chatModel.sendStream()`
+- [ ] Stream yields `ChatResult<ChatMessage>` with `.output.text`, `.output.toolCalls`, `.usage`
+- [ ] Deltas accumulated via `ChatResultConcat`
 - [ ] 100% existing tests pass
 - [ ] New targeted tests added
 - [ ] Zero analysis warnings

--- a/specs/004-migrate-langchain-dartantic/research.md
+++ b/specs/004-migrate-langchain-dartantic/research.md
@@ -1,0 +1,178 @@
+# Research: LangChain → dartantic_ai Migration
+
+**Date**: 2026-04-21  
+**Feature**: Migrate AI Orchestration Framework  
+**Scope**: Service layer replacement within `apps/auravibes_app`
+
+---
+
+## Decision Log
+
+### 1. Framework Choice: dartantic_ai
+
+**Decision**: Use `dartantic_ai` (v3.4.0) as the replacement for LangChain Dart.
+
+**Rationale**:
+
+- Active maintenance (last published 2026-04-02) vs. LangChain Dart which has been lagging
+- Simpler unified API across all providers
+- Built-in retry logic, streaming, tool calling, MCP support, and embeddings
+- Better Flutter ecosystem integration (optional `dartantic_chat` package)
+- Supports all required features: custom base URLs, custom headers, streaming, tool calling, token usage tracking
+
+**Alternatives considered**:
+
+- Keep LangChain Dart: Rejected due to maintenance concerns and limited provider support
+- Use raw HTTP clients per provider: Rejected due to excessive boilerplate and loss of unified abstractions
+- Use `ollama_dart` + other SDKs directly: Rejected due to fragmentation
+
+### 2. Migration Strategy: Big-Bang
+
+**Decision**: Replace all LangChain usage in a single commit/PR.
+
+**Rationale**:
+
+- LangChain types permeate the service layer; partial migration would create hybrid state
+- 22 files affected but mostly concentrated in 3-4 core service files
+- dartantic_ai provides a clean break with no need for transitional abstractions
+- User explicitly chose big-bang during clarification
+
+**Risk mitigation**:
+
+- Comprehensive test coverage required before merge
+- Feature branch isolation allows full validation
+- No runtime toggles or fallback code needed
+
+### 3. Provider Scope: All Built-In Providers
+
+**Decision**: Enable all dartantic_ai built-in providers via models.dev integration.
+
+**Rationale**:
+
+- dartantic_ai ships with 10+ providers (OpenAI, Anthropic, Google, Mistral, Cohere, Ollama, OpenRouter, xAI, etc.)
+- models.dev already provides dynamic LLM vendor fetching
+- Minimal extra work once the first provider is wired correctly
+
+**Implementation note**:
+
+- Provider configuration mapping needs to translate models.dev vendor IDs to dartantic_ai provider prefixes
+- Custom provider endpoints use `OpenAIProvider(baseUrl: ...)` via `Agent.forProvider()`
+
+### 4. MCP Integration: Preserve Existing
+
+**Decision**: Keep the existing custom MCP connection manager and tool spec lookup.
+
+**Rationale**:
+
+- MCP infrastructure is separate from the LangChain chat model layer
+- dartantic_ai has built-in `McpClient`, but migration scope should be focused
+- Existing MCP code works with `ToolSpec` which is conceptually similar to dartantic's `Tool`
+- Reduces risk by not touching working MCP code
+
+### 5. Tool System: Adapt to dartantic Tool API
+
+**Decision**: Convert tool definitions from LangChain's `ToolSpec` + `Tool.fromFunction` to dartantic_ai's `Tool` class.
+
+**Rationale**:
+
+- dartantic_ai unifies tool schema and execution in a single `Tool` class
+- Input schema uses `Schema.fromMap()` or `S.object()` instead of raw JSON schema maps
+- `onCall` callback replaces `Tool.fromFunction` pattern
+- Built-in tools (calculator, URL fetcher) need conversion
+- MCP tools remain unchanged since they use existing infrastructure
+
+**Mapping**:
+| LangChain | dartantic_ai |
+|-----------|-------------|
+| `ToolSpec(name, description, inputJsonSchema)` | `Tool(name, description, inputSchema, onCall)` |
+| `Tool.fromFunction<Input, Output>()` | `Tool(name, description, inputSchema, onCall)` |
+| `ToolOptions` | Not needed (options embedded in `Tool`) |
+
+### 6. Message Format: dartantic ChatMessage
+
+**Decision**: Convert domain `MessageEntity` objects to dartantic_ai's `ChatMessage` format.
+
+**Rationale**:
+
+- dartantic_ai uses `ChatMessage` list for history instead of LangChain's `ChatMessage.humanText()` / `.ai()` / `.tool()` factory constructors
+- History is passed explicitly to each `agent.send()` / `agent.sendStream()` call
+- Message parts include text, tool calls, tool results, and thinking parts
+
+**Mapping**:
+| LangChain | dartantic_ai |
+|-----------|-------------|
+| `ChatMessage.humanText(content)` | `ChatMessage.user(content)` |
+| `ChatMessage.ai(content, toolCalls: ...)` | `ChatMessage.assistant(content, toolCalls: ...)` |
+| `ChatMessage.tool(content, toolCallId: ...)` | `ChatMessage.tool(content, toolCallId: ...)` |
+| `PromptValue.chat(messages)` | Pass `List<ChatMessage>` directly |
+
+### 7. Streaming: agent.sendStream()
+
+**Decision**: Use `agent.sendStream()` for streaming responses.
+
+**Rationale**:
+
+- Returns `Stream<ChatResult>` just like LangChain's `BaseChatModel.stream()`
+- Chunks have `.output` (string) and `.usage` properties
+- Accumulate chunks with `.concat()` equivalent (manual accumulation or use result)
+
+**Mapping**:
+| LangChain | dartantic_ai |
+|-----------|-------------|
+| `model.stream(PromptValue.chat(messages))` | `agent.sendStream(prompt, history: messages)` |
+| `ChatResult.outputAsString` | `ChatResult.output` (or chunk text) |
+| `ChatResult.concat(results)` | Manual accumulation or use final result |
+
+### 8. Token Usage: LanguageModelUsage
+
+**Decision**: Use dartantic_ai's `LanguageModelUsage` for token tracking.
+
+**Rationale**:
+
+- dartantic_ai exposes `result.usage.promptTokens`, `responseTokens`, `totalTokens`
+- Same structure as LangChain's `LanguageModelUsage`
+- Minimal changes needed in `chat_result_extension.dart`
+
+### 9. Testing Strategy: Existing + Targeted New Tests
+
+**Decision**: All existing tests pass + add new tests for dartantic-specific integration.
+
+**Rationale**:
+
+- Existing tests validate user-facing behavior (regression prevention)
+- New tests cover provider initialization, message mapping, and streaming behavior
+- dartantic_ai has different internal types that need mock coverage
+
+**New test areas**:
+
+- Provider factory mapping (models.dev vendor → dartantic provider)
+- Message entity → dartantic ChatMessage conversion
+- Tool spec → dartantic Tool conversion
+- Streaming chunk accumulation
+- Custom base URL / header configuration
+
+---
+
+## Open Questions Resolved
+
+| Question            | Resolution                                           | Source           |
+| ------------------- | ---------------------------------------------------- | ---------------- |
+| Custom URL support? | `OpenAIProvider(baseUrl: Uri.parse(...))`            | dartantic docs   |
+| Custom headers?     | `headers: {...}` on any provider                     | dartantic docs   |
+| Tool calling API?   | `Tool` class with `inputSchema` + `onCall`           | dartantic docs   |
+| MCP support?        | Built-in `McpClient` available, but we keep existing | Clarification Q4 |
+| All providers?      | Yes, enable all built-in providers                   | Clarification Q3 |
+| Rollback?           | No rollback, fix forward                             | Clarification Q2 |
+
+---
+
+## Risk Assessment
+
+| Risk                          | Likelihood | Impact | Mitigation                        |
+| ----------------------------- | ---------- | ------ | --------------------------------- |
+| dartantic_ai API changes      | Low        | High   | Pin version, monitor changelog    |
+| Provider-specific quirks      | Medium     | Medium | Test each major provider category |
+| Tool call format differences  | Medium     | Medium | Comprehensive tool tests          |
+| Streaming behavior changes    | Low        | High   | Validate token-by-token output    |
+| Performance regression        | Low        | Medium | Benchmark before/after            |
+| Missing provider in dartantic | Low        | High   | Verify models.dev vendor mapping  |

--- a/specs/004-migrate-langchain-dartantic/spec.md
+++ b/specs/004-migrate-langchain-dartantic/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `004-migrate-langchain-dartantic`  
 **Created**: 2026-04-21  
 **Status**: Draft  
-**Input**: User description: "the change from lanchaing to dartantic_ai"
+**Input**: User description: "the change from LangChain to dartantic_ai"
 
 ## User Scenarios & Testing _(mandatory)_
 

--- a/specs/004-migrate-langchain-dartantic/spec.md
+++ b/specs/004-migrate-langchain-dartantic/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Migrate AI Orchestration Framework
+
+**Feature Branch**: `004-migrate-langchain-dartantic`  
+**Created**: 2026-04-21  
+**Status**: Draft  
+**Input**: User description: "the change from lanchaing to dartantic_ai"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Seamless Chat Experience (Priority: P1)
+
+As an end user, I can start a conversation, send messages, and receive AI responses so that I can interact with the assistant without any disruption.
+
+**Why this priority**: Chat is the core feature of the application. Any regression here directly impacts all users.
+
+**Independent Test**: A user can open a new conversation, type a message, and receive a coherent response. The experience must be indistinguishable from the current implementation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new conversation, **When** the user sends a text message, **Then** the AI responds with a relevant answer within the same time bounds as before.
+2. **Given** an ongoing conversation, **When** the user sends a follow-up message, **Then** the AI retains context and responds appropriately.
+3. **Given** a conversation with multiple messages, **When** the user scrolls through history, **Then** all messages display correctly with proper sender attribution.
+
+---
+
+### User Story 2 - Tool-Assisted Conversations (Priority: P2)
+
+As an end user, I can ask questions that require tools (such as calculations or web lookups) so that the AI can provide accurate, real-time information.
+
+**Why this priority**: Tool calling is a key differentiator. Users expect the assistant to perform actions beyond simple text generation.
+
+**Independent Test**: A user can ask a question that triggers a built-in tool, and the AI seamlessly incorporates the tool result into its response.
+
+**Acceptance Scenarios**:
+
+1. **Given** a conversation with no active tools, **When** the user asks for a calculation, **Then** the calculator tool executes and the AI includes the correct result.
+2. **Given** a conversation with external tools enabled, **When** the user asks for a web page summary, **Then** the URL fetch tool retrieves content and the AI summarizes it.
+3. **Given** a conversation with MCP tools connected, **When** the user invokes an MCP capability, **Then** the tool executes and the response is integrated into the chat.
+4. **Given** a tool call that fails, **When** the error occurs, **Then** the AI receives the error context and responds gracefully without crashing.
+
+---
+
+### User Story 3 - Streaming Responses (Priority: P2)
+
+As an end user, I can see the AI response appear word-by-word in real time so that the interaction feels responsive and engaging.
+
+**Why this priority**: Streaming is a critical UX feature. Removing it would make the app feel slow and unresponsive.
+
+**Independent Test**: A user can send a message and observe tokens appearing incrementally rather than waiting for the full response.
+
+**Acceptance Scenarios**:
+
+1. **Given** a stable network connection, **When** the user sends a message, **Then** the response streams token-by-token without stuttering or duplication.
+2. **Given** a long-running response, **When** the stream is active, **Then** the UI remains responsive and the user can scroll and interact.
+3. **Given** a streaming response with tool calls, **Then** the tool execution happens seamlessly and the final output incorporates results correctly.
+
+---
+
+### User Story 4 - Multi-Provider Support (Priority: P3)
+
+As a power user or administrator, I can configure and switch between different AI providers (such as OpenAI, Anthropic, Google, Mistral, and others) so that I can choose models based on preference, cost, or capability.
+
+**Why this priority**: Provider flexibility is important for advanced users but not required for basic chat functionality.
+
+**Independent Test**: A user can select a different provider in settings and start a new conversation that routes to the selected provider.
+
+**Acceptance Scenarios**:
+
+1. **Given** provider configuration for OpenAI, **When** a conversation starts, **Then** messages route to the OpenAI endpoint.
+2. **Given** provider configuration for Anthropic, **When** a conversation starts, **Then** messages route to the Anthropic endpoint.
+3. **Given** provider configuration for any dartantic_ai built-in provider (e.g., Google, Mistral, Cohere), **When** a conversation starts, **Then** messages route to the selected provider's endpoint.
+4. **Given** a custom provider endpoint URL, **When** configured, **Then** requests route to that URL instead of the default.
+
+---
+
+### User Story 5 - Token Usage Tracking (Priority: P3)
+
+As a user or administrator, I can view token usage statistics for conversations so that I can monitor consumption and costs.
+
+**Why this priority**: Usage tracking supports billing transparency and optimization but does not block core chat functionality.
+
+**Independent Test**: After a conversation, the token count for prompt and response is accurately recorded and visible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed conversation, **When** the user views conversation details, **Then** prompt tokens, response tokens, and total tokens are displayed accurately.
+2. **Given** a conversation with tool calls, **When** the usage is calculated, **Then** token counts reflect both chat and tool-related overhead correctly.
+
+---
+
+### Edge Cases
+
+- What happens when the configured API key is invalid or expired? The system should surface a clear error message without crashing.
+- What happens when a tool call times out or returns an unexpected format? The AI should receive an error result and attempt to recover.
+- What happens when the network disconnects mid-stream? The partial response should be preserved and the user notified.
+- What happens when switching providers mid-conversation? The conversation history should remain intact and the new provider should receive correct context.
+- What happens when a provider returns empty or malformed usage metadata? The system should handle gracefully without breaking the UI.
+
+## Clarifications
+
+### Session 2026-04-21
+
+- **Q: Should this be a big-bang replacement or gradual rollout?** → **A: Big-bang** — Replace all LangChain usage in a single commit/PR. All providers switch simultaneously.
+- **Q: Should the migration include a documented rollback procedure?** → **A: No rollback** — Once deployed, issues are fixed forward. No reversion to LangChain is planned or documented.
+- **Q: Should the migration enable additional dartantic_ai providers beyond OpenAI and Anthropic?** → **A: Enable all dartantic providers** — The system uses models.dev to dynamically fetch LLM vendors, so all dartantic_ai built-in providers should be configured and available.
+- **Q: Should the migration replace the existing custom MCP integration with dartantic_ai's built-in McpClient?** → **A: Keep existing MCP** — Retain the current custom MCP connection manager and tool spec lookup. Only replace the LangChain chat model and tool execution layers.
+- **Q: Should new tests be added for dartantic_ai-specific behavior, or only existing tests must pass?** → **A: Existing + targeted new tests** — All existing tests must pass, plus new tests are added for dartantic_ai-specific integration points (provider setup, message mapping, streaming behavior).
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The system MUST support sending messages to AI providers and receiving text responses.
+- **FR-002**: The system MUST stream AI responses token-by-token in real time.
+- **FR-003**: The system MUST support multi-turn conversations with persistent history across messages.
+- **FR-004**: The system MUST support built-in tools (e.g., calculator, URL fetcher) that the AI can invoke autonomously.
+- **FR-005**: The system MUST support external tools via the Model Context Protocol (MCP), allowing integration with third-party tool servers.
+- **FR-006**: The system MUST support multiple AI providers and allow per-conversation or per-workspace provider selection. All dartantic_ai built-in providers MUST be available for selection.
+- **FR-007**: The system MUST support custom provider endpoint URLs and custom HTTP headers for enterprise or proxy configurations.
+- **FR-008**: The system MUST track and expose token usage (prompt tokens, response tokens, total tokens) for each AI interaction.
+- **FR-009**: The system MUST generate conversation titles automatically based on the initial user message.
+- **FR-010**: The system MUST handle tool execution errors gracefully, passing error context back to the AI for recovery.
+- **FR-011**: The system MUST preserve all existing conversation data and behavior without requiring user action or data migration.
+- **FR-012**: The system MUST maintain the same performance characteristics for first-token latency and total response time.
+- **FR-013**: The migration MUST be performed as a big-bang replacement: all LangChain usage is removed and replaced with dartantic_ai in a single deployment. No gradual or partial migration is permitted.
+- **FR-014**: The existing custom MCP integration (connection manager, tool spec lookup, and related infrastructure) MUST be preserved. Only the LangChain-specific chat model and tool execution layers are replaced.
+
+### Key Entities _(include if feature involves data)_
+
+- **Conversation**: A sequence of messages between a user and the AI. Attributes include title, provider configuration, creation timestamp, and associated workspace.
+- **Message**: A single unit of communication within a conversation. Attributes include sender role (user/assistant/tool), content text, tool calls, tool results, token usage, and timestamps.
+- **Tool**: A callable capability exposed to the AI. Attributes include name, description, input schema, and execution logic. Tools may be built-in, native, or sourced from external MCP servers.
+- **Provider Configuration**: Settings defining which AI provider and model to use. Attributes include provider type, model identifier, base endpoint URL, API credentials reference, and custom headers.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Users can complete a multi-turn conversation without experiencing regressions in response quality, latency, or functionality.
+- **SC-002**: 100% of existing automated tests related to chat, tools, and streaming pass without modification to test assertions. Additionally, new targeted tests are added for dartantic_ai-specific integration points including provider initialization, message format conversion, and streaming behavior.
+- **SC-003**: Token usage counts for prompt and response remain accurate within a 5% tolerance compared to the previous implementation.
+- **SC-004**: First-token latency and end-to-end response time for equivalent prompts do not degrade by more than 10%.
+- **SC-005**: All supported tool types (built-in, native, MCP) execute successfully and return results integrated into the AI response.
+- **SC-006**: Custom provider endpoints and headers function identically to default endpoints, with no additional configuration steps required beyond URL and header input.
+- **SC-007**: All dartantic_ai built-in providers are selectable and functional, with chat and streaming capabilities verified for each major provider category.

--- a/specs/004-migrate-langchain-dartantic/spec.md
+++ b/specs/004-migrate-langchain-dartantic/spec.md
@@ -40,6 +40,11 @@ As an end user, I can ask questions that require tools (such as calculations or 
 
 **Agent Loop Architecture**: The app manages the agent loop using `ChatModel.sendStream()` directly (not `Agent.sendStream()`) to prevent dartantic from auto-executing tools. The flow is: model call -> detect tool calls in response -> check permissions via `ApproveToolCallUsecase` -> execute approved tools via `RunAllowedToolsUsecase` -> feed results back as tool messages -> loop. This ensures all tool invocations go through the user approval pipeline.
 
+Example flows:
+
+- **Tool execution**: User asks "What is 2+2?" -> AI generates `calculator` tool call -> app intercepts, auto-approves built-in tool -> calculator returns `4` -> AI incorporates result into response.
+- **Tool failure**: User triggers URL fetch -> tool times out -> error wrapped as tool result -> AI acknowledges error and suggests alternatives.
+
 ---
 
 ### User Story 3 - Streaming Responses (Priority: P2)

--- a/specs/004-migrate-langchain-dartantic/spec.md
+++ b/specs/004-migrate-langchain-dartantic/spec.md
@@ -38,6 +38,8 @@ As an end user, I can ask questions that require tools (such as calculations or 
 3. **Given** a conversation with MCP tools connected, **When** the user invokes an MCP capability, **Then** the tool executes and the response is integrated into the chat.
 4. **Given** a tool call that fails, **When** the error occurs, **Then** the AI receives the error context and responds gracefully without crashing.
 
+**Agent Loop Architecture**: The app manages the agent loop using `ChatModel.sendStream()` directly (not `Agent.sendStream()`) to prevent dartantic from auto-executing tools. The flow is: model call -> detect tool calls in response -> check permissions via `ApproveToolCallUsecase` -> execute approved tools via `RunAllowedToolsUsecase` -> feed results back as tool messages -> loop. This ensures all tool invocations go through the user approval pipeline.
+
 ---
 
 ### User Story 3 - Streaming Responses (Priority: P2)
@@ -90,11 +92,11 @@ As a user or administrator, I can view token usage statistics for conversations 
 
 ### Edge Cases
 
-- What happens when the configured API key is invalid or expired? The system should surface a clear error message without crashing.
-- What happens when a tool call times out or returns an unexpected format? The AI should receive an error result and attempt to recover.
+- What happens when the configured API key is invalid or expired? The system should surface a clear error message (e.g., "Authentication failed. Please check your API key in Settings.") without crashing.
+- What happens when a tool call times out or returns an unexpected format? The AI should receive an error result and attempt to recover. The partial response is preserved with error status.
 - What happens when the network disconnects mid-stream? The partial response should be preserved and the user notified.
 - What happens when switching providers mid-conversation? The conversation history should remain intact and the new provider should receive correct context.
-- What happens when a provider returns empty or malformed usage metadata? The system should handle gracefully without breaking the UI.
+- What happens when a provider returns empty or malformed usage metadata? The system should handle gracefully without breaking the UI. Token counts default to 0.
 
 ## Clarifications
 
@@ -103,7 +105,7 @@ As a user or administrator, I can view token usage statistics for conversations 
 - **Q: Should this be a big-bang replacement or gradual rollout?** → **A: Big-bang** — Replace all LangChain usage in a single commit/PR. All providers switch simultaneously.
 - **Q: Should the migration include a documented rollback procedure?** → **A: No rollback** — Once deployed, issues are fixed forward. No reversion to LangChain is planned or documented.
 - **Q: Should the migration enable additional dartantic_ai providers beyond OpenAI and Anthropic?** → **A: Enable all dartantic providers** — The system uses models.dev to dynamically fetch LLM vendors, so all dartantic_ai built-in providers should be configured and available.
-- **Q: Should the migration replace the existing custom MCP integration with dartantic_ai's built-in McpClient?** → **A: Keep existing MCP** — Retain the current custom MCP connection manager and tool spec lookup. Only replace the LangChain chat model and tool execution layers.
+- **Q: Should the migration replace the existing custom MCP integration with dartantic_ai's built-in McpClient?** → **A: Keep existing MCP** — Retain the current custom MCP connection manager and tool spec lookup. MCP tool specs are normalized to domain `ToolSpec` entities and converted to dartantic `Tool` objects via `ToolAdapter` for registration with `ChatModel`. Actual tool invocation still routes through the app's agent loop and MCP manager. Only the LangChain chat model and tool execution layers are replaced.
 - **Q: Should new tests be added for dartantic_ai-specific behavior, or only existing tests must pass?** → **A: Existing + targeted new tests** — All existing tests must pass, plus new tests are added for dartantic_ai-specific integration points (provider setup, message mapping, streaming behavior).
 
 ## Requirements _(mandatory)_
@@ -113,7 +115,7 @@ As a user or administrator, I can view token usage statistics for conversations 
 - **FR-001**: The system MUST support sending messages to AI providers and receiving text responses.
 - **FR-002**: The system MUST stream AI responses token-by-token in real time.
 - **FR-003**: The system MUST support multi-turn conversations with persistent history across messages.
-- **FR-004**: The system MUST support built-in tools (e.g., calculator, URL fetcher) that the AI can invoke autonomously.
+- **FR-004**: The system MUST support built-in tools (e.g., calculator, URL fetcher). Tool execution is app-controlled via the approval pipeline — tools are not auto-executed by the AI framework.
 - **FR-005**: The system MUST support external tools via the Model Context Protocol (MCP), allowing integration with third-party tool servers.
 - **FR-006**: The system MUST support multiple AI providers and allow per-conversation or per-workspace provider selection. All dartantic_ai built-in providers MUST be available for selection.
 - **FR-007**: The system MUST support custom provider endpoint URLs and custom HTTP headers for enterprise or proxy configurations.

--- a/specs/004-migrate-langchain-dartantic/tasks.md
+++ b/specs/004-migrate-langchain-dartantic/tasks.md
@@ -1,0 +1,221 @@
+# Tasks: Migrate AI Orchestration Framework (LangChain → dartantic_ai)
+
+**Input**: Design documents from `specs/004-migrate-langchain-dartantic/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Existing tests must pass + new targeted tests for dartantic_ai integration points (per SC-002).
+
+**Organization**: Tasks grouped by user story. Big-bang migration — all tasks land in a single commit.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Swap dependencies in pubspec.yaml
+
+- [x] T001 Remove `langchain`, `langchain_anthropic`, `langchain_openai` from `apps/auravibes_app/pubspec.yaml` and add `dartantic_ai: ^3.4.0`
+- [x] T002 Run `fvm flutter pub get` in `apps/auravibes_app/` and resolve any dependency conflicts
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Create shared adapter types that all user stories depend on. MUST complete before any user story work begins.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 Create domain-level `ToolSpec` class in `apps/auravibes_app/lib/domain/entities/tool_spec.dart` to replace langchain's `ToolSpec` (fields: `name`, `description`, `inputJsonSchema`). This decouples the tool layer from langchain types.
+- [ ] T004 [P] Create `ChatMessageAdapter` in `apps/auravibes_app/lib/services/chatbot_service/chat_message_adapter.dart` — converts domain `MessageEntity` list to dartantic `List<ChatMessage>`. Covers user, assistant (with tool calls), tool result, and system message mappings per `contracts/message_conversion.md`.
+- [ ] T005 [P] Create `ToolAdapter` in `apps/auravibes_app/lib/services/chatbot_service/tool_adapter.dart` — converts domain `ToolSpec` to dartantic `Tool` (maps `name`, `description`, `inputJsonSchema` → `Schema.fromMap()`, and wires `onCall` callback). Per `contracts/tool_definition.md`.
+- [ ] T006 [P] Create `ProviderFactory` in `apps/auravibes_app/lib/services/chatbot_service/provider_factory.dart` — maps provider configuration (type, model ID, base URL, headers, API key) to dartantic `Agent`. Supports built-in providers via prefix string and custom endpoints via `OpenAIProvider(baseUrl: ...)`. Per `contracts/chatbot_service.md`.
+- [ ] T007 [P] Add new test for `ChatMessageAdapter` in `apps/auravibes_app/test/services/chatbot_service/chat_message_adapter_test.dart` — verify user/assistant/tool/system message conversions, tool call mapping, empty content handling
+- [ ] T008 [P] Add new test for `ToolAdapter` in `apps/auravibes_app/test/services/chatbot_service/tool_adapter_test.dart` — verify ToolSpec→Tool conversion, schema mapping, onCall wiring
+- [ ] T009 [P] Add new test for `ProviderFactory` in `apps/auravibes_app/test/services/chatbot_service/provider_factory_test.dart` — verify all built-in provider prefixes, custom base URL, custom headers, invalid provider handling
+
+**Checkpoint**: Adapter layer complete — user story implementation can begin
+
+---
+
+## Phase 3: User Story 1 + 3 — Core Chat & Streaming (Priority: P1 + P2) 🎯 MVP
+
+**Goal**: Replace ChatbotService core with dartantic_ai Agent. Chat and streaming are inseparable — both must work together.
+
+**Independent Test**: User can open a conversation, send a message, and receive a streamed token-by-token response. Multi-turn context is preserved.
+
+### Implementation
+
+- [ ] T010 [US1] Rewrite `ChatbotService` in `apps/auravibes_app/lib/services/chatbot_service/chatbot_service.dart` — replace `BaseChatModel`/`ChatOpenAI`/`ChatAnthropic` with `Agent` via `ProviderFactory`. Replace `PromptValue.chat()` with direct `ChatMessage` list. Replace `model.stream()` with `agent.sendStream()`. Replace `ChatOpenAIOptions`/`ChatAnthropicOptions` with constructor parameters.
+- [ ] T011 [US1] Rewrite `build_prompt_chat_messages.dart` in `apps/auravibes_app/lib/services/chatbot_service/build_prompt_chat_messages.dart` — replace langchain `ChatMessage.humanText()`/`.ai()`/`.tool()` factories with `ChatMessageAdapter` calls. Remove `AIChatMessageToolCall` references.
+- [ ] T012 [US1] Update `chat_message_models.dart` in `apps/auravibes_app/lib/services/chatbot_service/models/chat_message_models.dart` — replace `AIChatMessageToolCall` with domain-level tool call type or dartantic `ToolCall`. Remove langchain import.
+- [ ] T013 [US1] Update `chat_result_extension.dart` in `apps/auravibes_app/lib/utils/chat_result_extension.dart` — retarget extension from langchain `ChatResult` to dartantic `ChatResult`. Verify `LanguageModelUsage` access pattern (`.usage.promptTokens`, `.responseTokens`, `.totalTokens`).
+- [ ] T014 [US3] Update `continue_agent_usecase.dart` in `apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart` — replace langchain `ChatResult` with dartantic `ChatResult`. Update stream consumption pattern.
+- [ ] T015 [US3] Update `messages_streaming_notifier.dart` in `apps/auravibes_app/lib/features/chats/notifiers/messages_streaming_notifier.dart` — replace langchain `ChatResult` with dartantic `ChatResult`.
+- [ ] T016 [US3] Update `streaming_runtime_provider.dart` in `apps/auravibes_app/lib/features/chats/providers/streaming_runtime_provider.dart` — replace langchain `ChatResult` with dartantic `ChatResult`.
+- [ ] T017 [US1] Update `chatbot_service.dart` title generation — replace `PromptValue.chat()` with `Agent.send()` using `ChatMessageAdapter`. Verify title extraction from response.
+
+### Tests
+
+- [ ] T018 [P] [US1] Update `build_prompt_chat_messages_test.dart` in `apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart` — replace `HumanChatMessage`/`AIChatMessage`/`ToolChatMessage` assertions with dartantic `ChatMessage` type checks.
+- [ ] T019 [P] [US3] Update `continue_agent_usecase_test.dart` in `apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.dart` — replace langchain `ChatResult`/`AIChatMessage`/`LanguageModelUsage`/`FinishReason` mocks with dartantic equivalents.
+- [ ] T020 [P] [US3] Update `chat_messages_provider_test.dart` in `apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart` — replace langchain `ChatResult`/`AIChatMessage`/`FinishReason`/`LanguageModelUsage` mocks with dartantic equivalents.
+
+**Checkpoint**: Core chat works end-to-end with streaming. User can send messages and receive responses.
+
+---
+
+## Phase 4: User Story 2 — Tool-Assisted Conversations (Priority: P2)
+
+**Goal**: All tool types (built-in, native, MCP) work with dartantic_ai agent.
+
+**Independent Test**: User asks a question that triggers a tool call. The tool executes, result integrates into the AI response.
+
+### Implementation
+
+- [ ] T021 [US2] Convert `calculator_tool.dart` in `apps/auravibes_app/lib/services/tools/user_tools/calculator_tool.dart` — replace `Tool.fromFunction<>()` with dartantic `Tool(name, description, inputSchema, onCall)`. Remove `ToolSpec`, `Tool`, `ToolOptions` langchain imports.
+- [ ] T022 [US2] Convert `url_tool.dart` in `apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart` — replace `Tool.fromFunction<>()` with dartantic `Tool(name, description, inputSchema, onCall)`. Remove langchain imports.
+- [ ] T023 [US2] Update `native_tool_entity.dart` in `apps/auravibes_app/lib/services/tools/native_tool_entity.dart` — replace langchain `ToolSpec` return type with domain `ToolSpec` (from T003). Remove langchain import.
+- [ ] T024 [US2] Update `user_tools_entity.dart` in `apps/auravibes_app/lib/services/tools/user_tools_entity.dart` — replace langchain `ToolSpec` return type with domain `ToolSpec` (from T003). Remove langchain import.
+- [ ] T025 [US2] Update `load_conversation_tool_specs_usecase.dart` in `apps/auravibes_app/lib/features/tools/usecases/load_conversation_tool_specs_usecase.dart` — replace langchain `ToolSpec` with domain `ToolSpec`. Remove langchain import.
+- [ ] T026 [US2] Update `build_combined_tool_specs_usecase.dart` in `apps/auravibes_app/lib/domain/usecases/tools/mcp/build_combined_tool_specs_usecase.dart` — replace langchain `ToolSpec` with domain `ToolSpec`. Remove langchain import.
+- [ ] T027 [US2] Update `mcp_tool_spec_lookup_provider.dart` in `apps/auravibes_app/lib/features/tools/providers/mcp_tool_spec_lookup_provider.dart` — replace langchain `ToolSpec` with domain `ToolSpec`. Remove langchain import.
+- [ ] T028 [US2] Update `mcp_connection_notifier.dart` in `apps/auravibes_app/lib/notifiers/mcp_connection_notifier.dart` — replace langchain `ToolSpec` return type with domain `ToolSpec`. Remove langchain import. MCP connection logic stays unchanged per FR-014.
+- [ ] T029 [US2] Wire `ToolAdapter` (from T005) into `ChatbotService` — convert domain `ToolSpec` list to dartantic `Tool` list before passing to `Agent`.
+
+### Tests
+
+- [ ] T030 [P] [US2] Update `load_conversation_tool_specs_usecase_test.dart` in `apps/auravibes_app/test/features/tools/usecases/load_conversation_tool_specs_usecase_test.dart` — replace langchain `ToolSpec` with domain `ToolSpec` assertions.
+- [ ] T031 [P] [US2] Update `build_combined_tool_specs_usecase_test.dart` in `apps/auravibes_app/test/domain/usecases/tools/mcp/build_combined_tool_specs_usecase_test.dart` — replace langchain `ToolSpec` with domain `ToolSpec` assertions.
+
+**Checkpoint**: All tool types work. Built-in, native, and MCP tools execute via dartantic_ai agent.
+
+---
+
+## Phase 5: User Story 4 — Multi-Provider Support (Priority: P3)
+
+**Goal**: All dartantic_ai built-in providers are selectable and functional.
+
+**Independent Test**: User selects a different provider (Google, Mistral, etc.) and starts a conversation that routes correctly.
+
+### Implementation
+
+- [ ] T032 [US4] Expand `ProviderFactory` in `apps/auravibes_app/lib/services/chatbot_service/provider_factory.dart` — add mapping for all dartantic_ai built-in providers (OpenAI, Anthropic, Google, Mistral, Cohere, Ollama, OpenRouter, xAI, xAI-Responses). Map models.dev vendor identifiers to dartantic provider prefixes.
+- [ ] T033 [US4] Add custom endpoint support in `ProviderFactory` — when `baseUrl` is provided, create `OpenAIProvider(apiKey: ..., baseUrl: Uri.parse(baseUrl), headers: customHeaders)` and use `Agent.forProvider(provider)`.
+- [ ] T034 [US4] Update `ProviderFactory` test in `apps/auravibes_app/test/services/chatbot_service/provider_factory_test.dart` — verify all 10 built-in provider prefixes resolve correctly. Verify custom URL routing.
+
+**Checkpoint**: All providers selectable. Custom endpoints work.
+
+---
+
+## Phase 6: User Story 5 — Token Usage Tracking (Priority: P3)
+
+**Goal**: Token usage (prompt, response, total) accurately recorded per conversation.
+
+**Independent Test**: After a conversation, token counts are persisted and displayed within 5% tolerance.
+
+### Implementation
+
+- [ ] T035 [US5] Verify `chat_result_extension.dart` token extraction in `apps/auravibes_app/lib/utils/chat_result_extension.dart` — confirm dartantic `LanguageModelUsage` fields (`.promptTokens`, `.responseTokens`, `.totalTokens`) map correctly to domain token tracking. Already updated in T013; this task validates accuracy.
+- [ ] T036 [US5] Verify token persistence — ensure streamed `ChatResult` final chunk contains usage data and is correctly saved to conversation metadata via existing Drift schema.
+
+**Checkpoint**: Token usage accurate and persisted.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final cleanup, validation, and removal of all langchain remnants
+
+- [ ] T037 Search entire `apps/auravibes_app/` for any remaining `langchain` or `langchain_` imports. Remove all references.
+- [ ] T038 [P] Add streaming integration test in `apps/auravibes_app/test/services/chatbot_service/chatbot_service_test.dart` — verify end-to-end streaming with message history, tool calls, and token usage extraction using dartantic types.
+- [ ] T039 [P] Add provider integration test in `apps/auravibes_app/test/services/chatbot_service/provider_factory_test.dart` — verify OpenAI and Anthropic provider creation with real configuration shapes (mocked HTTP).
+- [ ] T040 Run `fvm dart format --set-exit-if-changed .` in `apps/auravibes_app/`
+- [ ] T041 Run `fvm dart analyze --fatal-infos` in `apps/auravibes_app/`
+- [ ] T042 Run `fvm flutter test --no-pub` in `apps/auravibes_app/`
+- [ ] T043 Run `fvm dart run melos run validate` from monorepo root
+- [ ] T044 Verify quickstart.md steps work by running the migration checklist in `specs/004-migrate-langchain-dartantic/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1+US3 Core Chat (Phase 3)**: Depends on Phase 2 — MVP delivery
+- **US2 Tools (Phase 4)**: Depends on Phase 2. Can start in parallel with Phase 3 but T029 (wire ToolAdapter) depends on T010 (ChatbotService rewrite)
+- **US4 Multi-Provider (Phase 5)**: Depends on Phase 3 (T010 ChatbotService rewrite). ProviderFactory expanded after core chat works.
+- **US5 Token Usage (Phase 6)**: Depends on Phase 3 (T013 chat_result_extension)
+- **Polish (Phase 7)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+```
+Phase 1 (Setup)
+  └── Phase 2 (Foundational)
+        ├── Phase 3 (US1+US3: Chat+Streaming) ← MVP
+        │     └── Phase 5 (US4: Multi-Provider)
+        │     └── Phase 6 (US5: Token Usage)
+        ├── Phase 4 (US2: Tools) [partial parallel with Phase 3]
+        │     └── T029 depends on T010
+        └── Phase 7 (Polish) ← after all stories
+```
+
+### Parallel Opportunities
+
+- T004, T005, T006, T007, T008, T009 can all run in parallel (different files)
+- T018, T019, T020 can run in parallel (different test files)
+- T030, T031 can run in parallel (different test files)
+- T038, T039 can run in parallel (different test files)
+
+---
+
+## Parallel Example: Phase 2
+
+```text
+# All foundational adapters and tests can be built simultaneously:
+Task: "Create ChatMessageAdapter in apps/auravibes_app/lib/services/chatbot_service/chat_message_adapter.dart"
+Task: "Create ToolAdapter in apps/auravibes_app/lib/services/chatbot_service/tool_adapter.dart"
+Task: "Create ProviderFactory in apps/auravibes_app/lib/services/chatbot_service/provider_factory.dart"
+Task: "Add test for ChatMessageAdapter in apps/auravibes_app/test/services/chatbot_service/chat_message_adapter_test.dart"
+Task: "Add test for ToolAdapter in apps/auravibes_app/test/services/chatbot_service/tool_adapter_test.dart"
+Task: "Add test for ProviderFactory in apps/auravibes_app/test/services/chatbot_service/provider_factory_test.dart"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1+3 Only)
+
+1. Complete Phase 1: Setup (T001–T002)
+2. Complete Phase 2: Foundational (T003–T009)
+3. Complete Phase 3: US1+US3 Core Chat (T010–T020)
+4. **STOP and VALIDATE**: Test basic chat with streaming independently
+5. If working → continue to tools and providers
+
+### Full Migration (All User Stories)
+
+1. Setup + Foundational → Adapters ready
+2. Core Chat + Streaming → MVP (US1+US3)
+3. Tool System → Tools functional (US2)
+4. Multi-Provider → All providers available (US4)
+5. Token Usage → Accurate tracking (US5)
+6. Polish → Clean, validated, production-ready
+
+---
+
+## Notes
+
+- Big-bang migration: all tasks land in a single commit/PR
+- MCP connection logic preserved per FR-014; only `ToolSpec` type reference changes
+- No rollback per clarification — fix forward only
+- All dartantic_ai built-in providers enabled per clarification
+- Domain `ToolSpec` (T003) replaces langchain `ToolSpec` throughout codebase
+- Verify `fvm` prefix on all Dart/Flutter commands per AGENTS.md


### PR DESCRIPTION
## Summary

- Replaces LangChain Dart (`langchain`, `langchain_anthropic`, `langchain_openai`) with `dartantic_ai` as the AI orchestration framework
- Uses `ChatModel.sendStream()` directly instead of `Agent.sendStream()` to prevent dartantic from auto-executing tools — the app manages the agent loop and tool approval pipeline itself
- Adds `ProviderFactory` (explicit API keys, multi-provider support), `ToolAdapter` (domain `ToolSpec` → dartantic `Tool`), `ChatResultConcat` extension (streaming delta accumulation)
- Fixes OpenAI v1.1 API (`OpenAIClient.withApiKey()`, `client.models.list()`), Anthropic custom base URL handling, and removes duplicate `ChatMessageAdapter`

## Test plan

- [x] All 147 tests pass (`fvm flutter test --no-pub`)
- [x] Static analysis clean (`fvm dart analyze --fatal-infos`)
- [ ] Run `melos run validate` across monorepo
- [ ] Manual smoke test: send chat message, verify streaming response
- [ ] Manual smoke test: trigger tool call, verify approval pipeline works
- [ ] Verify token usage displays correctly in UI