### PR TITLE
fix(nav): load sidebar conversations on startup

### DIFF
--- a/apps/auravibes_app/lib/widgets/app_navigation_wrappers.dart
+++ b/apps/auravibes_app/lib/widgets/app_navigation_wrappers.dart
@@ -9,6 +9,7 @@ import 'package:auravibes_ui/ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 /// A sidebar widget that handles business logic and navigation state.
 ///
@@ -66,7 +67,7 @@ int _calculateSelectedIndex(BuildContext context, int shellIndex) {
   return shellIndex;
 }
 
-class AuraSidebarWrapper extends HookWidget {
+class AuraSidebarWrapper extends HookConsumerWidget {
   /// Creates a Aura sidebar widget.
   const AuraSidebarWrapper({
     required this.navigationShell,
@@ -77,9 +78,10 @@ class AuraSidebarWrapper extends HookWidget {
   final StatefulNavigationShell navigationShell;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     useListenable(GoRouter.of(context).routeInformationProvider);
 
+    final workspaceId = ref.watch(currentRouteWorkspaceIdProvider);
     final selectedIndex = _calculateSelectedIndex(
       context,
       navigationShell.currentIndex,
@@ -87,17 +89,14 @@ class AuraSidebarWrapper extends HookWidget {
 
     return AppWithResponsiveDrawer(
       navigationItems: _navigationItems,
-      onNavigationTap: (index) => _goBranch(context, index),
+      onNavigationTap: (index) => _goBranch(context, index, workspaceId),
       selectedIndex: selectedIndex,
+      workspaceId: workspaceId,
       child: navigationShell,
     );
   }
 
-  void _goBranch(BuildContext context, int index) {
-    final workspaceId = matchWorkspaceId(
-      GoRouter.of(context).routeInformationProvider.value.uri,
-    );
-
+  void _goBranch(BuildContext context, int index, String? workspaceId) {
     if (workspaceId == null || workspaceId.isEmpty) {
       debugPrint('[Navigation] _goBranch: workspaceId missing, ignoring tap');
       return;
@@ -122,6 +121,7 @@ class AppWithResponsiveDrawer extends StatefulWidget {
     required this.navigationItems,
     required this.onNavigationTap,
     required this.selectedIndex,
+    required this.workspaceId,
     super.key,
   });
 
@@ -129,6 +129,7 @@ class AppWithResponsiveDrawer extends StatefulWidget {
   final List<AuraNavigationData> navigationItems;
   final void Function(int) onNavigationTap;
   final int selectedIndex;
+  final String? workspaceId;
 
   @override
   State<AppWithResponsiveDrawer> createState() =>
@@ -168,10 +169,6 @@ class _AppWithResponsiveDrawerState extends State<AppWithResponsiveDrawer> {
 
   @override
   Widget build(BuildContext context) {
-    final workspaceId = matchWorkspaceId(
-      _router.routeInformationProvider.value.uri,
-    );
-
     return ResponsiveSlidingDrawer(
       controller: _controller,
       drawer: Material(
@@ -179,7 +176,9 @@ class _AppWithResponsiveDrawerState extends State<AppWithResponsiveDrawer> {
           navigationItems: widget.navigationItems,
           onNavigationTap: widget.onNavigationTap,
           header: const _AppLogo(),
-          middleSection: SidebarConversationsWidget(workspaceId: workspaceId),
+          middleSection: SidebarConversationsWidget(
+            workspaceId: widget.workspaceId,
+          ),
           selectedIndex: widget.selectedIndex,
         ),
       ),

--- a/apps/auravibes_app/lib/widgets/app_navigation_wrappers.dart
+++ b/apps/auravibes_app/lib/widgets/app_navigation_wrappers.dart
@@ -82,6 +82,10 @@ class AuraSidebarWrapper extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // useListenable keeps GoRouter.of(context).routeInformationProvider updates
+    // active for _calculateSelectedIndex;
+    // ref.watch(currentRouteWorkspaceIdProvider) only supplies the
+    // workspace id.
     useListenable(GoRouter.of(context).routeInformationProvider);
 
     final workspaceId = ref.watch(currentRouteWorkspaceIdProvider);
@@ -94,7 +98,7 @@ class AuraSidebarWrapper extends HookConsumerWidget {
       navigationItems: _navigationItems,
       onNavigationTap: (index) {
         if (workspaceId == null || workspaceId.isEmpty) {
-          _logger.warning(
+          _logger.fine(
             '[Navigation] onNavigationTap: workspaceId missing, ignoring tap',
           );
           return;

--- a/apps/auravibes_app/lib/widgets/app_navigation_wrappers.dart
+++ b/apps/auravibes_app/lib/widgets/app_navigation_wrappers.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:logging/logging.dart';
 
 /// A sidebar widget that handles business logic and navigation state.
 ///
@@ -74,6 +75,8 @@ class AuraSidebarWrapper extends HookConsumerWidget {
     super.key,
   });
 
+  static final Logger _logger = Logger('AuraSidebarWrapper');
+
   /// The main content to display next to the sidebar.
   final StatefulNavigationShell navigationShell;
 
@@ -90,20 +93,14 @@ class AuraSidebarWrapper extends HookConsumerWidget {
     return AppWithResponsiveDrawer(
       navigationItems: _navigationItems,
       onNavigationTap: (index) {
-        final branchWorkspaceId =
-            workspaceId ??
-            matchWorkspaceId(
-              GoRouter.of(context).routeInformationProvider.value.uri,
-            );
-
-        if (branchWorkspaceId == null || branchWorkspaceId.isEmpty) {
-          debugPrint(
-            '[Navigation] _goBranch: workspaceId missing, ignoring tap',
+        if (workspaceId == null || workspaceId.isEmpty) {
+          _logger.warning(
+            '[Navigation] onNavigationTap: workspaceId missing, ignoring tap',
           );
           return;
         }
 
-        _goBranch(context, index, branchWorkspaceId);
+        _goBranch(context, index, workspaceId);
       },
       selectedIndex: selectedIndex,
       workspaceId: workspaceId,
@@ -179,10 +176,6 @@ class _AppWithResponsiveDrawerState extends State<AppWithResponsiveDrawer> {
 
   @override
   Widget build(BuildContext context) {
-    final effectiveWorkspaceId =
-        widget.workspaceId ??
-        matchWorkspaceId(_router.routeInformationProvider.value.uri);
-
     return ResponsiveSlidingDrawer(
       controller: _controller,
       drawer: Material(
@@ -191,7 +184,7 @@ class _AppWithResponsiveDrawerState extends State<AppWithResponsiveDrawer> {
           onNavigationTap: widget.onNavigationTap,
           header: const _AppLogo(),
           middleSection: SidebarConversationsWidget(
-            workspaceId: effectiveWorkspaceId,
+            workspaceId: widget.workspaceId,
           ),
           selectedIndex: widget.selectedIndex,
         ),

--- a/apps/auravibes_app/lib/widgets/app_navigation_wrappers.dart
+++ b/apps/auravibes_app/lib/widgets/app_navigation_wrappers.dart
@@ -89,19 +89,29 @@ class AuraSidebarWrapper extends HookConsumerWidget {
 
     return AppWithResponsiveDrawer(
       navigationItems: _navigationItems,
-      onNavigationTap: (index) => _goBranch(context, index, workspaceId),
+      onNavigationTap: (index) {
+        final branchWorkspaceId =
+            workspaceId ??
+            matchWorkspaceId(
+              GoRouter.of(context).routeInformationProvider.value.uri,
+            );
+
+        if (branchWorkspaceId == null || branchWorkspaceId.isEmpty) {
+          debugPrint(
+            '[Navigation] _goBranch: workspaceId missing, ignoring tap',
+          );
+          return;
+        }
+
+        _goBranch(context, index, branchWorkspaceId);
+      },
       selectedIndex: selectedIndex,
       workspaceId: workspaceId,
       child: navigationShell,
     );
   }
 
-  void _goBranch(BuildContext context, int index, String? workspaceId) {
-    if (workspaceId == null || workspaceId.isEmpty) {
-      debugPrint('[Navigation] _goBranch: workspaceId missing, ignoring tap');
-      return;
-    }
-
+  void _goBranch(BuildContext context, int index, String workspaceId) {
     switch (index) {
       case 0:
         NewChatRoute(workspaceId: workspaceId).go(context);
@@ -169,6 +179,10 @@ class _AppWithResponsiveDrawerState extends State<AppWithResponsiveDrawer> {
 
   @override
   Widget build(BuildContext context) {
+    final effectiveWorkspaceId =
+        widget.workspaceId ??
+        matchWorkspaceId(_router.routeInformationProvider.value.uri);
+
     return ResponsiveSlidingDrawer(
       controller: _controller,
       drawer: Material(
@@ -177,7 +191,7 @@ class _AppWithResponsiveDrawerState extends State<AppWithResponsiveDrawer> {
           onNavigationTap: widget.onNavigationTap,
           header: const _AppLogo(),
           middleSection: SidebarConversationsWidget(
-            workspaceId: widget.workspaceId,
+            workspaceId: effectiveWorkspaceId,
           ),
           selectedIndex: widget.selectedIndex,
         ),

--- a/apps/auravibes_app/test/features/chats/widgets/sidebar_conversations_widget_test.dart
+++ b/apps/auravibes_app/test/features/chats/widgets/sidebar_conversations_widget_test.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+
+import 'package:auravibes_app/domain/entities/conversation.dart';
+import 'package:auravibes_app/domain/repositories/conversation_repository.dart';
+import 'package:auravibes_app/features/chats/providers/conversation_repository_provider.dart';
+import 'package:auravibes_app/features/chats/widgets/sidebar_conversations_widget.dart';
+import 'package:auravibes_app/providers/router_providers.dart';
+import 'package:auravibes_ui/ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+void main() {
+  testWidgets(
+    'loads sidebar conversations when workspace id becomes available',
+    (tester) async {
+      final repository = _RecordingConversationRepository();
+      addTearDown(repository.close);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            conversationRepositoryProvider.overrideWithValue(repository),
+            routerPathSegmentsProvider.overrideWithValue(const []),
+          ],
+          child: const MaterialApp(
+            home: _SidebarWorkspaceHost(),
+          ),
+        ),
+      );
+
+      expect(repository.workspaceWatchCalls, isEmpty);
+
+      await tester.tap(find.byKey(_SidebarWorkspaceHost.loadWorkspaceKey));
+      await tester.pump();
+
+      expect(
+        repository.workspaceWatchCalls,
+        equals([
+          const _WorkspaceWatchCall(workspaceId: 'workspace-1', limit: 10),
+        ]),
+      );
+    },
+  );
+}
+
+class _SidebarWorkspaceHost extends StatefulWidget {
+  const _SidebarWorkspaceHost();
+
+  static const loadWorkspaceKey = Key('load-workspace');
+
+  @override
+  State<_SidebarWorkspaceHost> createState() => _SidebarWorkspaceHostState();
+}
+
+class _SidebarWorkspaceHostState extends State<_SidebarWorkspaceHost> {
+  String? _workspaceId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: ThemeData(extensions: [AuraTheme.light]),
+      child: Column(
+        children: [
+          TextButton(
+            key: _SidebarWorkspaceHost.loadWorkspaceKey,
+            onPressed: () => setState(() => _workspaceId = 'workspace-1'),
+            child: const Text('Load workspace'),
+          ),
+          SidebarConversationsWidget(workspaceId: _workspaceId),
+        ],
+      ),
+    );
+  }
+}
+
+@immutable
+class _WorkspaceWatchCall {
+  const _WorkspaceWatchCall({required this.workspaceId, required this.limit});
+
+  final String workspaceId;
+  final int? limit;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _WorkspaceWatchCall &&
+        other.workspaceId == workspaceId &&
+        other.limit == limit;
+  }
+
+  @override
+  int get hashCode => Object.hash(workspaceId, limit);
+
+  @override
+  String toString() {
+    return '_WorkspaceWatchCall(workspaceId: $workspaceId, limit: $limit)';
+  }
+}
+
+class _RecordingConversationRepository implements ConversationRepository {
+  final workspaceWatchCalls = <_WorkspaceWatchCall>[];
+  final _controllers = <StreamController<List<ConversationEntity>>>[];
+
+  @override
+  Stream<List<ConversationEntity>> watchConversationsByWorkspace(
+    String workspaceId, {
+    int? limit,
+  }) {
+    workspaceWatchCalls.add(
+      _WorkspaceWatchCall(workspaceId: workspaceId, limit: limit),
+    );
+
+    final controller = StreamController<List<ConversationEntity>>();
+    _controllers.add(controller);
+    return controller.stream;
+  }
+
+  Future<void> close() async {
+    await Future.wait(_controllers.map((controller) => controller.close()));
+  }
+
+  @override
+  Future<ConversationEntity> createConversation(
+    ConversationToCreate conversation,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> deleteConversation(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ConversationEntity?> getConversationById(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ConversationEntity> patchConversation(
+    String id,
+    ConversationPatch conversation,
+  ) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<ConversationEntity?> watchConversationById(String id) {
+    throw UnimplementedError();
+  }
+}

--- a/apps/auravibes_app/test/features/chats/widgets/sidebar_conversations_widget_test.dart
+++ b/apps/auravibes_app/test/features/chats/widgets/sidebar_conversations_widget_test.dart
@@ -42,12 +42,59 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    're-subscribes when workspace id changes',
+    (tester) async {
+      final repository = _RecordingConversationRepository();
+      addTearDown(repository.close);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            conversationRepositoryProvider.overrideWithValue(repository),
+            routerPathSegmentsProvider.overrideWithValue(const []),
+          ],
+          child: const MaterialApp(
+            home: _SidebarWorkspaceHost(),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(_SidebarWorkspaceHost.loadWorkspaceKey));
+      await tester.pump();
+
+      expect(
+        repository.workspaceWatchCalls,
+        equals([
+          const _WorkspaceWatchCall(workspaceId: 'workspace-1', limit: 10),
+        ]),
+      );
+      expect(repository._controllers, hasLength(1));
+      final firstController = repository._controllers.single;
+
+      await tester.tap(find.byKey(_SidebarWorkspaceHost.switchWorkspaceKey));
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        repository.workspaceWatchCalls,
+        equals([
+          const _WorkspaceWatchCall(workspaceId: 'workspace-1', limit: 10),
+          const _WorkspaceWatchCall(workspaceId: 'workspace-2', limit: 10),
+        ]),
+      );
+      expect(repository._controllers, hasLength(1));
+      expect(repository._controllers, isNot(contains(firstController)));
+    },
+  );
 }
 
 class _SidebarWorkspaceHost extends StatefulWidget {
   const _SidebarWorkspaceHost();
 
   static const loadWorkspaceKey = Key('load-workspace');
+  static const switchWorkspaceKey = Key('switch-workspace');
 
   @override
   State<_SidebarWorkspaceHost> createState() => _SidebarWorkspaceHostState();
@@ -60,15 +107,22 @@ class _SidebarWorkspaceHostState extends State<_SidebarWorkspaceHost> {
   Widget build(BuildContext context) {
     return Theme(
       data: ThemeData(extensions: [AuraTheme.light]),
-      child: Column(
-        children: [
-          TextButton(
-            key: _SidebarWorkspaceHost.loadWorkspaceKey,
-            onPressed: () => setState(() => _workspaceId = 'workspace-1'),
-            child: const Text('Load workspace'),
-          ),
-          SidebarConversationsWidget(workspaceId: _workspaceId),
-        ],
+      child: Material(
+        child: Column(
+          children: [
+            TextButton(
+              key: _SidebarWorkspaceHost.loadWorkspaceKey,
+              onPressed: () => setState(() => _workspaceId = 'workspace-1'),
+              child: const Text('Load workspace'),
+            ),
+            TextButton(
+              key: _SidebarWorkspaceHost.switchWorkspaceKey,
+              onPressed: () => setState(() => _workspaceId = 'workspace-2'),
+              child: const Text('Switch workspace'),
+            ),
+            SidebarConversationsWidget(workspaceId: _workspaceId),
+          ],
+        ),
       ),
     );
   }
@@ -110,13 +164,20 @@ class _RecordingConversationRepository implements ConversationRepository {
       _WorkspaceWatchCall(workspaceId: workspaceId, limit: limit),
     );
 
-    final controller = StreamController<List<ConversationEntity>>();
+    late final StreamController<List<ConversationEntity>> controller;
+    controller = StreamController<List<ConversationEntity>>(
+      onCancel: () => _controllers.remove(controller),
+    );
     _controllers.add(controller);
     return controller.stream;
   }
 
   Future<void> close() async {
-    await Future.wait(_controllers.map((controller) => controller.close()));
+    await Future.wait(
+      _controllers
+          .where((controller) => !controller.isClosed)
+          .map((controller) => controller.close()),
+    );
   }
 
   @override

--- a/apps/auravibes_app/test/features/chats/widgets/sidebar_conversations_widget_test.dart
+++ b/apps/auravibes_app/test/features/chats/widgets/sidebar_conversations_widget_test.dart
@@ -165,7 +165,7 @@ class _RecordingConversationRepository implements ConversationRepository {
     );
 
     late final StreamController<List<ConversationEntity>> controller;
-    controller = StreamController<List<ConversationEntity>>(
+    controller = StreamController<List<ConversationEntity>>.broadcast(
       onCancel: () => _controllers.remove(controller),
     );
     _controllers.add(controller);


### PR DESCRIPTION
## Summary
- make the sidebar wrapper consume the reactive route workspace id
- pass the workspace id into the responsive drawer instead of relying only on cached route parsing
- keep branch navigation requiring a non-null workspace id, with nullable resolution handled before calling `_goBranch`

## Tests
- `fvm flutter test test/features/chats/widgets/sidebar_conversations_widget_test.dart --no-pub`
- `fvm dart run melos analyze` (passes with existing info-level findings)