### PR TITLE
feat: Add reusable agents planning artifacts

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/006-fix-native-tool-permissions"
+  "feature_directory": "specs/007-reusable-agents"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ fvm flutter pub add dev:build_runner dev:json_serializable
 valid on melos >7
 
 ```bash
-fvm dart run melos analyze            # Analyze code quality
+fvm dart run melos run analyze        # Analyze code quality
 fvm dart run melos format             # Check code formatting
 fvm dart run melos run test               # Run all tests
 fvm dart run melos run validate:quick     # Quick development check
@@ -159,7 +159,7 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 - Verify version references are consistent across README, pubspec, and FVM config
 
 ## Active Technologies
-- Dart 3.11+ with Flutter 3.41.4+ via FVM + Flutter SDK, Riverpod with code generation, Freezed, Drift, dartantic_ai, auravibes_ui (007-reusable-agents)
+- Dart 3.11+ with Flutter 3.41.7 via FVM + Flutter SDK, Riverpod with code generation, Freezed, Drift, dartantic_ai, auravibes_ui (007-reusable-agents)
 - Local Drift SQLite database with schema migration (007-reusable-agents)
 
 - Dart 3.x (FVM pinned to 3.41.4+) + Flutter, Riverpod (with code generation), Freezed, auravibes_ui (001-two-step-model-selector)
@@ -170,7 +170,7 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 
 ## Recent Changes
 
-- 007-reusable-agents: Added Dart 3.11+ with Flutter 3.41.4+ via FVM + Flutter SDK, Riverpod with code generation, Freezed, Drift, dartantic_ai, auravibes_ui
+- 007-reusable-agents: Added reusable agents planning artifacts; canonical stack is listed in [Active Technologies](#active-technologies).
 - 001-two-step-model-selector: Added Dart 3.x (FVM pinned to 3.41.4+) + Flutter, Riverpod (with code generation), Freezed, auravibes_ui
 - 001-ui-library-widgets: Added Dart 3.11+ (Flutter 3.41.4+ via FVM) + Flutter SDK, flutter_portal, gpt_markdown, riverpod (existing)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ valid on melos >7
 
 ```bash
 fvm dart run melos run analyze        # Analyze code quality
-fvm dart run melos format             # Check code formatting
+fvm dart run melos run format:check   # Check code formatting
 fvm dart run melos run test               # Run all tests
 fvm dart run melos run validate:quick     # Quick development check
 fvm dart run melos run validate           # Full CI validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,8 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 - Verify version references are consistent across README, pubspec, and FVM config
 
 ## Active Technologies
+- Dart 3.11+ with Flutter 3.41.4+ via FVM + Flutter SDK, Riverpod with code generation, Freezed, Drift, dartantic_ai, auravibes_ui (007-reusable-agents)
+- Local Drift SQLite database with schema migration (007-reusable-agents)
 
 - Dart 3.x (FVM pinned to 3.41.4+) + Flutter, Riverpod (with code generation), Freezed, auravibes_ui (001-two-step-model-selector)
 - Drift database (existing, no schema changes needed) (001-two-step-model-selector)
@@ -168,6 +170,7 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 
 ## Recent Changes
 
+- 007-reusable-agents: Added Dart 3.11+ with Flutter 3.41.4+ via FVM + Flutter SDK, Riverpod with code generation, Freezed, Drift, dartantic_ai, auravibes_ui
 - 001-two-step-model-selector: Added Dart 3.x (FVM pinned to 3.41.4+) + Flutter, Riverpod (with code generation), Freezed, auravibes_ui
 - 001-ui-library-widgets: Added Dart 3.11+ (Flutter 3.41.4+ via FVM) + Flutter SDK, flutter_portal, gpt_markdown, riverpod (existing)
 
@@ -175,6 +178,6 @@ SomeExperimentalApi(), // ignore: experimental_member_use - Required for widgetb
 
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at `specs/006-fix-native-tool-permissions/plan.md`
+at `specs/007-reusable-agents/plan.md`
 
 <!-- SPECKIT END -->

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -85,16 +85,16 @@ melos:
     # Validation Pipeline (for CI)
     validate:
       run: |
-        melos analyze &&
-        melos run format &&
+        melos run analyze &&
+        melos run format:check &&
         melos run test &&
         melos run build
       description: Full validation pipeline for CI/CD
 
     validate:quick:
       run: |
-        melos analyze &&
-        melos run format
+        melos run analyze &&
+        melos run format:check
       description: Quick validation for development
 
     # Development Scripts
@@ -131,5 +131,3 @@ melos:
       packageFilters:
         dependsOn:
           - flutter_launcher_icons
-
-

--- a/specs/007-reusable-agents/agent-workflows.md
+++ b/specs/007-reusable-agents/agent-workflows.md
@@ -1,0 +1,81 @@
+# Agent Workflows: Reusable Agents
+
+## Example Agents
+
+| Display name | Slug | Instructions |
+| --- | --- | --- |
+| Reviewer | `reviewer` | Review code changes for correctness, missing tests, and unsafe assumptions. |
+| Support | `support` | Draft concise customer-support replies using workspace tone and escalation rules. |
+| Planner | `planner` | Break product requests into implementation phases, dependencies, and validation checks. |
+
+## New Chat Selection
+
+```text
+User selects Reviewer
+  -> NewChatNotifier stores selected agentId
+  -> SendNewMessageUsecase validates agent workspace ownership
+  -> ConversationRepository creates conversation with agentId
+  -> ContinueAgentUsecase resolves latest Reviewer instructions
+  -> build_prompt_chat_messages prepends instructions before chat history
+```
+
+Prompt before selection:
+
+```text
+user: "Review this diff."
+```
+
+Prompt after selecting `reviewer`:
+
+```text
+developer: "Review code changes for correctness, missing tests, and unsafe assumptions."
+user: "Review this diff."
+```
+
+## Existing Conversation Change
+
+```text
+User changes conversation from No Agent to Support
+  -> ConversationChatNotifier requests change
+  -> ChangeConversationAgentUsecase validates workspace ownership
+  -> ConversationRepository patches conversation.agentId
+  -> Next assistant response resolves latest Support instructions
+```
+
+Past messages are not rewritten. Only future response generation uses the new selection.
+
+## Edit Agent
+
+```text
+User edits Reviewer instructions
+  -> AgentsNotifier submits AgentPatch
+  -> UpdateAgentUsecase validates name/instructions and workspace slug uniqueness
+  -> AgentRepository saves updated record
+  -> Future prompts for conversations using Reviewer resolve the latest instructions
+```
+
+Conversations store `agentId`, not an instruction snapshot.
+
+## Delete Agent
+
+```text
+User deletes Reviewer
+  -> DeleteAgentUsecase deletes the agent
+  -> AgentRepository clears affected conversation.agentId values or guarantees fallback behavior
+  -> Selectors remove Reviewer
+  -> Next prompt behaves as No Agent
+```
+
+No stale deleted-agent instructions are injected.
+
+## Interface Responsibilities
+
+| Layer | Inputs | Outputs | Errors |
+| --- | --- | --- | --- |
+| `ChatAgentSelector` | current `agentId`, workspace agents | selected `agentId?` | local validation display only |
+| `NewChatNotifier` | selected `agentId?`, draft message | new conversation request | keeps previous selection on failure |
+| `ChangeConversationAgentUsecase` | conversation id, `agentId?` | updated conversation selection | cross-workspace and not-found exceptions |
+| `AgentRepository` | create/update/delete requests | persisted agent state | validation, duplicate slug, not-found exceptions |
+| `build_prompt_chat_messages` | messages, optional instructions | ordered prompt messages | no persistence or UI side effects |
+
+Unexpected infrastructure failures should bubble unless they can be mapped to validation, duplicate slug, not-found, or cross-workspace cases.

--- a/specs/007-reusable-agents/checklists/requirements.md
+++ b/specs/007-reusable-agents/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Reusable Agents
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on first review.

--- a/specs/007-reusable-agents/contracts/reusable-agents-ui.md
+++ b/specs/007-reusable-agents/contracts/reusable-agents-ui.md
@@ -1,0 +1,72 @@
+# UI Contract: Reusable Agents
+
+## Agents Management Screen
+
+Route context:
+- Workspace route: `/workspaces/:workspaceId/...`
+- Screen displays agents for current workspace only.
+
+Required states:
+- Empty: show no agents and offer create action.
+- Loaded: show scannable list/table with name, slug, and instructions preview.
+- Saving/deleting: prevent duplicate submissions and show progress.
+- Error: show user-readable validation or persistence failure.
+
+Required actions:
+- Create agent with `name` and `instructions`.
+- Edit agent `name` and `instructions`.
+- Delete agent.
+
+Validation behavior:
+- Empty name blocks save.
+- Empty instructions block save.
+- Duplicate generated slug in same workspace blocks save and asks for a distinct name.
+
+## New Chat Agent Selector
+
+Location:
+- New chat screen near model selection and chat input.
+
+Options:
+- Always includes "No Agent".
+- Includes current workspace agents only.
+
+Behavior:
+- Default selection is "No Agent".
+- Selected agent id is passed into new conversation creation.
+- Starting a chat remains blocked only by required model/message validation, not by lack of agents.
+
+## Existing Conversation Agent Selector
+
+Location:
+- Conversation screen near conversation-level controls.
+
+Options:
+- Always includes "No Agent".
+- Includes current workspace agents only.
+
+Behavior:
+- Shows the conversation's current agent selection.
+- Changing selection updates the conversation for future assistant responses only.
+- If current selection references a deleted agent, show "No Agent" and inform the user before next send.
+
+## Prompt Behavior Contract
+
+Inputs:
+- `conversationId`
+- Conversation messages
+- Current conversation agent selection
+- Latest saved instructions for selected agent, if any
+
+Expected behavior:
+- "No Agent": prompt contains only normal conversation history and existing tool messages.
+- Selected agent: prompt includes latest saved agent instructions as non-visible conversation guidance before normal conversation history.
+- Deleted/missing selected agent: clear or ignore selection, inform user, and proceed as "No Agent".
+
+## Out of Scope
+
+- Tool presets.
+- Per-agent model selection.
+- Scheduled/background tasks.
+- Flow builder.
+- Instruction version history.

