### PR TITLE
docs: refactor Riverpod skill refs

### DIFF
--- a/.agents/skills/flutter-riverpod-expert/SKILL.md
+++ b/.agents/skills/flutter-riverpod-expert/SKILL.md
@@ -50,18 +50,45 @@ Apply Riverpod 3 patterns that fit the current codebase. In AuraVibes, prefer th
 
 ## Common AuraVibes Pattern
 
+This sample is based on `ConversationSendQueue` in `apps/auravibes_app`.
+
 ```dart
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'conversation_send_queue_notifier.g.dart';
 
-@riverpod
-class ConversationSendQueueNotifier extends _$ConversationSendQueueNotifier {
-  @override
-  List<String> build() => const [];
+class ConversationQueuedDraft {
+  const ConversationQueuedDraft({
+    required this.id,
+    required this.content,
+  });
 
-  void enqueue(String messageId) {
-    state = [...state, messageId];
+  final String id;
+  final String content;
+}
+
+@riverpod
+class ConversationSendQueue extends _$ConversationSendQueue {
+  int _nextDraftId = 0;
+
+  @override
+  Map<String, List<ConversationQueuedDraft>> build() => {};
+
+  ConversationQueuedDraft enqueue({
+    required String conversationId,
+    required String content,
+  }) {
+    final draft = ConversationQueuedDraft(
+      id: 'queued-${_nextDraftId++}',
+      content: content,
+    );
+
+    state = {
+      ...state,
+      conversationId: [...state[conversationId] ?? const [], draft],
+    };
+
+    return draft;
   }
 }
 ```

--- a/.agents/skills/flutter-riverpod-expert/SKILL.md
+++ b/.agents/skills/flutter-riverpod-expert/SKILL.md
@@ -1,692 +1,93 @@
 ---
 name: flutter-riverpod-expert
-description: Expert knowledge in Flutter Riverpod state management (2025 best practices). Use when working with Riverpod, Flutter state management, AsyncNotifier, provider types, code generation with riverpod_generator, state synchronization, or when the user mentions data fetching, mutations, reactive state, performance optimization, or testing in Flutter apps. Covers AsyncNotifierProvider patterns, repository architecture, autoDispose, family providers, and common anti-patterns to avoid.
+description: Expert Riverpod 3 guidance for Flutter apps, especially projects using hooks_riverpod, flutter_hooks, riverpod_annotation, and riverpod_generator. Use when working with Riverpod providers, HookConsumerWidget/ConsumerWidget, WidgetRef/Ref, generated @riverpod providers, Notifier/AsyncNotifier/StreamNotifier, mutations, scoped providers, provider overrides, testing, caching, automatic retry, performance with select, or migrations from StateNotifier/ChangeNotifier/legacy providers.
 ---
 
-# Flutter Riverpod Expert - 2025 Best Practices
+# Flutter Riverpod Expert
 
-You have expert knowledge in Flutter Riverpod state management following 2025 best practices. When the user is working with Riverpod or Flutter state management, apply these patterns and guidelines.
+Apply Riverpod 3 patterns that fit the current codebase. In AuraVibes, prefer the existing `hooks_riverpod` setup for Flutter widgets instead of adding or recommending `flutter_riverpod` directly.
 
-## When to Use This Skill
+## First Checks
 
-Activate this expertise when the user mentions:
-- Riverpod, providers, state management, or StateNotifier
-- AsyncNotifier, FutureProvider, StreamProvider, NotifierProvider
-- Code generation with riverpod_generator or build_runner
-- Data fetching, API integration, mutations, or reactive state
-- State synchronization, caching, autoDispose, or memory management
-- Provider testing, dependency injection, or repository patterns
-- Performance issues with rebuilds, provider selection, or optimization
-- Migration from old Riverpod patterns to modern approaches
+1. Inspect the package's `pubspec.yaml` before suggesting imports or dependencies.
+2. In this repo, use:
+   - `package:hooks_riverpod/hooks_riverpod.dart` for Flutter widgets, `WidgetRef`, `ProviderScope`, `ProviderContainer`, hooks, `Mutation`, and consumer widgets.
+   - `package:riverpod_annotation/riverpod_annotation.dart` for generated providers.
+   - `package:riverpod_annotation/experimental/scope.dart` only when `@Dependencies` is required for scoped providers.
+   - `package:hooks_riverpod/legacy.dart` only when maintaining existing `StateProvider`, `StateNotifierProvider`, or `ChangeNotifierProvider` code.
+3. Do not manually edit `pubspec.yaml` for dependency changes in this repo. Use the project command convention with `fvm flutter pub add ...`.
+4. Run generation from the package directory after changing generated providers:
+   `fvm dart run build_runner build --delete-conflicting-outputs`
 
-## Core Principles (2025)
+## Load References
 
-1. **Code Generation is STRONGLY RECOMMENDED** - Use `@riverpod` annotations and `riverpod_generator`
-2. **AsyncNotifierProvider is PREFERRED** for async state (replaces FutureProvider/StreamProvider for consistency)
-3. **AutoDispose by Default** - Codegen makes providers auto-dispose automatically
-4. **Repository Pattern** - Separate data layer from state management
-5. **Performance First** - Use `select()` to optimize rebuilds
+- Read `references/auravibes-riverpod.md` before editing AuraVibes Riverpod code.
+- Read `references/riverpod3-core.md` for provider selection, Riverpod 3 behavior changes, lifecycle, async state, and testing.
+- Read `references/hooks-riverpod.md` when touching UI widgets, local widget state, hooks, `HookConsumerWidget`, or imports.
 
-## Provider Selection Guide
+## Default Decisions
 