--- a/specs/007-reusable-agents/contracts/reusable-agents-ui.md
+++ b/specs/007-reusable-agents/contracts/reusable-agents-ui.md
@@ -12,6 +12,35 @@ Required states:
 - Saving/deleting: prevent duplicate submissions and show progress.
 - Error: show user-readable validation or persistence failure.
 
+Example states:
+
+```text
+Empty
++------------------------------+
+| No reusable agents           |
+| [Create Agent]               |
++------------------------------+
+
+Loaded
++------------+---------------+----------------------+
+| Name       | Slug          | Instructions         |
++------------+---------------+----------------------+
+| Reviewer   | reviewer      | Review code changes. |
+| Support    | support       | Answer with tone.    |
++------------+---------------+----------------------+
+
+Saving/deleting
++------------+---------------+----------------------+
+| Reviewer   | reviewer      | Saving.              |
++------------+---------------+----------------------+
+
+Error
++------------------------------+
+| Name already exists in this  |
+| workspace. Choose another.   |
++------------------------------+
+```
+
 Required actions:
 - Create agent with `name` and `instructions`.
 - Edit agent `name` and `instructions`.
@@ -30,6 +59,14 @@ Location:
 Options:
 - Always includes "No Agent".
 - Includes current workspace agents only.
+
+Example option list:
+
+```text
+No Agent
+Reviewer        reviewer
+Support         support
+```
 
 Behavior:
 - Default selection is "No Agent".
@@ -50,6 +87,15 @@ Behavior:
 - Changing selection updates the conversation for future assistant responses only.
 - If current selection references a deleted agent, show "No Agent" and inform the user before next send.
 
+Selector state flow:
+
+```text
+loading agents -> show current value -> user selects option -> save selection
+save success -> update displayed value
+save failure -> keep previous value and show error
+deleted selected agent -> display "No Agent" and show fallback notice
+```
+
 ## Prompt Behavior Contract
 
 Inputs:
@@ -62,6 +108,12 @@ Expected behavior:
 - "No Agent": prompt contains only normal conversation history and existing tool messages.
 - Selected agent: prompt includes latest saved agent instructions as non-visible conversation guidance before normal conversation history.
 - Deleted/missing selected agent: clear or ignore selection, inform user, and proceed as "No Agent".
+
+Agent responsibilities and use cases:
+- `Reviewer` should influence future assistant responses by adding review-focused instructions before conversation history.
+- `Support` should influence future assistant responses by adding support-tone instructions before conversation history.
+- Selectors only choose an agent; prompt composition owns instruction injection.
+- Delete flow owns fallback to "No Agent"; prompt composition must not use deleted-agent instructions.
 
 ## Out of Scope
 

--- a/specs/007-reusable-agents/data-model.md
+++ b/specs/007-reusable-agents/data-model.md
@@ -97,3 +97,14 @@ Output rule:
 - If no agent is selected, build prompt from conversation messages only.
 - If an agent is selected, prepend agent instructions as conversation-level guidance before conversation history.
 - User-created agent instructions do not override platform safety or security rules.
+
+Example selected-agent prompt shape:
+
+```text
+1. developer: "Reusable agent instructions for reviewer: Review code changes for correctness, missing tests, and unsafe assumptions."
+2. user: "Can you review this diff?"
+3. assistant: "Yes. Share the diff."
+4. user: "<diff>"
+```
+
+The first message is derived from the latest saved `ReusableAgent.instructions`. It guides the assistant for this response but remains lower priority than platform, safety, and security instructions.

--- a/specs/007-reusable-agents/data-model.md
+++ b/specs/007-reusable-agents/data-model.md
@@ -85,7 +85,7 @@ Conversation.agentId
 - Add unique index for `(workspace_id, slug)`.
 - Add nullable `agent_id` to `conversations`.
 - Migration increments Drift schema version.
-- Deleting an agent should make affected conversations behave as "No Agent"; implementation may either null affected `agent_id` values in the delete operation or use nullable references with fallback logic, but user-visible behavior must match the spec.
+- Deleting an agent must transactionally set `conversations.agent_id = NULL` for all affected conversations. Runtime missing-agent fallback is defense-in-depth only and must not be the primary deletion contract.
 
 ## Prompt Composition
 

--- a/specs/007-reusable-agents/data-model.md
+++ b/specs/007-reusable-agents/data-model.md
@@ -1,0 +1,99 @@
+# Data Model: Reusable Agents
+
+## Entity: ReusableAgent
+
+Workspace-scoped assistant profile selected by conversations.
+
+Fields:
+- `id`: Unique identifier.
+- `workspaceId`: Parent workspace identifier. Required.
+- `name`: User-facing display name. Required, trimmed, non-empty.
+- `slug`: Slug derived from `name`. Required, non-empty, unique within `workspaceId`.
+- `instructions`: User-authored reusable agent instructions. Required, trimmed, non-empty.
+- `createdAt`: Creation timestamp.
+- `updatedAt`: Last update timestamp.
+
+Relationships:
+- Belongs to one Workspace.
+- Can be referenced by many Conversations.
+
+Validation:
+- `workspaceId` must not be empty.
+- `name` must not be empty after trimming.
+- `slug` must not be empty after generation.
+- `(workspaceId, slug)` must be unique.
+- `instructions` must not be empty after trimming.
+
+Lifecycle:
+- Created from Agents management screen.
+- Edited from Agents management screen.
+- Deleted from Agents management screen.
+- Deleted agents are unavailable in selectors.
+
+## Entity: Conversation
+
+Existing conversation entity extended with optional selected agent.
+
+Added field:
+- `agentId`: Optional selected reusable agent identifier. `null` means "No Agent".
+
+Relationships:
+- Belongs to one Workspace.
+- May reference one ReusableAgent in the same workspace.
+
+Validation:
+- `agentId` may be null.
+- If `agentId` is present, the referenced agent must exist in the conversation workspace.
+
+Lifecycle:
+- New conversation starts with `agentId` from the new-chat selector.
+- Existing conversation can update `agentId` from the conversation selector.
+- If referenced agent is deleted, conversation falls back to `agentId = null` before the next message is sent.
+
+## Entity: ConversationAgentSelection
+
+User-facing state derived from Conversation and ReusableAgent.
+
+Fields:
+- `conversationId`: Conversation identifier.
+- `selectedAgentId`: Optional reusable agent identifier.
+- `label`: "No Agent" or selected agent display name.
+- `slug`: Selected agent slug when present.
+
+Validation:
+- `selectedAgentId = null` is always valid.
+- Selected agent must belong to the same workspace as the conversation.
+
+## State Transitions
+
+```text
+ReusableAgent
+  draft input -> saved
+  saved -> edited
+  saved -> deleted
+
+Conversation.agentId
+  null -> agentId        (user selects agent)
+  agentId -> otherAgent  (user switches agent)
+  agentId -> null        (user selects No Agent)
+  deletedAgent -> null   (fallback before next send)
+```
+
+## Database Notes
+
+- Add `agents` table with a foreign key to `workspaces`.
+- Add unique index for `(workspace_id, slug)`.
+- Add nullable `agent_id` to `conversations`.
+- Migration increments Drift schema version.
+- Deleting an agent should make affected conversations behave as "No Agent"; implementation may either null affected `agent_id` values in the delete operation or use nullable references with fallback logic, but user-visible behavior must match the spec.
+
+## Prompt Composition
+
+Prompt generation receives:
+- Existing conversation messages.
+- Optional selected agent instructions resolved from the latest saved ReusableAgent.
+
+Output rule:
+- If no agent is selected, build prompt from conversation messages only.
+- If an agent is selected, prepend agent instructions as conversation-level guidance before conversation history.
+- User-created agent instructions do not override platform safety or security rules.

--- a/specs/007-reusable-agents/data-model.md
+++ b/specs/007-reusable-agents/data-model.md
@@ -24,6 +24,18 @@ Validation:
 - `(workspaceId, slug)` must be unique.
 - `instructions` must not be empty after trimming.
 
+Slug generation:
+- Trim leading and trailing whitespace from `name`.
+- Normalize Unicode to a comparable ASCII form where possible.
+- Convert to lowercase.
+- Replace runs of whitespace with a single hyphen.
+- Remove punctuation and unsupported special characters.
+- Collapse repeated hyphens and trim leading or trailing hyphens.
+- Limit the generated slug to 64 characters, truncating at a hyphen boundary when practical.
+- Resolve same-workspace collisions by appending the next numeric suffix (`-1`, `-2`, and so on) until unique.
+- Example: `"Code Reviewer!"` becomes `code-reviewer`.
+- Implementations may use the project's standard slugify utility if it follows these rules.
+
 Lifecycle:
 - Created from Agents management screen.
 - Edited from Agents management screen.

--- a/specs/007-reusable-agents/plan.md
+++ b/specs/007-reusable-agents/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: Reusable Agents
+
+**Branch**: `007-reusable-agents` | **Date**: 2026-04-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/007-reusable-agents/spec.md`
+
+## Summary
+
+Add workspace-scoped reusable agents to the Flutter app. Users can create, edit, delete, browse, and select agents for new and existing conversations. Each agent stores a display name, a workspace-unique slug, and instructions. Conversations store the selected agent reference and always use the latest saved agent instructions for future responses. Deleted agents disappear from selection surfaces and affected conversations fall back to "No Agent".
+
+Technical approach: add Drift persistence for agents and conversation selections, domain entities/repositories/use cases under the existing app architecture, Riverpod providers/notifiers for UI state, chat prompt composition that prepends selected agent instructions as conversation-level guidance, and UI controls in Agents, New Chat, and Conversation screens.
+
+## Technical Context
+
+**Language/Version**: Dart 3.11+ with Flutter 3.41.4+ via FVM  
+**Primary Dependencies**: Flutter SDK, Riverpod with code generation, Freezed, Drift, dartantic_ai, auravibes_ui  
+**Storage**: Local Drift SQLite database with schema migration  
+**Testing**: `fvm flutter test` for focused package tests; `fvm dart run melos analyze`, `fvm dart run melos format`, and `fvm dart run melos run validate:quick` for validation  
+**Target Platform**: AuraVibes Flutter app targets supported desktop/mobile/web platforms  
+**Project Type**: Flutter monorepo application feature in `apps/auravibes_app`  
+**Performance Goals**: Agent list and selectors remain responsive with at least 10 workspace agents; selecting/changing an agent completes in 2 actions or fewer per spec  
+**Constraints**: Use existing feature-based architecture, Drift DAOs for persistence, Riverpod generated providers, `auravibes_ui` design system, no tool presets, no model selection changes, no scheduled/background tasks, no flow builder  
+**Scale/Scope**: Workspace-local agent management, conversation-level selection, latest-instructions prompt injection, delete fallback to "No Agent"
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Start with User Needs**: PASS. Spec defines prioritized independently testable stories for create, select, edit, browse, and delete.
+- **II. Design with Data**: PASS. This plan defines Drift tables, repository boundaries, data model, UI contract, and migration before implementation.
+- **III. Package-First Architecture**: PASS. Feature belongs in `apps/auravibes_app`; reusable styling remains in `auravibes_ui`; no new package needed.
+- **IV. UI Kit Mandate**: PASS. Screens and selectors must use `auravibes_ui` components/tokens.
+- **V. Test-Driven Development**: PASS. Quickstart requires tests for DAO/repository/use cases/widgets before implementation, integration coverage for critical agent journeys, and a coverage audit before completion.
+- **VI. Fail Fast + Explicit Errors**: PASS. Validation failures, duplicate slug conflicts, not-found cases, and cross-workspace selection rejections use meaningful explicit domain exceptions per `error-handling-exceptions`; generic catch-and-rethrow wrappers are not allowed.
+- **VII. Simplicity + YAGNI**: PASS. Plan excludes tools, model choice, scheduling, background tasks, and flow builder.
+- **VIII. Observability + Performance**: PASS. Plan includes task coverage for structured logging on create/edit/delete/select/fallback operations, timed manual verification for UX success criteria, and lightweight query targets.
+- **IX. Security + Privacy**: PASS. Agent instructions are user-authored conversation guidance; no secrets should be logged; platform rules remain higher priority.
+- **X. Code Quality Standards**: PASS. Plan follows existing Dart naming, generated providers, Freezed entities, Drift DAOs, and validation commands.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-reusable-agents/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── reusable-agents-ui.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+apps/auravibes_app/lib/
+├── data/
+│   ├── database/drift/
+│   │   ├── app_database.dart
+│   │   ├── daos/agents_dao.dart
+│   │   └── tables/agents_table.dart
+│   └── repositories/agent_repository_impl.dart
+├── domain/
+│   ├── entities/agent.dart
+│   └── repositories/agent_repository.dart
+├── features/
+│   ├── agents/
+│   │   ├── notifiers/agents_notifier.dart
+│   │   ├── providers/agent_repository_provider.dart
+│   │   ├── screens/agents_screen.dart
+│   │   ├── usecases/create_agent_usecase.dart
+│   │   ├── usecases/delete_agent_usecase.dart
+│   │   ├── usecases/update_agent_usecase.dart
+│   │   └── widgets/
+│   └── chats/
+│       ├── notifiers/new_chat_notifier.dart
+│       ├── screens/chat_conversation_screen.dart
+│       ├── screens/new_chat_screen.dart
+│       └── usecases/
+│           ├── change_conversation_agent_usecase.dart
+│           ├── send_new_message_usecase.dart
+│           └── continue_agent_usecase.dart
+├── router/app_router.dart
+├── widgets/app_navigation_wrappers.dart
+└── services/chatbot_service/build_prompt_chat_messages.dart
+
+apps/auravibes_app/test/
+├── data/
+│   ├── database/agents_dao_test.dart
+│   └── repositories/agent_repository_impl_test.dart
+├── features/
+│   ├── agents/
+│   └── chats/
+└── services/chatbot_service/build_prompt_chat_messages_test.dart
+```
+
+**Structure Decision**: Implement in `apps/auravibes_app` because agents are app-specific workspace/conversation behavior. Add domain/repository/data layers for persistence, feature-layer use cases and notifiers for user actions, and update chat services only where prompt composition needs selected agent instructions.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Phase 0: Research
+
+See [research.md](./research.md).
+
+## Phase 1: Design
+
+See [data-model.md](./data-model.md), [contracts/reusable-agents-ui.md](./contracts/reusable-agents-ui.md), and [quickstart.md](./quickstart.md).
+
+## Post-Design Constitution Check
+
+- **Data before UI**: PASS. `data-model.md` defines tables, relationships, validation, and transitions before task generation.
+- **API contracts before providers**: PASS. `contracts/reusable-agents-ui.md` defines UI and prompt behavior contracts.
+- **TDD path**: PASS. `quickstart.md` lists focused failing tests before implementation, integration tests for critical journeys, and coverage validation.
+- **Simplicity**: PASS. No future workflow features enter implementation scope.
+- **Security/privacy**: PASS. Prompt priority, meaningful explicit exceptions, and no-secret structured logging constraints are explicit.

--- a/specs/007-reusable-agents/plan.md
+++ b/specs/007-reusable-agents/plan.md
@@ -14,7 +14,7 @@ Technical approach: add Drift persistence for agents and conversation selections
 **Language/Version**: Dart 3.11+ with Flutter 3.41.7 via FVM
 **Primary Dependencies**: Flutter SDK, Riverpod with code generation, Freezed, Drift, dartantic_ai, auravibes_ui
 **Storage**: Local Drift SQLite database with schema migration
-**Testing**: `fvm flutter test` for focused package tests; `fvm dart run melos run analyze`, `fvm dart run melos format`, and `fvm dart run melos run validate:quick` for validation
+**Testing**: `fvm flutter test` for focused package tests; `fvm dart run melos run analyze`, `fvm dart run melos run format:check`, and `fvm dart run melos run validate:quick` for validation
 **Target Platform**: AuraVibes Flutter app targets supported desktop/mobile/web platforms
 **Project Type**: Flutter monorepo application feature in `apps/auravibes_app`
 **Performance Goals**: Agent list and selectors remain responsive with at least 10 workspace agents; selecting/changing an agent completes in 2 actions or fewer per spec

--- a/specs/007-reusable-agents/plan.md
+++ b/specs/007-reusable-agents/plan.md
@@ -11,14 +11,14 @@ Technical approach: add Drift persistence for agents and conversation selections
 
 ## Technical Context
 
-**Language/Version**: Dart 3.11+ with Flutter 3.41.4+ via FVM  
-**Primary Dependencies**: Flutter SDK, Riverpod with code generation, Freezed, Drift, dartantic_ai, auravibes_ui  
-**Storage**: Local Drift SQLite database with schema migration  
-**Testing**: `fvm flutter test` for focused package tests; `fvm dart run melos analyze`, `fvm dart run melos format`, and `fvm dart run melos run validate:quick` for validation  
-**Target Platform**: AuraVibes Flutter app targets supported desktop/mobile/web platforms  
-**Project Type**: Flutter monorepo application feature in `apps/auravibes_app`  
-**Performance Goals**: Agent list and selectors remain responsive with at least 10 workspace agents; selecting/changing an agent completes in 2 actions or fewer per spec  
-**Constraints**: Use existing feature-based architecture, Drift DAOs for persistence, Riverpod generated providers, `auravibes_ui` design system, no tool presets, no model selection changes, no scheduled/background tasks, no flow builder  
+**Language/Version**: Dart 3.11+ with Flutter 3.41.7 via FVM
+**Primary Dependencies**: Flutter SDK, Riverpod with code generation, Freezed, Drift, dartantic_ai, auravibes_ui
+**Storage**: Local Drift SQLite database with schema migration
+**Testing**: `fvm flutter test` for focused package tests; `fvm dart run melos run analyze`, `fvm dart run melos format`, and `fvm dart run melos run validate:quick` for validation
+**Target Platform**: AuraVibes Flutter app targets supported desktop/mobile/web platforms
+**Project Type**: Flutter monorepo application feature in `apps/auravibes_app`
+**Performance Goals**: Agent list and selectors remain responsive with at least 10 workspace agents; selecting/changing an agent completes in 2 actions or fewer per spec
+**Constraints**: Use existing feature-based architecture, Drift DAOs for persistence, Riverpod generated providers, `auravibes_ui` design system, no tool presets, no model selection changes, no scheduled/background tasks, no flow builder
 **Scale/Scope**: Workspace-local agent management, conversation-level selection, latest-instructions prompt injection, delete fallback to "No Agent"
 
 ## Constitution Check
@@ -108,6 +108,10 @@ See [research.md](./research.md).
 ## Phase 1: Design
 
 See [data-model.md](./data-model.md), [contracts/reusable-agents-ui.md](./contracts/reusable-agents-ui.md), and [quickstart.md](./quickstart.md).
+
+### Agent Interaction Examples
+
+See [agent-workflows.md](./agent-workflows.md) for concrete reusable-agent examples, UI-to-domain flow sequences, prompt composition before/after examples, and selector fallback behavior.
 
 ## Post-Design Constitution Check
 