-### Quick Decision Tree
+- Keep state ownership in generated Notifier classes when state has user intents or mutations.
+- Use generated function providers for pure computed values, repositories, services, one-shot fetches, and streams without public mutation methods.
+- Use hooks for local widget-only state such as controllers, focus nodes, animation controllers, debounce timers, and form-local state.
+- Use Riverpod for app/domain state shared across widgets, persisted across routes, injected into use cases, or consumed by tests.
+- Prefer `ref.watch` for reactive values, `ref.select` for narrow rebuilds, `ref.read` in event handlers and notifier methods, and `ref.listen` for side effects.
+- Prefer `AsyncValue` pattern matching or `.when` for UI. Avoid ad hoc `isLoading`/`error` flags unless a domain state object needs them for a specific UX.
+- After `await` inside notifier methods, check `ref.mounted` before touching `ref` or `state` if the notifier may have been disposed.
+- Treat Riverpod 3 `Mutation` as experimental. Use it only where the project already has the pattern or the user asks for it.
 
-**Immutable/Computed Values** - Use `Provider`:
-```dart
-@riverpod
-String apiKey(Ref ref) => 'YOUR_API_KEY';
+## Avoid
 
-@riverpod
-int totalPrice(Ref ref) {
-  final cart = ref.watch(cartProvider);
-  return cart.items.fold(0, (sum, item) => sum + item.price);
-}
-```
+- Do not recommend replacing `hooks_riverpod` with `flutter_riverpod` in this repo.
+- Do not add `flutter_riverpod` just to access `ConsumerWidget`, `WidgetRef`, `ProviderScope`, or `ProviderContainer`; `hooks_riverpod` already provides the Flutter Riverpod API plus hooks support.
+- Do not introduce legacy provider types for new state unless maintaining legacy code.
+- Do not use `ref.read` inside `build` to avoid rebuilds. Use `ref.watch`, `ref.select`, or split widgets.
+- Do not watch providers inside large list builders when a row widget can watch its own item.
+- Do not keep mutable app state in widgets if multiple features or screens need it.
+- Do not make every provider `keepAlive: true`; default generated providers are auto-dispose and that is usually correct.
+- Do not use scoped providers without declaring `dependencies` on scoped providers and generated dependents.
 
-**Simple Synchronous State** - Use `NotifierProvider`:
-```dart
-@riverpod
-class Counter extends _$Counter {
-  @override
-  int build() => 0;
+## Common AuraVibes Pattern
 
-  void increment() => state++;
-  void decrement() => state = max(0, state - 1);
-}
-```
-
-**Async Data with Mutations (PREFERRED 2025)** - Use `AsyncNotifierProvider`:
-```dart
-@riverpod
-class TodoList extends _$TodoList {
-  @override
-  Future<List<Todo>> build() async {
-    final repo = ref.watch(todoRepositoryProvider);
-    return repo.fetchTodos();
-  }
-
-  Future<void> addTodo(String title) async {
-    state = const AsyncLoading();
-    state = await AsyncValue.guard(() async {
-      final repo = ref.read(todoRepositoryProvider);
-      await repo.createTodo(title);
-      return repo.fetchTodos();
-    });
-  }
-
-  Future<void> deleteTodo(String id) async {
-    // Optimistic update
-    state = AsyncData(state.value!.where((t) => t.id != id).toList());
-
-    try {
-      await ref.read(todoRepositoryProvider).deleteTodo(id);
-    } catch (e) {
-      ref.invalidateSelf(); // Rollback on error
-    }
-  }
-}
-```
-
-**Real-time Streams Only** - Use `StreamProvider`:
-```dart
-@riverpod
-Stream<User?> authState(Ref ref) {
-  return FirebaseAuth.instance.authStateChanges();
-}
-```
-
-**Key Rule**: Prefer AsyncNotifierProvider over FutureProvider/StreamProvider for better consistency and mutation support.
-
-## Code Generation Setup
-
-### Dependencies (pubspec.yaml)
-```yaml
-dependencies:
-  flutter_riverpod: ^2.5.0
-  riverpod_annotation: ^2.3.0
-
-dev_dependencies:
-  build_runner: ^2.4.0
-  riverpod_generator: ^2.4.0
-  custom_lint: ^0.6.0
-  riverpod_lint: ^2.3.0
-```
-
-### File Template
-Every provider file needs:
 ```dart
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'filename.g.dart';  // REQUIRED
+part 'conversation_send_queue_notifier.g.dart';
 
 @riverpod
-class MyProvider extends _$MyProvider {
+class ConversationSendQueueNotifier extends _$ConversationSendQueueNotifier {
   @override
-  Future<Data> build() async => fetchData();
-}
-```
+  List<String> build() => const [];
 