--- a/specs/007-reusable-agents/quickstart.md
+++ b/specs/007-reusable-agents/quickstart.md
@@ -1,0 +1,92 @@
+# Quickstart: Reusable Agents
+
+## Preconditions
+
+- Run commands from repo root unless noted.
+- Use `fvm` for all Dart/Flutter commands.
+- No new dependency should be added without `fvm flutter pub add` from the package directory.
+
+## TDD Checklist
+
+1. Add failing DAO/repository tests for workspace-scoped agents:
+   - create stores name, slug, instructions, workspace id
+   - duplicate slug in same workspace fails
+   - same slug in different workspace succeeds
+   - edit updates name, slug, instructions
+   - delete removes agent from selectors and falls conversations back to "No Agent"
+
+2. Add failing domain/use-case tests:
+   - creating rejects empty name or instructions
+   - selecting an agent rejects agents from another workspace
+   - new conversation stores selected agent id
+   - existing conversation agent change affects future responses only
+   - deleted agent selection resolves to "No Agent"
+
+3. Add failing prompt tests:
+   - no agent keeps current prompt behavior unchanged
+   - selected agent prepends latest saved instructions
+   - edited instructions are used on next response
+   - deleted agent does not inject stale instructions
+
+4. Add failing widget/notifier tests:
+   - Agents screen empty/list/error states
+   - create/edit validation messages
+   - duplicate slug error
+   - new chat selector defaults to "No Agent"
+   - conversation selector reflects and changes selected agent
+
+5. Add failing integration journey tests:
+   - create, edit, browse, and delete an agent in one workspace
+   - start a new chat with an agent and verify selected-agent behavior
+   - change an existing conversation agent and verify future-only behavior
+   - delete a selected agent and verify fallback to "No Agent"
+
+6. Record each focused failing test run before implementation for the related phase.
+
+## Implementation Order
+
+1. Add Drift table, DAO, schema version migration, and generated files.
+2. Add domain entity and repository interface/implementation.
+3. Add feature providers, use cases, and notifiers for agent CRUD and selection.
+4. Update conversation entity/repository to support optional `agentId`.
+5. Update new-chat flow to pass selected agent id.
+6. Update conversation flow to change selected agent.
+7. Update prompt composition to inject latest selected-agent instructions.
+8. Replace Agents placeholder screen with management UI.
+9. Add selector UI to new chat and conversation screens.
+
+## Validation Commands
+
+From repo root:
+
+```bash
+fvm dart run build_runner build --delete-conflicting-outputs
+fvm dart run melos analyze
+fvm dart run melos format
+fvm dart run melos run validate:quick
+```
+
+From `apps/auravibes_app`:
+
+```bash
+fvm flutter test test/data/database/agents_dao_test.dart --no-pub
+fvm flutter test test/data/repositories/agent_repository_impl_test.dart --no-pub
+fvm flutter test test/services/chatbot_service/build_prompt_chat_messages_test.dart --no-pub
+fvm flutter test integration_test/reusable_agents_management_flow_test.dart integration_test/reusable_agents_new_chat_flow_test.dart integration_test/reusable_agents_conversation_flow_test.dart --no-pub
+fvm flutter test --coverage --no-pub
+```
+
+## Manual Verification
+
+1. Open a workspace.
+2. Open Agents.
+3. Create agent named `Reviewer` with instructions.
+4. Confirm slug is shown and duplicate `Reviewer` in same workspace is rejected.
+5. Start new chat with `Reviewer`; verify future response follows instructions.
+6. Edit `Reviewer` instructions; verify next response uses latest instructions.
+7. Switch existing conversation to "No Agent"; verify instructions stop applying.
+8. Delete `Reviewer`; verify selector no longer shows it and affected conversations fall back to "No Agent".
+9. Verify create completes in under 60 seconds.
+10. Verify new-chat agent selection and existing-conversation agent changes each take 2 actions or fewer.
+11. Verify current conversation agent is identifiable within 3 seconds.
+12. Verify an existing agent can be found and edited within 30 seconds when the workspace has at least 10 agents.

--- a/specs/007-reusable-agents/quickstart.md
+++ b/specs/007-reusable-agents/quickstart.md
@@ -62,7 +62,7 @@ From repo root:
 ```bash
 fvm dart run melos run generate
 fvm dart run melos run analyze
-fvm dart run melos format
+fvm dart run melos run format:check
 fvm dart run melos run validate:quick
 ```
 

--- a/specs/007-reusable-agents/quickstart.md
+++ b/specs/007-reusable-agents/quickstart.md
@@ -60,8 +60,8 @@
 From repo root:
 
 ```bash
-fvm dart run build_runner build --delete-conflicting-outputs
-fvm dart run melos analyze
+fvm dart run melos run generate
+fvm dart run melos run analyze
 fvm dart run melos format
 fvm dart run melos run validate:quick
 ```

--- a/specs/007-reusable-agents/research.md
+++ b/specs/007-reusable-agents/research.md
@@ -48,6 +48,29 @@
 - Store agent instructions as visible chat messages: rejected because it pollutes conversation history.
 - Append instructions after user messages: rejected because it weakens the intended guidance and can confuse chronological history.
 
+**Usage example**:
+
+Before selection, prompt construction uses the visible conversation history only:
+
+```text
+user: "Review this migration."
+assistant: "Share the migration file."
+```
+
+After selecting `code-reviewer`, prompt construction prepends the latest saved instructions:
+
+```text
+developer: "Act as a code reviewer. Focus on correctness, tests, and migration safety."
+user: "Review this migration."
+assistant: "Share the migration file."
+```
+
+If the selected `agentId` later points to a deleted agent, the conversation behaves as `"No Agent"` before the next send and does not inject stale instructions.
+
+Example agents:
+- `code-reviewer`: reviews diffs for correctness, test gaps, and unsafe assumptions.
+- `support-bot`: answers customer-support drafts using workspace tone and escalation rules.
+
 ## Decision: Keep tool presets, model choice, scheduling, background tasks, and flow builder out of scope
 
 **Rationale**: The first implementation should ship reusable instruction profiles only. Future workflow capabilities can attach to the same workspace-scoped agent concept after the core lifecycle is stable.

--- a/specs/007-reusable-agents/research.md
+++ b/specs/007-reusable-agents/research.md
@@ -1,0 +1,57 @@
+# Research: Reusable Agents
+
+## Decision: Store agents as workspace-scoped records
+
+**Rationale**: Workspace scope matches existing app routing (`/workspaces/:workspaceId/...`) and keeps reusable instructions tied to the work context where they are meaningful. It avoids cross-workspace leakage and matches the clarified spec.
+
+**Alternatives considered**:
+- User-wide agents: rejected because the current app surfaces most resources through workspace context.
+- Conversation-local agents: rejected because the feature goal is reuse across conversations.
+
+## Decision: Store display name and generated slug
+
+**Rationale**: The user-facing name preserves natural labels while the slug gives a stable, scannable unique identifier per workspace. Unique workspace slugs reduce ambiguity in selectors and future linking without forcing global uniqueness.
+
+**Alternatives considered**:
+- Name only: rejected because duplicate names would create selector ambiguity.
+- Global slug uniqueness: rejected because common names such as "reviewer" should be reusable in different workspaces.
+
+## Decision: Add agent reference to conversations
+
+**Rationale**: Conversation-level selection must persist across app restarts and affect future responses. A nullable `agentId` on conversations models "No Agent" naturally and keeps current chat flows simple.
+
+**Alternatives considered**:
+- Separate conversation-agent table: rejected because each conversation has at most one selected agent in current scope.
+- Store instructions snapshot on conversation: rejected by clarification; conversations must use latest saved instructions.
+
+## Decision: Use latest saved instructions at prompt time
+
+**Rationale**: The selected conversation references the reusable agent. Looking up current instructions before response generation honors edits immediately and avoids version-history complexity.
+
+**Alternatives considered**:
+- Selection-time snapshot: rejected because it makes edits less predictable for users.
+- User-selectable version behavior: rejected as unnecessary configurability for the first scope.
+
+## Decision: Delete agents and fall conversations back to "No Agent"
+
+**Rationale**: Deletion completes the CRUD lifecycle. Falling back to "No Agent" is predictable, avoids hidden archived behavior, and prevents stale instructions from continuing after deletion.
+
+**Alternatives considered**:
+- No delete: rejected because clarified scope includes deletion.
+- Archive: rejected because it adds extra state and selector rules not needed now.
+
+## Decision: Inject agent instructions as conversation-level guidance before chat history
+
+**Rationale**: Agent instructions should guide future assistant behavior without becoming a normal user message. Prompt construction can prepend a system/developer-style instruction message, subject to available provider capabilities, while preserving higher-priority platform safety rules.
+
+**Alternatives considered**:
+- Store agent instructions as visible chat messages: rejected because it pollutes conversation history.
+- Append instructions after user messages: rejected because it weakens the intended guidance and can confuse chronological history.
+
+## Decision: Keep tool presets, model choice, scheduling, background tasks, and flow builder out of scope
+
+**Rationale**: The first implementation should ship reusable instruction profiles only. Future workflow capabilities can attach to the same workspace-scoped agent concept after the core lifecycle is stable.
+
+**Alternatives considered**:
+- Add placeholder fields now: rejected by YAGNI and constitution simplicity rules.
+- Build a generic workflow graph now: rejected because it exceeds current accepted requirements.

--- a/specs/007-reusable-agents/spec.md
+++ b/specs/007-reusable-agents/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: Reusable Agents
+
+**Feature Branch**: `007-reusable-agents`  
+**Created**: 2026-04-24  
+**Status**: Draft  
+**Input**: User description: "Agent workflows: reusable agents, tool presets, scheduled/background tasks, flow builder. A table that design the agent per workflow. If user don't have an agent, the user can run conversation with no agent (or a general agent from our system whatever is best for UX). In new chat and in conversation, the chat interface should allow selecting an agent from no agent to any created one. When creating or editing the agent, the agent has name and instructions. No tools for now, no model for now. When a user selects an agent for the conversation, then the instructions are added as system prompts. How other AI agents manage the agents system instructions?"
+
+## Clarifications
+
+### Session 2026-04-24
+
+- Q: What ownership scope should reusable agents have? → A: Workspace-scoped agents
+- Q: What uniqueness rule should reusable agent names follow? → A: Store display name and slug; slug must be unique per workspace
+- Q: What should happen when users delete reusable agents? → A: Users can delete agents; conversations using them fall back to "No Agent"
+- Q: Should conversations use latest agent instructions or a selection-time snapshot? → A: Conversations always use the latest saved agent instructions
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Create a reusable agent (Priority: P1)
+
+A user creates a reusable agent by giving it a clear name and reusable instructions so they can apply the same behavior across multiple chats.
+
+**Why this priority**: Agent creation is the foundation for reuse. Without it, chat selection has no user-created agents to apply.
+
+**Independent Test**: Can be fully tested by creating an agent with a name and instructions, then confirming it appears in the user's agent list.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has no reusable agents, **When** they create an agent with a valid name and instructions, **Then** the agent is saved and appears in the agent list.
+2. **Given** a user enters an empty name or empty instructions, **When** they try to save the agent, **Then** the system prevents saving and explains which field needs input.
+3. **Given** a user has existing reusable agents, **When** they create another agent with a distinct name, **Then** both agents remain available for future conversations.
+4. **Given** a user enters a name whose generated slug already exists in the workspace, **When** they try to save the agent, **Then** the system prevents saving and asks for a distinct name.
+
+---
+
+### User Story 2 - Select an agent for a new chat (Priority: P1)
+
+A user starts a new chat and chooses whether the conversation should use no agent or one of their reusable agents.
+
+**Why this priority**: The main value of reusable agents is applying saved instructions at conversation start.
+
+**Independent Test**: Can be fully tested by opening a new chat, selecting an agent, sending a message, and confirming the conversation uses the selected agent's instructions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has created reusable agents, **When** they start a new chat, **Then** the chat interface offers "No Agent" and each created agent as choices.
+2. **Given** a user selects "No Agent" for a new chat, **When** they send a message, **Then** the conversation runs without user-defined agent instructions.
+3. **Given** a user selects a reusable agent for a new chat, **When** they send a message, **Then** the conversation applies that agent's instructions to the assistant behavior.
+
+---
+
+### User Story 3 - Change the agent in an existing conversation (Priority: P2)
+
+A user changes the selected agent inside an existing conversation so future assistant responses follow the newly selected instructions.
+
+**Why this priority**: Users may discover that a conversation needs a different role or no agent after it has already started.
+
+**Independent Test**: Can be fully tested by changing the selected agent in an existing conversation and confirming subsequent responses use the new selection.
+
+**Acceptance Scenarios**:
+
+1. **Given** a conversation is using "No Agent", **When** the user selects a reusable agent, **Then** future assistant responses use the selected agent's instructions.
+2. **Given** a conversation is using one reusable agent, **When** the user selects a different reusable agent, **Then** future assistant responses use the new agent's instructions.
+3. **Given** a conversation is using a reusable agent, **When** the user selects "No Agent", **Then** future assistant responses stop using user-defined agent instructions.
+
+---
+
+### User Story 4 - Edit a reusable agent (Priority: P2)
+
+A user edits a reusable agent's name or instructions so the saved agent remains useful as their workflow changes.
+
+**Why this priority**: Agent instructions need refinement over time, but editing can ship after basic create-and-select behavior.
+
+**Independent Test**: Can be fully tested by editing an existing agent, selecting it in a conversation, and confirming the updated instructions are used for future responses.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has an existing agent, **When** they edit the agent name, **Then** selectors and lists show the updated name.
+2. **Given** a user has an existing agent, **When** they edit the agent instructions, **Then** future responses in conversations using that agent apply the updated instructions.
+3. **Given** a conversation already used an agent before it was edited, **When** the user continues the conversation, **Then** the interface clearly reflects the currently selected agent and uses the latest saved instructions for future responses.
+
+---
+
+### User Story 5 - Browse agents in a workflow-oriented table (Priority: P3)
+
+A user views reusable agents in a table-like management surface so they can scan names, instructions previews, and usage context before editing or selecting one.
+
+**Why this priority**: A table improves management as agents grow, but creation and selection deliver the first usable value.
+
+**Independent Test**: Can be fully tested by creating multiple agents and confirming the management surface presents them in a scannable list with edit access.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has multiple agents, **When** they open agent management, **Then** each agent appears as one row or item with its name and an instructions preview.
+2. **Given** a user wants to refine an agent, **When** they choose edit from the management surface, **Then** they can update the agent's name and instructions.
+
+---
+
+### User Story 6 - Delete a reusable agent (Priority: P3)
+
+A user deletes a reusable agent they no longer need so outdated instructions do not clutter the workspace's agent list.
+
+**Why this priority**: Deletion completes the agent lifecycle, but users can still get value from create, edit, and select before deletion ships.
+
+**Independent Test**: Can be fully tested by deleting an agent and confirming it no longer appears in agent management or chat selectors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has an existing reusable agent, **When** they delete the agent, **Then** it no longer appears in the workspace's agent management surface or chat selectors.
+2. **Given** a deleted agent was selected in existing conversations, **When** those conversations are opened or continued, **Then** they fall back to "No Agent" before the next message is sent.
+
+### Edge Cases
+
+- If a user has no created agents, the chat selector still allows starting or continuing with "No Agent".
+- If an agent is renamed while selected in a conversation, the conversation selector shows the updated name without changing the selected agent.
+- If an edited name would create a duplicate workspace slug, the system prevents saving and keeps the previous agent values.
+- If an agent's instructions are very long, the management surface truncates previews while preserving the full instructions for editing and conversation use.
+- If the selected agent is deleted, the conversation falls back to "No Agent" and informs the user before the next message is sent.
+- If a user switches agents mid-conversation, only future assistant responses are affected; previous messages remain unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Users MUST be able to create a workspace-scoped reusable agent with a name and instructions.
+- **FR-002**: Users MUST be able to edit a reusable agent's name and instructions.
+- **FR-003**: The system MUST prevent saving a reusable agent when the name or instructions are empty.
+- **FR-004**: The system MUST store both the user-facing agent name and a slug derived from that name.
+- **FR-005**: Reusable agent slugs MUST be unique within each workspace.
+- **FR-006**: Users MUST be able to delete reusable agents from the current workspace.
+- **FR-007**: When a reusable agent is deleted, the system MUST remove it from the workspace's agent management surface and chat selectors.
+- **FR-008**: Conversations that referenced a deleted agent MUST fall back to "No Agent" before the next message is sent.
+- **FR-009**: Users MUST be able to view reusable agents for the current workspace in a management surface suitable for scanning multiple agents.
+- **FR-010**: The agent management surface MUST show each agent's name, slug, and a preview of its instructions.
+- **FR-011**: The chat interface MUST let users choose "No Agent" or one of the current workspace's reusable agents when starting a new chat.
+- **FR-012**: The chat interface MUST let users choose "No Agent" or one of the current workspace's reusable agents from within an existing conversation.
+- **FR-013**: "No Agent" MUST be available even when the user has no created agents.
+- **FR-014**: When a reusable agent is selected for a conversation, the assistant MUST apply that agent's instructions as higher-priority conversation guidance than the user's normal message content.
+- **FR-015**: User-created agent instructions MUST NOT override non-user system safety, security, or platform rules.
+- **FR-016**: Changing the selected agent in an existing conversation MUST affect future assistant responses only.
+- **FR-017**: The system MUST clearly show the currently selected agent for a conversation.
+- **FR-018**: Conversations using a reusable agent MUST use the latest saved instructions for that agent when generating future assistant responses.
+- **FR-019**: The current feature MUST exclude tool presets, scheduled or background tasks, flow-builder behavior, and model selection.
+
+### Key Entities
+
+- **Reusable Agent**: A workspace-scoped assistant profile with a display name, unique workspace slug, and instructions. It is intended to be selected across multiple conversations in that workspace.
+- **Conversation Agent Selection**: The current agent choice for a conversation. It can be "No Agent" or one reusable agent.
+- **Agent Management Surface**: A scannable list or table where users create, review, and edit reusable agents.
+
+### Assumptions
+
+- "No Agent" is the default state because it is explicit, predictable, and avoids inventing an unseen general-agent behavior.
+- Reusable agents belong to one workspace and are not available from other workspaces.
+- Agent slugs are derived from display names and must be unique only inside their workspace.
+- Agent instructions act like conversation-level system guidance, while platform and safety rules remain higher priority.
+- Agent edits apply to future uses and future responses; historical messages are not rewritten.
+- Conversation agent selections reference the reusable agent itself, not a frozen copy of the instructions.
+- Deleted agents are unavailable for future selection, and affected conversations use "No Agent" going forward.
+- Tool presets, scheduled/background tasks, and flow builder are future workflow capabilities, not part of this feature's first scope.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can create a reusable agent with valid name and instructions in under 60 seconds.
+- **SC-002**: A user can start a new chat with "No Agent" or a selected reusable agent in 2 actions or fewer from the new-chat screen.
+- **SC-003**: A user can change the selected agent in an existing conversation in 2 actions or fewer from the conversation screen.
+- **SC-004**: 95% of tested agent selections result in future assistant responses following the selected agent's instructions while preserving higher-priority platform rules.
+- **SC-005**: Users can identify the currently selected conversation agent within 3 seconds during usability testing.
+- **SC-006**: Users can find and edit an existing reusable agent within 30 seconds when the account has at least 10 agents.