-### Run Generator
-```bash
-# Watch mode (RECOMMENDED during development)
-dart run build_runner watch -d
-
-# One-time generation
-dart run build_runner build --delete-conflicting-outputs
-```
-
-## Performance Optimization Patterns
-
-### Use ref.select() for Specific Fields
-```dart
-// ❌ BAD: Rebuilds on ANY product change
-final product = ref.watch(productProvider);
-return Text('\$${product.price}');
-
-// ✅ GOOD: Only rebuilds when price changes
-final price = ref.watch(productProvider.select((p) => p.price));
-return Text('\$$price');
-```
-
-### ref.watch() vs ref.select() vs ref.read() vs ref.listen()
-
-**ref.watch()** - Subscribe to changes (use in build):
-```dart
-@override
-Widget build(BuildContext context, WidgetRef ref) {
-  final todos = ref.watch(todoListProvider);
-  return ListView(...);
-}
-```
-
-**ref.select()** - Subscribe to specific property (optimize rebuilds):
-```dart
-final count = ref.watch(todoListProvider.select((todos) => todos.length));
-final isAdult = ref.watch(personProvider.select((p) => p.age >= 18));
-```
-
-**ref.read()** - One-time read with NO subscription (event handlers only):
-```dart
-onPressed: () {
-  ref.read(todoListProvider.notifier).addTodo('New task');
-}
-
-// ❌ NEVER use read() in build to "optimize" - it won't rebuild!
-```
-
-**ref.listen()** - Side effects (navigation, snackbars, logging):
-```dart
-ref.listen<AsyncValue<List<Todo>>>(
-  todoListProvider,
-  (previous, next) {
-    next.whenOrNull(
-      error: (error, stack) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error: $error')),
-        );
-      },
-    );
-  },
-);
-```
-
-### Avoid Watching in Loops
-```dart
-// ❌ BAD: Causes performance issues
-ListView.builder(
-  itemBuilder: (context, index) {
-    final todo = ref.watch(todoProvider(ids[index])); // DON'T!
-    return ListTile(...);
-  },
-);
-
-// ✅ GOOD: Separate widget for each item
-class TodoItem extends ConsumerWidget {
-  const TodoItem({required this.todoId});
-  final String todoId;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final todo = ref.watch(todoProvider(todoId));
-    return ListTile(title: Text(todo.title));
+  void enqueue(String messageId) {
+    state = [...state, messageId];
   }
 }
+```
 