--- a/specs/007-reusable-agents/tasks.md
+++ b/specs/007-reusable-agents/tasks.md
@@ -1,0 +1,312 @@
+# Tasks: Reusable Agents
+
+**Input**: Design documents from `specs/007-reusable-agents/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/reusable-agents-ui.md](./contracts/reusable-agents-ui.md), [quickstart.md](./quickstart.md)
+**Tests**: Required by project constitution and quickstart. Write tests first, run them, and confirm they fail before implementation.
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no dependency on incomplete tasks.
+- **[Story]**: Maps to the user story phase only.
+- Every task includes exact file path(s).
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare feature folders and navigation targets without implementing behavior.
+
+- [ ] T001 Create agents feature folders in `apps/auravibes_app/lib/features/agents/notifiers/`, `apps/auravibes_app/lib/features/agents/providers/`, `apps/auravibes_app/lib/features/agents/usecases/`, and `apps/auravibes_app/lib/features/agents/widgets/`
+- [ ] T002 [P] Create agent test folders in `apps/auravibes_app/test/features/agents/notifiers/`, `apps/auravibes_app/test/features/agents/usecases/`, and `apps/auravibes_app/test/features/agents/widgets/`
+- [ ] T003 [P] Create data test placeholders in `apps/auravibes_app/test/data/database/agents_dao_test.dart` and `apps/auravibes_app/test/data/repositories/agent_repository_impl_test.dart`
+- [ ] T004 [P] Create chat agent-selection test placeholders in `apps/auravibes_app/test/features/chats/usecases/change_conversation_agent_usecase_test.dart` and `apps/auravibes_app/test/features/chats/notifiers/new_chat_notifier_test.dart`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core data/domain infrastructure required before user stories.
+
+**CRITICAL**: No user story implementation begins until this phase is complete.
+
+- [ ] T005 [P] Add failing Drift schema tests for `agents` table columns, `(workspace_id, slug)` uniqueness, and nullable `conversations.agent_id` in `apps/auravibes_app/test/data/database/agents_dao_test.dart`
+- [ ] T006 [P] Add failing domain validation tests for `AgentToCreate`, `AgentPatch`, and slug generation in `apps/auravibes_app/test/domain/entities/agent_test.dart`
+- [ ] T007 Create `Agents` Drift table with `workspaceId`, `name`, `slug`, `instructions`, timestamps, and workspace foreign key in `apps/auravibes_app/lib/data/database/drift/tables/agents_table.dart`
+- [ ] T008 Update `Conversations` Drift table with nullable `agentId` foreign-key field in `apps/auravibes_app/lib/data/database/drift/tables/conversations_table.dart`
+- [ ] T009 Register `Agents` table and `AgentsDao` in `apps/auravibes_app/lib/data/database/drift/app_database.dart`
+- [ ] T010 Add Drift migration for schema version 6 with `agents` table, unique workspace slug index, and `conversations.agent_id` column in `apps/auravibes_app/lib/data/database/drift/app_database.dart`
+- [ ] T011 Implement `AgentsDao` with create, update, delete, get-by-id, get-by-workspace, get-by-workspace-slug, and watch-by-workspace methods in `apps/auravibes_app/lib/data/database/drift/daos/agents_dao.dart`
+- [ ] T012 Add `AgentEntity`, `AgentToCreate`, and `AgentPatch` Freezed models with validation helpers in `apps/auravibes_app/lib/domain/entities/agent.dart`
+- [ ] T013 Add slug generation helper used by `AgentToCreate` and `AgentPatch` in `apps/auravibes_app/lib/domain/entities/agent.dart`
+- [ ] T014 Add `AgentRepository` interface and explicit agent exceptions in `apps/auravibes_app/lib/domain/repositories/agent_repository.dart`
+- [ ] T015 Implement `AgentRepositoryImpl` with validation, slug uniqueness mapping, and DAO calls in `apps/auravibes_app/lib/data/repositories/agent_repository_impl.dart`
+- [ ] T016 Add Riverpod repository provider for agents in `apps/auravibes_app/lib/features/agents/providers/agent_repository_provider.dart`
+- [ ] T017 Update `ConversationEntity`, `ConversationToCreate`, and `ConversationPatch` with optional `agentId` in `apps/auravibes_app/lib/domain/entities/conversation.dart`
+- [ ] T018 Update `ConversationRepositoryImpl` mapping, create, patch, and validation for optional `agentId` in `apps/auravibes_app/lib/data/repositories/conversation_repository_impl.dart`
+- [ ] T019 Run generated code for Drift, Freezed, and Riverpod from repo root using `fvm dart run build_runner build --delete-conflicting-outputs`
+
+**Checkpoint**: Data/domain foundation builds and user-story work can begin.
+
+---
+
+## Phase 3: User Story 1 - Create a reusable agent (Priority: P1) MVP
+
+**Goal**: User creates a workspace-scoped reusable agent with valid name and instructions.
+
+**Independent Test**: Create an agent and confirm it appears in the workspace agent list; empty fields and duplicate slug are rejected.
+
+### Tests for User Story 1
+
+- [ ] T020 [P] [US1] Add failing repository tests for successful create, empty name, empty instructions, duplicate slug in same workspace, and same slug in another workspace in `apps/auravibes_app/test/data/repositories/agent_repository_impl_test.dart`
+- [ ] T021 [P] [US1] Add failing create use-case tests for validation and duplicate slug errors in `apps/auravibes_app/test/features/agents/usecases/create_agent_usecase_test.dart`
+- [ ] T022 [P] [US1] Add failing Agents notifier tests for create loading, success refresh, and validation error state in `apps/auravibes_app/test/features/agents/notifiers/agents_notifier_test.dart`
+- [ ] T023 [P] [US1] Add failing widget tests for create-agent form required fields and duplicate slug error in `apps/auravibes_app/test/features/agents/widgets/agent_form_test.dart`
+
+### Implementation for User Story 1
+
+- [ ] T024 [US1] Implement create-agent repository path and map duplicate slug failures to `AgentDuplicateSlugException` in `apps/auravibes_app/lib/data/repositories/agent_repository_impl.dart`
+- [ ] T025 [US1] Implement `CreateAgentUsecase` in `apps/auravibes_app/lib/features/agents/usecases/create_agent_usecase.dart`
+- [ ] T026 [US1] Implement `AgentsNotifier` create flow, loading state, error state, and list refresh in `apps/auravibes_app/lib/features/agents/notifiers/agents_notifier.dart`
+- [ ] T027 [US1] Implement reusable agent form widget with name and instructions inputs in `apps/auravibes_app/lib/features/agents/widgets/agent_form.dart`
+- [ ] T028 [US1] Replace placeholder create state in `apps/auravibes_app/lib/features/agents/screens/agents_screen.dart` with create action wired to `AgentsNotifier`
+
+**Checkpoint**: US1 works independently as MVP.
+
+---
+
+## Phase 4: User Story 2 - Select an agent for a new chat (Priority: P1)
+
+**Goal**: User starts a new chat with "No Agent" or one workspace agent.
+
+**Independent Test**: Select an agent on new chat, send first message, and confirm the new conversation stores the selected agent and prompt uses its latest instructions.
+
+### Tests for User Story 2
+
+- [ ] T029 [P] [US2] Add failing `SendNewMessageUsecase` tests for `agentId` persistence and cross-workspace rejection in `apps/auravibes_app/test/features/chats/usecases/send_new_message_usecase_test.dart`
+- [ ] T030 [P] [US2] Add failing `NewChatNotifier` tests for default "No Agent", set agent, and start conversation with selected agent in `apps/auravibes_app/test/features/chats/notifiers/new_chat_notifier_test.dart`
+- [ ] T031 [P] [US2] Add failing prompt tests for no-agent unchanged behavior and selected-agent instruction injection in `apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart`
+- [ ] T032 [P] [US2] Add failing widget tests for new-chat agent selector options and default selection in `apps/auravibes_app/test/features/chats/widgets/chat_agent_selector_test.dart`
+
+### Implementation for User Story 2
+
+- [ ] T033 [US2] Update `SendNewMessageUsecase` to accept optional `agentId`, validate workspace ownership, and create conversation with selected agent in `apps/auravibes_app/lib/features/chats/usecases/send_new_message_usecase.dart`
+- [ ] T034 [US2] Update `NewChatState` and `NewChatNotifier` with selected `agentId` and setter in `apps/auravibes_app/lib/features/chats/notifiers/new_chat_notifier.dart`
+- [ ] T035 [US2] Implement read provider for workspace agents used by chat selectors in `apps/auravibes_app/lib/features/agents/providers/agents_provider.dart`
+- [ ] T036 [US2] Implement `ChatAgentSelector` widget with "No Agent" plus workspace agents in `apps/auravibes_app/lib/features/chats/widgets/chat_agent_selector.dart`
+- [ ] T037 [US2] Add `ChatAgentSelector` to `NewChatScreen` and pass selected `agentId` into `NewChatNotifier` in `apps/auravibes_app/lib/features/chats/screens/new_chat_screen.dart`
+- [ ] T038 [US2] Update prompt construction to support optional selected agent instructions in `apps/auravibes_app/lib/services/chatbot_service/build_prompt_chat_messages.dart`
+- [ ] T039 [US2] Update `ContinueAgentUsecase` to resolve the conversation's current agent and pass latest instructions to prompt construction in `apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart`
+
+**Checkpoint**: US2 works independently with US1-created agents.
+
+---
+
+## Phase 5: User Story 3 - Change the agent in an existing conversation (Priority: P2)
+
+**Goal**: User changes a conversation's selected agent and only future responses use the new selection.
+
+**Independent Test**: Change an existing conversation from "No Agent" to an agent, from one agent to another, and back to "No Agent"; verify future prompt behavior.
+
+### Tests for User Story 3
+
+- [ ] T040 [P] [US3] Add failing `ChangeConversationAgentUsecase` tests for set agent, switch agent, clear agent, and cross-workspace rejection in `apps/auravibes_app/test/features/chats/usecases/change_conversation_agent_usecase_test.dart`
+- [ ] T041 [P] [US3] Add failing `ConversationChatNotifier` tests for setting conversation agent and refreshing selected state in `apps/auravibes_app/test/features/chats/notifiers/conversation_chat_notifier_test.dart`
+- [ ] T042 [P] [US3] Add failing conversation selector widget tests for current value and change handling in `apps/auravibes_app/test/features/chats/widgets/conversation_agent_selector_test.dart`
+
+### Implementation for User Story 3
+
+- [ ] T043 [US3] Implement `ChangeConversationAgentUsecase` in `apps/auravibes_app/lib/features/chats/usecases/change_conversation_agent_usecase.dart`
+- [ ] T044 [US3] Update `ConversationChatNotifier` with set-agent flow and error handling in `apps/auravibes_app/lib/features/chats/notifiers/conversation_chat_notifier.dart`
+- [ ] T045 [US3] Add `ChatAgentSelector` to `ChatConversationScreen` with current conversation `agentId` and set-agent callback in `apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart`
+- [ ] T046 [US3] Ensure `ContinueAgentUsecase` uses changed `agentId` only for future response generation in `apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart`
+
+**Checkpoint**: US3 works independently after foundation and agent creation.
+
+---
+
+## Phase 6: User Story 4 - Edit a reusable agent (Priority: P2)
+
+**Goal**: User edits agent name or instructions; future responses use the latest saved instructions.
+
+**Independent Test**: Edit an agent, confirm selectors/lists show new name/slug, and confirm next response uses updated instructions.
+
+### Tests for User Story 4
+
+- [ ] T047 [P] [US4] Add failing repository tests for update name, update instructions, duplicate slug on edit, and unchanged values in `apps/auravibes_app/test/data/repositories/agent_repository_impl_test.dart`
+- [ ] T048 [P] [US4] Add failing update use-case tests for validation and latest-instructions behavior in `apps/auravibes_app/test/features/agents/usecases/update_agent_usecase_test.dart`
+- [ ] T049 [P] [US4] Add failing prompt test proving edited instructions are used on the next response in `apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart`
+- [ ] T050 [P] [US4] Add failing widget tests for edit-agent form prefill and save behavior in `apps/auravibes_app/test/features/agents/widgets/agent_form_test.dart`
+
+### Implementation for User Story 4
+
+- [ ] T051 [US4] Implement update-agent repository path and duplicate slug mapping in `apps/auravibes_app/lib/data/repositories/agent_repository_impl.dart`
+- [ ] T052 [US4] Implement `UpdateAgentUsecase` in `apps/auravibes_app/lib/features/agents/usecases/update_agent_usecase.dart`
+- [ ] T053 [US4] Extend `AgentsNotifier` with edit flow, loading state, and refresh in `apps/auravibes_app/lib/features/agents/notifiers/agents_notifier.dart`
+- [ ] T054 [US4] Wire edit action and prefilled `AgentForm` in `apps/auravibes_app/lib/features/agents/screens/agents_screen.dart`
+- [ ] T055 [US4] Ensure prompt resolution fetches latest agent instructions at response time in `apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart`
+
+**Checkpoint**: US4 works independently with existing selected conversations.
+
+---
+
+## Phase 7: User Story 5 - Browse agents in a workflow-oriented table (Priority: P3)
+
+**Goal**: User scans workspace agents by name, slug, and instructions preview.
+
+**Independent Test**: Create multiple agents and confirm management surface shows scannable rows/items with edit access.
+
+### Tests for User Story 5
+
+- [ ] T056 [P] [US5] Add failing Agents screen widget tests for empty state, loaded rows, slug display, instructions preview, and edit action in `apps/auravibes_app/test/features/agents/screens/agents_screen_test.dart`
+- [ ] T057 [P] [US5] Add failing provider tests for workspace agent list ordering and current-workspace filtering in `apps/auravibes_app/test/features/agents/providers/agents_provider_test.dart`
+
+### Implementation for User Story 5
+
+- [ ] T058 [US5] Implement workspace agent list provider with current-workspace filtering in `apps/auravibes_app/lib/features/agents/providers/agents_provider.dart`
+- [ ] T059 [US5] Implement agent list/table row widget showing name, slug, and instructions preview in `apps/auravibes_app/lib/features/agents/widgets/agent_list_item.dart`
+- [ ] T060 [US5] Complete `AgentsScreen` empty, loading, error, and loaded management states in `apps/auravibes_app/lib/features/agents/screens/agents_screen.dart`
+- [ ] T061 [US5] Add Agents route branch in `apps/auravibes_app/lib/router/app_router.dart`
+- [ ] T062 [US5] Add Agents navigation item and branch handling in `apps/auravibes_app/lib/widgets/app_navigation_wrappers.dart`
+
+**Checkpoint**: US5 management view is independently usable.
+
+---
+
+## Phase 8: User Story 6 - Delete a reusable agent (Priority: P3)
+
+**Goal**: User deletes an agent; selectors remove it and affected conversations fall back to "No Agent".
+
+**Independent Test**: Delete a selected agent, reopen affected conversation, and confirm no stale instructions are injected.
+
+### Tests for User Story 6
+
+- [ ] T063 [P] [US6] Add failing DAO/repository tests for delete and conversation fallback to null `agentId` in `apps/auravibes_app/test/data/repositories/agent_repository_impl_test.dart`
+- [ ] T064 [P] [US6] Add failing delete use-case tests for deletion, missing agent, and fallback behavior in `apps/auravibes_app/test/features/agents/usecases/delete_agent_usecase_test.dart`
+- [ ] T065 [P] [US6] Add failing prompt test proving deleted agent instructions are not injected in `apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart`
+- [ ] T066 [P] [US6] Add failing Agents screen widget tests for delete confirmation, deleting state, and row removal in `apps/auravibes_app/test/features/agents/screens/agents_screen_test.dart`
+
+### Implementation for User Story 6
+
+- [ ] T067 [US6] Implement delete-agent repository transaction that removes the agent and nulls affected conversations in `apps/auravibes_app/lib/data/repositories/agent_repository_impl.dart`
+- [ ] T068 [US6] Implement `DeleteAgentUsecase` in `apps/auravibes_app/lib/features/agents/usecases/delete_agent_usecase.dart`
+- [ ] T069 [US6] Extend `AgentsNotifier` with delete flow, confirmation state, loading state, and refresh in `apps/auravibes_app/lib/features/agents/notifiers/agents_notifier.dart`
+- [ ] T070 [US6] Wire delete action and confirmation UI in `apps/auravibes_app/lib/features/agents/screens/agents_screen.dart`
+- [ ] T071 [US6] Add fallback notification when a conversation's deleted agent resolves to "No Agent" in `apps/auravibes_app/lib/features/chats/screens/chat_conversation_screen.dart`
+
+**Checkpoint**: US6 lifecycle behavior works without stale prompt instructions.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validation, generated files, accessibility, and documentation.
+
+- [ ] T072 [P] Add localization keys for agent labels, validation errors, and delete confirmation in `apps/auravibes_app/lib/i18n/locale_keys.dart`
+- [ ] T073 [P] Add localized agent strings to app translation files under `apps/auravibes_app/assets/i18n/`
+- [ ] T074 [P] Review UI accessibility labels and keyboard focus behavior for agent forms/selectors in `apps/auravibes_app/lib/features/agents/widgets/agent_form.dart` and `apps/auravibes_app/lib/features/chats/widgets/chat_agent_selector.dart`
+- [ ] T075 [P] Add failing integration test for create, edit, browse, and delete agent lifecycle in `apps/auravibes_app/integration_test/reusable_agents_management_flow_test.dart`
+- [ ] T076 [P] Add failing integration test for new-chat agent selection and prompt behavior in `apps/auravibes_app/integration_test/reusable_agents_new_chat_flow_test.dart`
+- [ ] T077 [P] Add failing integration test for existing-conversation agent change and deleted-agent fallback in `apps/auravibes_app/integration_test/reusable_agents_conversation_flow_test.dart`
+- [ ] T078 Add structured logging assertions for create/edit/delete/select/fallback operations in `apps/auravibes_app/test/features/agents/notifiers/agents_notifier_test.dart` and `apps/auravibes_app/test/features/chats/notifiers/conversation_chat_notifier_test.dart`
+- [ ] T079 Implement structured logging with user action, workspace id, conversation id when present, agent id when present, and error type in `apps/auravibes_app/lib/features/agents/notifiers/agents_notifier.dart` and `apps/auravibes_app/lib/features/chats/notifiers/conversation_chat_notifier.dart`
+- [ ] T080 Review agent repository and use cases for `error-handling-exceptions`: keep validation, duplicate slug, not-found, and cross-workspace exceptions; remove generic catch-and-rethrow wrappers in `apps/auravibes_app/lib/data/repositories/agent_repository_impl.dart`, `apps/auravibes_app/lib/features/agents/usecases/`, and `apps/auravibes_app/lib/features/chats/usecases/change_conversation_agent_usecase.dart`
+- [ ] T081 Run generated code from repo root using `fvm dart run build_runner build --delete-conflicting-outputs`
+- [ ] T082 Run focused app tests from `apps/auravibes_app` using `fvm flutter test test/data/database/agents_dao_test.dart test/data/repositories/agent_repository_impl_test.dart test/services/chatbot_service/build_prompt_chat_messages_test.dart --no-pub`
+- [ ] T083 Run integration tests from `apps/auravibes_app` using `fvm flutter test integration_test/reusable_agents_management_flow_test.dart integration_test/reusable_agents_new_chat_flow_test.dart integration_test/reusable_agents_conversation_flow_test.dart --no-pub`
+- [ ] T084 Run coverage audit from `apps/auravibes_app` using `fvm flutter test --coverage --no-pub` and verify new feature coverage meets the project 80% minimum
+- [ ] T085 Manually verify SC-001 through SC-006 timings and action counts from `specs/007-reusable-agents/quickstart.md`
+- [ ] T086 Run repo validation from root using `fvm dart run melos analyze`, `fvm dart run melos format`, and `fvm dart run melos run validate:quick`
+- [ ] T087 Update `specs/007-reusable-agents/quickstart.md` with any final manual verification changes discovered during implementation
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup; blocks all user stories.
+- **US1 Create Agent (Phase 3)**: Depends on Foundational; MVP.
+- **US2 New Chat Selection (Phase 4)**: Depends on Foundational and uses agents from US1 for full manual demo.
+- **US3 Existing Conversation Selection (Phase 5)**: Depends on Foundational and reusable agents from US1.
+- **US4 Edit Agent (Phase 6)**: Depends on Foundational and reusable agents from US1.
+- **US5 Browse Agents (Phase 7)**: Depends on Foundational; benefits from US1 data.
+- **US6 Delete Agent (Phase 8)**: Depends on Foundational and reusable agents from US1.
+- **Polish (Phase 9)**: Depends on completed target stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: First MVP slice; no other story dependency after foundation.
+- **US2 (P1)**: Can be built after foundation but needs an existing agent to verify selected-agent behavior.
+- **US3 (P2)**: Needs existing conversations and agents for full verification.
+- **US4 (P2)**: Needs existing agents and selected conversations to verify latest instructions.
+- **US5 (P3)**: Can be built after foundation, but meaningful with created agents.
+- **US6 (P3)**: Needs existing agents and selected conversations to verify fallback.
+
+### Parallel Opportunities
+
+- T002, T003, and T004 can run in parallel after T001.
+- T005 and T006 can run in parallel before schema/domain implementation.
+- Within each user story, test tasks marked `[P]` can run in parallel before implementation.
+- US3, US4, US5, and US6 can be developed in parallel after US1 creates reusable agents, with coordination on shared files noted below.
+
+### Shared File Coordination
+
+- `apps/auravibes_app/lib/features/agents/screens/agents_screen.dart` is touched by US1, US4, US5, and US6; sequence those tasks or merge carefully.
+- `apps/auravibes_app/lib/features/agents/notifiers/agents_notifier.dart` is touched by US1, US4, and US6; sequence those tasks.
+- `apps/auravibes_app/lib/features/chats/usecases/continue_agent_usecase.dart` is touched by US2, US3, and US4; sequence prompt-resolution changes.
+- `apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart` is touched by US2, US4, and US6; keep test additions grouped by scenario.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "T020 [P] [US1] Add failing repository tests for successful create, empty name, empty instructions, duplicate slug in same workspace, and same slug in another workspace in apps/auravibes_app/test/data/repositories/agent_repository_impl_test.dart"
+Task: "T021 [P] [US1] Add failing create use-case tests for validation and duplicate slug errors in apps/auravibes_app/test/features/agents/usecases/create_agent_usecase_test.dart"
+Task: "T022 [P] [US1] Add failing Agents notifier tests for create loading, success refresh, and validation error state in apps/auravibes_app/test/features/agents/notifiers/agents_notifier_test.dart"
+Task: "T023 [P] [US1] Add failing widget tests for create-agent form required fields and duplicate slug error in apps/auravibes_app/test/features/agents/widgets/agent_form_test.dart"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "T029 [P] [US2] Add failing SendNewMessageUsecase tests for agentId persistence and cross-workspace rejection in apps/auravibes_app/test/features/chats/usecases/send_new_message_usecase_test.dart"
+Task: "T030 [P] [US2] Add failing NewChatNotifier tests for default No Agent, set agent, and start conversation with selected agent in apps/auravibes_app/test/features/chats/notifiers/new_chat_notifier_test.dart"
+Task: "T031 [P] [US2] Add failing prompt tests for no-agent unchanged behavior and selected-agent instruction injection in apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart"
+Task: "T032 [P] [US2] Add failing widget tests for new-chat agent selector options and default selection in apps/auravibes_app/test/features/chats/widgets/chat_agent_selector_test.dart"
+```
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 (US1 Create Agent).
+3. Stop and validate: user can create a workspace-scoped reusable agent and see validation failures.
+4. Add Phase 4 (US2) for first end-to-end conversation value.
+
+### Incremental Delivery
+
+1. Foundation: Drift/domain/repository contracts.
+2. US1: Create reusable agent.
+3. US2: Select agent on new chat and inject instructions.
+4. US3: Change agent in existing conversation.
+5. US4: Edit latest instructions.
+6. US5: Browse/manage table.
+7. US6: Delete with fallback.
+
+### TDD Rule
+
+For each story phase, complete test tasks first, run focused tests to confirm failure, then implement story tasks and rerun the same tests until green.
+
+### Explicit Exceptions Rule
+
+Use meaningful domain exceptions only for expected business decisions: validation rejected, duplicate slug, missing agent, and cross-workspace selection. Let unexpected infrastructure errors bubble unless they can be mapped to one of those business cases.
+
+## Notes
+
+- No tasks add tool presets, model selection, scheduled/background tasks, or flow-builder behavior.
+- Use `auravibes_ui` components and tokens for all UI work.
+- Use Riverpod generated providers and run build_runner after adding generated annotations.
+- Use Drift DAOs and migrations for persistence changes.
+- Never log agent instructions, chat content, API keys, auth tokens, or other sensitive values in structured logs.