-class TodoList extends ConsumerWidget {
+```dart
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class ChatInputWidget extends HookConsumerWidget {
+  const ChatInputWidget({super.key});
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ids = ref.watch(todoIdsProvider);
-    return ListView.builder(
-      itemCount: ids.length,
-      itemBuilder: (context, index) => TodoItem(todoId: ids[index]),
+    final isSending = ref.watch(sendMessageProvider.select((state) => state.isSending));
+
+    return IconButton(
+      onPressed: isSending
+          ? null
+          : () => ref.read(sendMessageProvider.notifier).send(),
+      icon: const Icon(Icons.send),
     );
   }
 }
 ```
 
-### Create Derived Providers
-```dart
-// ✅ GOOD: Separate provider for computed state
-@riverpod
-List<Todo> filteredSortedTodos(Ref ref) {
-  final todos = ref.watch(todoListProvider);
-  final filter = ref.watch(filterProvider);
-  final sortOrder = ref.watch(sortOrderProvider);
-
-  final filtered = todos.where((t) => t.matches(filter)).toList();
-  return filtered..sort(sortOrder.comparator);
-}
-```
-
-## Repository Pattern Architecture
-
-### 3-Layer Architecture
-
-**1. Data Layer - Repository**:
-```dart
-@riverpod
-TodoRepository todoRepository(Ref ref) {
-  return TodoRepository(dio: ref.watch(dioProvider));
-}
-
-class TodoRepository {
-  TodoRepository({required this.dio});
-  final Dio dio;
-
-  Future<List<Todo>> fetchTodos() async {
-    final response = await dio.get('/todos');
-    return (response.data as List)
-      .map((json) => Todo.fromJson(json))
-      .toList();
-  }
-
-  Future<Todo> createTodo(String title) async {
-    final response = await dio.post('/todos', data: {'title': title});
-    return Todo.fromJson(response.data);
-  }
-
-  Future<void> deleteTodo(String id) async {
-    await dio.delete('/todos/$id');
-  }
-}
-```
-
-**2. Application Layer - State Management**:
-```dart
-@riverpod
-class TodoList extends _$TodoList {
-  @override
-  Future<List<Todo>> build() async {
-    final repository = ref.watch(todoRepositoryProvider);
-    return repository.fetchTodos();
-  }
-
-  Future<void> addTodo(String title) async {
-    final repository = ref.read(todoRepositoryProvider);
-
-    state = const AsyncLoading();
-    state = await AsyncValue.guard(() async {
-      await repository.createTodo(title);
-      return repository.fetchTodos();
-    });
-  }
-}
-```
-
-**3. Presentation Layer - UI**:
-```dart
-class TodoListScreen extends ConsumerWidget {
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final todosAsync = ref.watch(todoListProvider);
-
-    return Scaffold(
-      appBar: AppBar(title: const Text('Todos')),
-      body: todosAsync.when(
-        data: (todos) => ListView.builder(
-          itemCount: todos.length,
-          itemBuilder: (context, index) => TodoTile(todos[index]),
-        ),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stack) => ErrorView(error: error),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => _showAddDialog(context, ref),
-        child: const Icon(Icons.add),
-      ),
-    );
-  }
-}
-```
-
-### Dependency Injection
-```dart
-// Services
-@riverpod
-Dio dio(Ref ref) {
-  final dio = Dio(BaseOptions(baseUrl: 'https://api.example.com'));
-  dio.interceptors.add(LogInterceptor());
-  return dio;
-}
-
-@riverpod
-Future<SharedPreferences> sharedPreferences(Ref ref) async {
-  return await SharedPreferences.getInstance();
-}
-
-@riverpod
-AuthService authService(Ref ref) {
-  return AuthService(
-    dio: ref.watch(dioProvider),
-    storage: ref.watch(sharedPreferencesProvider).value!,
-  );
-}
-
-// Repositories depend on services
-@riverpod
-UserRepository userRepository(Ref ref) {
-  return UserRepository(
-    dio: ref.watch(dioProvider),
-    authService: ref.watch(authServiceProvider),
-  );
-}
-
-// State providers depend on repositories
-@riverpod
-class CurrentUser extends _$CurrentUser {
-  @override
-  Future<User?> build() async {
-    final authService = ref.watch(authServiceProvider);
-    final userId = await authService.getCurrentUserId();
-
-    if (userId == null) return null;
-
-    final repository = ref.watch(userRepositoryProvider);
-    return repository.fetchUser(userId);
-  }
-
-  Future<void> logout() async {
-    final authService = ref.read(authServiceProvider);
-    await authService.logout();
-    ref.invalidateSelf();
-  }
-}
-```
-
-## Family Providers (Parameterized)
-
-Family providers are automatic with code generation when you add parameters:
-
-```dart
-// Simple family provider
-@riverpod
-Future<User> user(Ref ref, String id) async {
-  final dio = ref.watch(dioProvider);
-  final response = await dio.get('/users/$id');
-  return User.fromJson(response.data);
-}
-
-// Usage
-final user = ref.watch(userProvider('123'));
-
-// Family with AsyncNotifier
-@riverpod
-class UserNotifier extends _$UserNotifier {
-  @override
-  Future<User> build(String id) async {
-    final repo = ref.watch(userRepositoryProvider);
-    return repo.fetchUser(id);
-  }
-
-  Future<void> updateName(String newName) async {
-    final userId = arg; // Access the parameter via 'arg'
-    state = const AsyncLoading();
-    state = await AsyncValue.guard(() async {
-      await ref.read(userRepositoryProvider).updateUser(userId, name: newName);
-      return ref.read(userRepositoryProvider).fetchUser(userId);
-    });
-  }
-}
-
-// Complex parameters need proper equality
-class UserFilter {
-  const UserFilter({required this.role, required this.active});
-  final String role;
-  final bool active;
-
-  @override
-  bool operator ==(Object other) =>
-    identical(this, other) ||
-    other is UserFilter &&
-    role == other.role &&
-    active == other.active;
-
-  @override
-  int get hashCode => Object.hash(role, active);
-}
-
-@riverpod
-Future<List<User>> filteredUsers(Ref ref, UserFilter filter) async {
-  return fetchUsers(filter);
-}
-```
-
-## AutoDispose and Caching
-
-Code generation makes providers **auto-dispose by default**.
-
-```dart
-// Default: auto-dispose when no listeners
-@riverpod
-Future<String> data(Ref ref) async => fetchData();
-
-// Keep alive permanently
-@Riverpod(keepAlive: true)
-Future<Config> config(Ref ref) async => loadConfig();
-
-// Conditional keep alive - cache on success
-@riverpod
-Future<String> cachedData(Ref ref) async {
-  final data = await fetchData();
-  ref.keepAlive(); // Cache this result forever
-  return data;
-}
-
-// Timed cache (5 minutes)
-@riverpod
-Future<String> timedCache(Ref ref) async {
-  final data = await fetchData();
-  final link = ref.keepAlive();
-  Timer(const Duration(minutes: 5), link.close);
-  return data;
-}
-
-// Manual disposal - cleanup resources
-@riverpod
-Stream<int> websocket(Ref ref) {
-  final client = WebSocketClient();
-
-  ref.onDispose(() {
-    client.close(); // Cleanup when provider is disposed
-  });
-
-  return client.stream;
-}
-```
-
-## Error Handling
-
-### Comprehensive Error Handling
-```dart
-@riverpod
-class TodoList extends _$TodoList {
-  @override
-  Future<List<Todo>> build() async {
-    try {
-      final repository = ref.watch(todoRepositoryProvider);
-      return await repository.fetchTodos();
-    } on DioException catch (e) {
-      if (e.response?.statusCode == 401) {
-        ref.read(authServiceProvider).logout();
-        throw UnauthorizedException();
-      }
-      throw NetworkException(e.message);
-    } catch (e) {
-      throw UnexpectedException(e.toString());
-    }
-  }
-
-  Future<void> addTodo(String title) async {
-    state = const AsyncLoading();
-
-    state = await AsyncValue.guard(() async {
-      final repository = ref.read(todoRepositoryProvider);
-      await repository.createTodo(title);
-      return repository.fetchTodos();
-    });
-  }
-}
-```
-
-### UI Error Handling
-```dart
-// Using .when()
-todosAsync.when(
-  data: (todos) => ListView.builder(...),
-  loading: () => const Center(child: CircularProgressIndicator()),
-  error: (error, stack) {
-    if (error is NetworkException) {
-      return ErrorView(
-        message: 'Network error. Check your connection.',
-        onRetry: () => ref.invalidate(todoListProvider),
-      );
-    }
-    if (error is UnauthorizedException) {
-      return const ErrorView(message: 'Please log in again.');
-    }
-    return ErrorView(message: 'Error: $error');
-  },
-);
-
-// Listen for errors (side effects)
-ref.listen<AsyncValue<List<Todo>>>(
-  todoListProvider,
-  (previous, next) {
-    next.whenOrNull(
-      error: (error, stack) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(error.toString()),
-            backgroundColor: Colors.red,
-          ),
-        );
-      },
-    );
-  },
-);
-```
-
-## Testing
-
-### Provider Testing
-```dart
-test('TodoList fetches todos correctly', () async {
-  final container = ProviderContainer.test(
-    overrides: [
-      todoRepositoryProvider.overrideWithValue(MockTodoRepository()),
-    ],
-  );
-
-  final todos = await container.read(todoListProvider.future);
-
-  expect(todos.length, 2);
-  expect(todos[0].title, 'Test Todo 1');
-});
-
-test('TodoList adds todo correctly', () async {
-  final mockRepo = MockTodoRepository();
-  final container = ProviderContainer.test(
-    overrides: [
-      todoRepositoryProvider.overrideWithValue(mockRepo),
-    ],
-  );
-
-  await container.read(todoListProvider.notifier).addTodo('New Todo');
-
-  verify(() => mockRepo.createTodo('New Todo')).called(1);
-});
-```
-
-### Widget Testing
-```dart
-testWidgets('TodoListScreen displays todos', (tester) async {
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: [
-        todoRepositoryProvider.overrideWithValue(MockTodoRepository()),
-      ],
-      child: const MaterialApp(home: TodoListScreen()),
-    ),
-  );
-
-  await tester.pumpAndSettle();
-
-  expect(find.text('Test Todo 1'), findsOneWidget);
-  expect(find.text('Test Todo 2'), findsOneWidget);
-});
-```
-
-## Common Anti-Patterns to AVOID
-
-### Performance Pitfalls
-```dart
-// ❌ Using ref.read() to avoid rebuilds
-final todos = ref.read(todoListProvider); // Won't rebuild!
-
-// ✅ Use ref.watch() or ref.select()
-final count = ref.watch(todoListProvider.select((todos) => todos.length));
-```
-
-### Memory Leaks
-```dart
-// ❌ Not disposing resources
-@riverpod
-Stream<int> badWebsocket(Ref ref) {
-  final client = WebSocketClient();
-  return client.stream; // Never closed!
-}
-
-// ✅ Dispose resources
-@riverpod
-Stream<int> goodWebsocket(Ref ref) {
-  final client = WebSocketClient();
-  ref.onDispose(() => client.close());
-  return client.stream;
-}
-```
-
-### Multiple Sources of Truth
-```dart
-// ❌ BAD: Which is the source of truth?
-class BadWidget extends StatefulWidget {
-  int localCount = 0; // Local state
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final providerCount = ref.watch(counterProvider); // Provider state
-    return Text('$localCount vs $providerCount'); // Confusing!
-  }
-}
-
-// ✅ GOOD: Single source of truth
-class GoodWidget extends ConsumerWidget {
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final count = ref.watch(counterProvider);
-    return Text('$count');
-  }
-}
-```
-
-### Not Invalidating Dependent Providers
-```dart
-// ❌ BAD
-Future<void> logout() async {
-  state = null;
-  // Other providers still have old user data!
-}
-
-// ✅ GOOD: Invalidate dependent providers
-Future<void> logout() async {
-  state = null;
-  ref.invalidate(userProfileProvider);
-  ref.invalidate(userSettingsProvider);
-  ref.invalidate(userNotificationsProvider);
-}
-
-// ✅ EVEN BETTER: Make providers watch auth
-@riverpod
-Future<UserProfile> userProfile(Ref ref) async {
-  final user = ref.watch(authProvider);
-  if (user == null) throw UnauthenticatedException();
-  return fetchUserProfile(user.id); // Auto-refetches when user changes
-}
-```
-
-## Instructions for Use
-
-When the user is working with Riverpod:
-
-1. **Always recommend code generation** with `@riverpod` annotations
-2. **Prefer AsyncNotifierProvider** over FutureProvider/StreamProvider for async state
-3. **Optimize performance** by suggesting `select()` when watching specific fields
-4. **Follow repository pattern** for clean architecture
-5. **Use proper error handling** with AsyncValue.guard() and .when()
-6. **Remind about autoDispose** and caching strategies
-7. **Point out anti-patterns** if you see them in user code
-8. **Provide complete, working examples** with proper imports
-
-## Reference
-
-For complete details and advanced patterns, refer to:
-`/Users/pablito/EVOworkspace/flutter/CesarferPromotoresFlutter/promotores/RIVERPOD_2025_BEST_PRACTICES.md`
+## Validation
+
+- Run targeted tests from the package directory with `fvm flutter test <files> --no-pub`.
+- Run generation before analysis when provider signatures, annotations, file names, or provider names change.
+- Run `fvm dart run melos analyze` or the repo's focused validation command when the change affects shared providers.

--- a/.agents/skills/flutter-riverpod-expert/SKILL.md
+++ b/.agents/skills/flutter-riverpod-expert/SKILL.md
@@ -11,9 +11,10 @@ Apply Riverpod 3 patterns that fit the current codebase. In AuraVibes, prefer th
 
 1. Inspect the package's `pubspec.yaml` before suggesting imports or dependencies.
 2. In this repo, use:
-   - `package:hooks_riverpod/hooks_riverpod.dart` for Flutter widgets, `WidgetRef`, `ProviderScope`, `ProviderContainer`, hooks, `Mutation`, and consumer widgets.
+   - `package:hooks_riverpod/hooks_riverpod.dart` for Flutter widgets, `WidgetRef`, `ProviderScope`, `ProviderContainer`, hooks, and consumer widgets.
    - `package:riverpod_annotation/riverpod_annotation.dart` for generated providers.
    - `package:riverpod_annotation/experimental/scope.dart` only when `@Dependencies` is required for scoped providers.
+   - `package:riverpod/experimental/mutation.dart` only when using experimental `Mutation`.
    - `package:hooks_riverpod/legacy.dart` only when maintaining existing `StateProvider`, `StateNotifierProvider`, or `ChangeNotifierProvider` code.
 3. Do not manually edit `pubspec.yaml` for dependency changes in this repo. Use the project command convention with `fvm flutter pub add ...`.
 4. Run generation from the package directory after changing generated providers:

--- a/.agents/skills/flutter-riverpod-expert/references/auravibes-riverpod.md
+++ b/.agents/skills/flutter-riverpod-expert/references/auravibes-riverpod.md
@@ -36,6 +36,12 @@ Use scoped-provider annotation imports only when the file has `@Dependencies`:
 import 'package:riverpod_annotation/experimental/scope.dart';
 ```
 
+Use experimental mutation imports only when the file declares or uses `Mutation`:
+
+```dart
+import 'package:riverpod/experimental/mutation.dart';
+```
+
 Use legacy imports only for existing legacy providers:
 
 ```dart

--- a/.agents/skills/flutter-riverpod-expert/references/auravibes-riverpod.md
+++ b/.agents/skills/flutter-riverpod-expert/references/auravibes-riverpod.md
@@ -57,13 +57,14 @@ import 'package:hooks_riverpod/legacy.dart';
 
 ## Scoped Providers
 
-AuraVibes uses scoped providers for selected conversation/workspace context.
+AuraVibes uses scoped providers for selected conversation/workspace context. Default scoped providers should be non-nullable and fail fast until overridden via `ProviderScope`.
 
 For a scoped generated provider:
 
 ```dart
 @Riverpod(dependencies: [])
-String? conversationSelected(Ref ref) => null;
+String conversationSelected(Ref ref) =>
+    throw const NoConversationSelectedException();
 ```
 
 Any generated provider that watches it must list it:

--- a/.agents/skills/flutter-riverpod-expert/references/auravibes-riverpod.md
+++ b/.agents/skills/flutter-riverpod-expert/references/auravibes-riverpod.md
@@ -1,0 +1,100 @@
+# AuraVibes Riverpod Rules
+
+Use this reference before editing Riverpod code in AuraVibes.
+
+## Current Package Shape
+
+`apps/auravibes_app/pubspec.yaml` currently uses:
+
+- `hooks_riverpod: ^3.0.3`
+- `riverpod: ^3.0.3`
+- `riverpod_annotation: ^4.0.0`
+- `riverpod_generator: ^4.0.0+1`
+- `flutter_hooks: ^0.21.3+1`
+
+Implication: use `hooks_riverpod`, not `flutter_riverpod`, in Flutter widgets. `hooks_riverpod` depends on and exposes the Flutter Riverpod APIs while also supporting `HookConsumerWidget`.
+
+## Imports
+
+Use widget imports like:
+
+```dart
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+```
+
+Use generated provider imports like:
+
+```dart
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'my_provider.g.dart';
+```
+
+Use scoped-provider annotation imports only when the file has `@Dependencies`:
+
+```dart
+import 'package:riverpod_annotation/experimental/scope.dart';
+```
+
+Use legacy imports only for existing legacy providers:
+
+```dart
+import 'package:hooks_riverpod/legacy.dart';
+```
+
+## Naming and Folders
+
+- Mutable state owners should usually be `*Notifier` under `notifiers/`.
+- Pure repository/service providers belong under `providers/`.
+- Generated provider names come from class/function names. For `ThemeNotifier`, generator emits `themeProvider`, not `themeNotifierProvider`.
+- Keep feature-local providers inside the feature unless the provider is genuinely app-wide.
+
+## Scoped Providers
+
+AuraVibes uses scoped providers for selected conversation/workspace context.
+
+For a scoped generated provider:
+
+```dart
+@Riverpod(dependencies: [])
+String? conversationSelected(Ref ref) => null;
+```
+
+Any generated provider that watches it must list it:
+
+```dart
+@Riverpod(dependencies: [conversationSelected])
+Future<List<MessageEntity>> chatMessages(Ref ref) async {
+  final conversationId = ref.watch(conversationSelectedProvider);
+  ...
+}
+```
+
+Widgets that directly or indirectly depend on scoped providers may need `@Dependencies([...])` from `riverpod_annotation/experimental/scope.dart`.
+
+## Commands
+
+Run Dart/Flutter commands through FVM:
+
+```bash
+fvm dart run build_runner build --delete-conflicting-outputs
+fvm flutter test test/path/to/file_test.dart --no-pub
+fvm dart run melos analyze
+```
+
+Do not hand-edit dependencies. Use:
+
+```bash
+fvm flutter pub add package_name
+fvm flutter pub add dev:package_name
+```
+
+## Review Checklist
+
+- Widget files import `hooks_riverpod`, not `flutter_riverpod`.
+- Provider definition files import `riverpod_annotation` and have the correct `part`.
+- Generated files are updated after provider API changes.
+- Scoped providers declare `dependencies` consistently.
+- `keepAlive: true` is justified by app lifetime, service lifetime, or expensive setup.
+- Long async notifier methods avoid touching disposed refs after `await`.
+- UI rebuilds are narrowed with `select` or widget splitting where state is broad.

--- a/.agents/skills/flutter-riverpod-expert/references/hooks-riverpod.md
+++ b/.agents/skills/flutter-riverpod-expert/references/hooks-riverpod.md
@@ -1,0 +1,80 @@
+# Hooks Riverpod
+
+Use this reference when editing Flutter UI that combines Riverpod and hooks.
+
+Official package/docs references used when this reference was written:
+
+- https://riverpod.dev/docs/introduction/getting_started
+- https://pub.dev/packages/hooks_riverpod
+
+## Package Choice
+
+`hooks_riverpod` is the right import when the app uses both Riverpod and Flutter hooks. It provides the Flutter Riverpod consumer APIs and hook-aware consumer widgets. Do not add `flutter_riverpod` separately just to get `ConsumerWidget`, `WidgetRef`, `ProviderScope`, or `ProviderContainer`.
+
+## Widget Selection
+
+- Use `ConsumerWidget` when the widget only needs Riverpod.
+- Use `HookConsumerWidget` when the widget needs hooks and Riverpod in the same `build`.
+- Use `Consumer` for a small subtree when only part of a larger widget should rebuild.
+- Use hooks for widget-local lifecycle objects and ephemeral UI state.
+
+```dart
+class SearchBox extends HookConsumerWidget {
+  const SearchBox({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = useTextEditingController();
+    final focusNode = useFocusNode();
+    final isBusy = ref.watch(searchProvider.select((state) => state.isBusy));
+
+    return TextField(
+      controller: controller,
+      focusNode: focusNode,
+      onSubmitted: isBusy
+          ? null
+          : (query) => ref.read(searchProvider.notifier).search(query),
+    );
+  }
+}
+```
+
+## Local vs Shared State
+
+Use hooks for:
+
+- `TextEditingController`, `FocusNode`, `AnimationController`, `ScrollController`
+- selected tab in a single widget
+- debounce handles scoped to one widget
+- UI-only expanded/collapsed flags that no other widget needs
+
+Use Riverpod for:
+
+- state shared between widgets/screens
+- async data, caching, repository access, use-case orchestration
+- domain/application state
+- values that tests need to override or inspect
+
+## Listening and Side Effects
+
+Use `ref.listen` for UI side effects such as snackbars, dialogs, routing, focus changes, or analytics. Do not trigger those directly from `ref.watch`.
+
+```dart
+ref.listen<AsyncValue<void>>(saveProvider, (previous, next) {
+  if (next case AsyncError(:final error)) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(error.toString())),
+    );
+  }
+});
+```
+
+## Rebuild Control
+
+Prefer narrow watches:
+
+```dart
+final isSending = ref.watch(chatInputProvider.select((state) => state.isSending));
+```
+
+Split row widgets so each row watches its own provider/family parameter. Avoid watching many provider instances inline in a large builder when the row can be a `ConsumerWidget`.

--- a/.agents/skills/flutter-riverpod-expert/references/hooks-riverpod.md
+++ b/.agents/skills/flutter-riverpod-expert/references/hooks-riverpod.md
@@ -13,10 +13,10 @@ Official package/docs references used when this reference was written:
 
 ## Widget Selection
 
-- Use `ConsumerWidget` when the widget only needs Riverpod.
-- Use `HookConsumerWidget` when the widget needs hooks and Riverpod in the same `build`.
-- Use `Consumer` for a small subtree when only part of a larger widget should rebuild.
-- Use hooks for widget-local lifecycle objects and ephemeral UI state.
+- Prefer `ConsumerWidget` when the widget only needs Riverpod.
+- Choose `HookConsumerWidget` if the widget needs hooks and Riverpod in the same `build`.
+- Employ `Consumer` for a small subtree when only part of a larger widget should rebuild.
+- Reserve hooks for widget-local lifecycle objects and ephemeral UI state.
 
 ```dart
 class SearchBox extends HookConsumerWidget {

--- a/.agents/skills/flutter-riverpod-expert/references/riverpod3-core.md
+++ b/.agents/skills/flutter-riverpod-expert/references/riverpod3-core.md
@@ -65,7 +65,7 @@ Generated family parameters become available by name inside the class (`listId` 
 - Generated providers are auto-dispose by default. Use `@Riverpod(keepAlive: true)` only when provider lifetime must outlive listeners.
 - `StateProvider`, `StateNotifierProvider`, and `ChangeNotifierProvider` are legacy in Riverpod 3. Keep them only for migration/maintenance and import from `legacy.dart`.
 - `AsyncValue` is sealed. Prefer exhaustive `switch` or `.when`.
-- In Riverpod 3, the safe nullable data getter is `.value`; old `valueOrNull` usage should be migrated.
+- In Riverpod 3, `valueOrNull` was renamed to `.value` and removed; migrate old `valueOrNull` reads to `.value`.
 - Riverpod throws if `Ref`/`Notifier` is used after disposal. Check `ref.mounted` after awaits in methods that might outlive the provider.
 - Exceptions while reading providers may be wrapped in `ProviderException`; inspect the original error when needed.
 - Widget listeners can be paused when widgets are not visible; do not assume an offscreen widget listener remains active for app-level work.
@@ -127,16 +127,24 @@ Override scoped values with `ProviderScope(overrides: [...])`.
 
 ## Testing
 
-Use `ProviderContainer.test` for provider tests:
+Use `ProviderContainer(...)` for provider tests and dispose it in `tearDown`:
 
 ```dart
-test('loads todos', () async {
-  final container = ProviderContainer.test(
+late ProviderContainer container;
+
+setUp(() {
+  container = ProviderContainer(
     overrides: [
       todoRepositoryProvider.overrideWithValue(fakeRepository),
     ],
   );
+});
 
+tearDown(() {
+  container.dispose();
+});
+
+test('loads todos', () async {
   expect(await container.read(todosProvider('inbox').future), hasLength(2));
 });
 ```

--- a/.agents/skills/flutter-riverpod-expert/references/riverpod3-core.md
+++ b/.agents/skills/flutter-riverpod-expert/references/riverpod3-core.md
@@ -87,6 +87,8 @@ Use `.when` if that better matches existing code.
 Riverpod 3 includes experimental `Mutation`. It is useful for UI-observable side effects such as create/update/delete operations. Because it is experimental, prefer existing project patterns.
 
 ```dart
+import 'package:riverpod/experimental/mutation.dart';
+
 final addMessageMutation = Mutation<MessageEntity>();
 
 void submit(WidgetRef ref, String text) {

--- a/.agents/skills/flutter-riverpod-expert/references/riverpod3-core.md
+++ b/.agents/skills/flutter-riverpod-expert/references/riverpod3-core.md
@@ -1,0 +1,142 @@
+# Riverpod 3 Core
+
+Use this reference for provider design, Riverpod 3 behavior, migrations, and tests.
+
+Official docs used when this reference was written:
+
+- https://riverpod.dev/docs/introduction/getting_started
+- https://riverpod.dev/docs/whats_new
+- https://riverpod.dev/docs/3.0_migration
+- https://riverpod.dev/docs/concepts/about_code_generation
+- https://riverpod.dev/docs/concepts2/scoping
+- https://riverpod.dev/docs/migration/from_state_notifier
+- https://riverpod.dev/docs/migration/from_change_notifier
+
+## Provider Selection
+
+Use generated providers when the project already uses `riverpod_generator`.
+
+| Need | Generated shape |
+| --- | --- |
+| Pure sync value, dependency injection, computed state | `@riverpod T name(Ref ref)` |
+| One-shot async fetch with no public mutation methods | `@riverpod Future<T> name(Ref ref)` |
+| Stream with no public mutation methods | `@riverpod Stream<T> name(Ref ref)` |
+| Mutable sync state with public intents | `@riverpod class Name extends _$Name { T build(); ... }` |
+| Mutable async state with public intents | `@riverpod class Name extends _$Name { Future<T> build() async; ... }` |
+| Mutable stream state with public intents | generated class with `Stream<T> build()` |
+
+Code generation is optional in Riverpod 3 generally, but if the package already uses generated providers, keep that style for consistency.
+
+## Generated Provider Basics
+
+```dart
+import 'dart:async';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'todos_notifier.g.dart';
+
+@riverpod
+class TodosNotifier extends _$TodosNotifier {
+  @override
+  FutureOr<List<Todo>> build(String listId) async {
+    final repo = ref.watch(todoRepositoryProvider);
+    return repo.fetchTodos(listId);
+  }
+
+  Future<void> addTodo(String title) async {
+    final previous = await future;
+    final repo = ref.read(todoRepositoryProvider);
+
+    state = AsyncData([...previous, Todo.pending(title)]);
+    await repo.createTodo(listId, title);
+
+    if (!ref.mounted) return;
+    ref.invalidateSelf();
+  }
+}
+```
+
+Generated family parameters become available by name inside the class (`listId` above). For non-codegen families this is usually `arg`.
+
+## Riverpod 3 Behavior to Remember
+
+- Failing providers retry automatically by default with exponential backoff until success or disposal. Disable/customize retry at `ProviderScope`, `ProviderContainer`, or provider annotation/constructor when errors are permanent.
+- Generated providers are auto-dispose by default. Use `@Riverpod(keepAlive: true)` only when provider lifetime must outlive listeners.
+- `StateProvider`, `StateNotifierProvider`, and `ChangeNotifierProvider` are legacy in Riverpod 3. Keep them only for migration/maintenance and import from `legacy.dart`.
+- `AsyncValue` is sealed. Prefer exhaustive `switch` or `.when`.
+- In Riverpod 3, the safe nullable data getter is `.value`; old `valueOrNull` usage should be migrated.
+- Riverpod throws if `Ref`/`Notifier` is used after disposal. Check `ref.mounted` after awaits in methods that might outlive the provider.
+- Exceptions while reading providers may be wrapped in `ProviderException`; inspect the original error when needed.
+- Widget listeners can be paused when widgets are not visible; do not assume an offscreen widget listener remains active for app-level work.
+
+## Async UI
+
+```dart
+return switch (ref.watch(todosProvider(listId))) {
+  AsyncData(:final value) => TodoListView(todos: value),
+  AsyncError(:final error) => ErrorView(error: error),
+  AsyncLoading(:final progress) => LoadingView(progress: progress),
+};
+```
+
+Use `.when` if that better matches existing code.
+
+## Mutations
+
+Riverpod 3 includes experimental `Mutation`. It is useful for UI-observable side effects such as create/update/delete operations. Because it is experimental, prefer existing project patterns.
+
+```dart
+final addMessageMutation = Mutation<MessageEntity>();
+
+void submit(WidgetRef ref, String text) {
+  addMessageMutation.run(ref, (tsx) async {
+    final notifier = tsx.get(chatMessagesProvider.notifier);
+    return notifier.addMessage(text);
+  });
+}
+```
+
+Use `tsx.get` inside mutation transactions rather than `ref.read`.
+
+## Scoped Providers
+
+Scoping requires explicit opt-in.
+
+```dart
+@Riverpod(dependencies: [])
+String? selectedConversation(Ref ref) => null;
+
+@Riverpod(dependencies: [selectedConversation])
+Future<List<Message>> messages(Ref ref) async {
+  final id = ref.watch(selectedConversationProvider);
+  ...
+}
+```
+
+Override scoped values with `ProviderScope(overrides: [...])`.
+
+## Performance
+
+- Use `select` when a widget needs one field from broad state.
+- Split widgets so each consumer rebuilds at the smallest practical boundary.
+- Avoid derived computations in widgets when a derived provider makes invalidation and tests clearer.
+- Use immutable state updates. Do not mutate lists/maps in place and reassign the same reference.
+
+## Testing
+
+Use `ProviderContainer.test` for provider tests:
+
+```dart
+test('loads todos', () async {
+  final container = ProviderContainer.test(
+    overrides: [
+      todoRepositoryProvider.overrideWithValue(fakeRepository),
+    ],
+  );
+
+  expect(await container.read(todosProvider('inbox').future), hasLength(2));
+});
+```
+
+Use `ProviderScope(overrides: [...])` in widget tests. Use Riverpod testing utilities already present in the project instead of creating global containers.


### PR DESCRIPTION
## Summary
- Split the Riverpod skill into a lean trigger file plus focused references
- Make `hooks_riverpod` the default Flutter import for AuraVibes
- Add Riverpod 3 guidance for scoped providers, auto-dispose, `Ref.mounted`, async state, and experimental mutations

## Testing
- Validated the skill metadata with the bundled skill validator