--- a/specs/007-reusable-agents/tasks.md
+++ b/specs/007-reusable-agents/tasks.md
@@ -311,6 +311,6 @@ See [agent-workflows.md](./agent-workflows.md) for UI-to-notifier-to-usecase seq
 
 - No tasks add tool presets, model selection, scheduled/background tasks, or flow-builder behavior.
 - Use `auravibes_ui` components and tokens for all UI work.
-- Use Riverpod generated providers and run build_runner after adding generated annotations.
+- Use Riverpod generated providers and run code generation via `fvm dart run melos run generate` after adding generated annotations.
 - Use Drift DAOs and migrations for persistence changes.
 - Never log agent instructions, chat content, API keys, auth tokens, or other sensitive values in structured logs.

--- a/specs/007-reusable-agents/tasks.md
+++ b/specs/007-reusable-agents/tasks.md
@@ -42,7 +42,7 @@
 - [ ] T016 Add Riverpod repository provider for agents in `apps/auravibes_app/lib/features/agents/providers/agent_repository_provider.dart`
 - [ ] T017 Update `ConversationEntity`, `ConversationToCreate`, and `ConversationPatch` with optional `agentId` in `apps/auravibes_app/lib/domain/entities/conversation.dart`
 - [ ] T018 Update `ConversationRepositoryImpl` mapping, create, patch, and validation for optional `agentId` in `apps/auravibes_app/lib/data/repositories/conversation_repository_impl.dart`
-- [ ] T019 Run generated code for Drift, Freezed, and Riverpod from repo root using `fvm dart run build_runner build --delete-conflicting-outputs`
+- [ ] T019 Run generated code for Drift, Freezed, and Riverpod from repo root using `fvm dart run melos run generate`
 
 **Checkpoint**: Data/domain foundation builds and user-story work can begin.
 
@@ -209,12 +209,12 @@
 - [ ] T078 Add structured logging assertions for create/edit/delete/select/fallback operations in `apps/auravibes_app/test/features/agents/notifiers/agents_notifier_test.dart` and `apps/auravibes_app/test/features/chats/notifiers/conversation_chat_notifier_test.dart`
 - [ ] T079 Implement structured logging with user action, workspace id, conversation id when present, agent id when present, and error type in `apps/auravibes_app/lib/features/agents/notifiers/agents_notifier.dart` and `apps/auravibes_app/lib/features/chats/notifiers/conversation_chat_notifier.dart`
 - [ ] T080 Review agent repository and use cases for `error-handling-exceptions`: keep validation, duplicate slug, not-found, and cross-workspace exceptions; remove generic catch-and-rethrow wrappers in `apps/auravibes_app/lib/data/repositories/agent_repository_impl.dart`, `apps/auravibes_app/lib/features/agents/usecases/`, and `apps/auravibes_app/lib/features/chats/usecases/change_conversation_agent_usecase.dart`
-- [ ] T081 Run generated code from repo root using `fvm dart run build_runner build --delete-conflicting-outputs`
+- [ ] T081 Run generated code from repo root using `fvm dart run melos run generate`
 - [ ] T082 Run focused app tests from `apps/auravibes_app` using `fvm flutter test test/data/database/agents_dao_test.dart test/data/repositories/agent_repository_impl_test.dart test/services/chatbot_service/build_prompt_chat_messages_test.dart --no-pub`
 - [ ] T083 Run integration tests from `apps/auravibes_app` using `fvm flutter test integration_test/reusable_agents_management_flow_test.dart integration_test/reusable_agents_new_chat_flow_test.dart integration_test/reusable_agents_conversation_flow_test.dart --no-pub`
 - [ ] T084 Run coverage audit from `apps/auravibes_app` using `fvm flutter test --coverage --no-pub` and verify new feature coverage meets the project 80% minimum
 - [ ] T085 Manually verify SC-001 through SC-006 timings and action counts from `specs/007-reusable-agents/quickstart.md`
-- [ ] T086 Run repo validation from root using `fvm dart run melos analyze`, `fvm dart run melos format`, and `fvm dart run melos run validate:quick`
+- [ ] T086 Run repo validation from root using `fvm dart run melos run analyze`, `fvm dart run melos format`, and `fvm dart run melos run validate:quick`
 - [ ] T087 Update `specs/007-reusable-agents/quickstart.md` with any final manual verification changes discovered during implementation
 
 ---
@@ -302,6 +302,10 @@ For each story phase, complete test tasks first, run focused tests to confirm fa
 ### Explicit Exceptions Rule
 
 Use meaningful domain exceptions only for expected business decisions: validation rejected, duplicate slug, missing agent, and cross-workspace selection. Let unexpected infrastructure errors bubble unless they can be mapped to one of those business cases.
+
+### Agent Workflow Examples
+
+See [agent-workflows.md](./agent-workflows.md) for UI-to-notifier-to-usecase sequences, prompt composition examples, and interface responsibilities for reusable-agent selection, edit, and delete flows.
 
 ## Notes
 

--- a/specs/007-reusable-agents/tasks.md
+++ b/specs/007-reusable-agents/tasks.md
@@ -214,7 +214,7 @@
 - [ ] T083 Run integration tests from `apps/auravibes_app` using `fvm flutter test integration_test/reusable_agents_management_flow_test.dart integration_test/reusable_agents_new_chat_flow_test.dart integration_test/reusable_agents_conversation_flow_test.dart --no-pub`
 - [ ] T084 Run coverage audit from `apps/auravibes_app` using `fvm flutter test --coverage --no-pub` and verify new feature coverage meets the project 80% minimum
 - [ ] T085 Manually verify SC-001 through SC-006 timings and action counts from `specs/007-reusable-agents/quickstart.md`
-- [ ] T086 Run repo validation from root using `fvm dart run melos run analyze`, `fvm dart run melos format`, and `fvm dart run melos run validate:quick`
+- [ ] T086 Run repo validation from root using `fvm dart run melos run analyze`, `fvm dart run melos run format:check`, and `fvm dart run melos run validate:quick`
 - [ ] T087 Update `specs/007-reusable-agents/quickstart.md` with any final manual verification changes discovered during implementation
 
 ---


### PR DESCRIPTION
## Summary
- Add the reusable agents spec, clarification log, plan, research, data model, UI contract, quickstart, and task list
- Update AGENTS.md to point to the new feature plan and record the current technology stack
- Set `.specify/feature.json` to the new feature directory

## Testing
- Not run (not requested)