### PR TITLE
fix(chatbot): group resolved tool results in single ChatMessage.user

### DIFF
--- a/apps/auravibes_app/lib/services/chatbot_service/build_prompt_chat_messages.dart
+++ b/apps/auravibes_app/lib/services/chatbot_service/build_prompt_chat_messages.dart
@@ -19,7 +19,7 @@ class BuildPromptChatMessages {
         message.metadata?.toolCalls ?? const <MessageToolCallEntity>[];
 
     final parts = <Part>[
-      TextPart(message.content),
+      if (message.content.isNotEmpty) TextPart(message.content),
       for (final toolCall in toolCalls)
         ToolPart.call(
           callId: toolCall.id,
@@ -28,24 +28,19 @@ class BuildPromptChatMessages {
         ),
     ];
 
-    final results = <ChatMessage>[];
-    for (final toolCall in toolCalls) {
-      if (toolCall.isResolved) {
-        results.add(
-          ChatMessage.model(
-            '',
-            parts: [
-              ToolPart.result(
-                callId: toolCall.id,
-                toolName: toolCall.name,
-                result: toolCall.getResponseForAI(),
-              ),
-            ],
+    final resultParts = [
+      for (final toolCall in toolCalls)
+        if (toolCall.isResolved)
+          ToolPart.result(
+            callId: toolCall.id,
+            toolName: toolCall.name,
+            result: toolCall.getResponseForAI(),
           ),
-        );
-      }
-    }
+    ];
 
-    return [ChatMessage.model('', parts: parts), ...results];
+    return [
+      ChatMessage.model('', parts: parts),
+      if (resultParts.isNotEmpty) ChatMessage.user('', parts: resultParts),
+    ];
   }
 }

--- a/apps/auravibes_app/lib/services/chatbot_service/build_prompt_chat_messages.dart
+++ b/apps/auravibes_app/lib/services/chatbot_service/build_prompt_chat_messages.dart
@@ -39,7 +39,7 @@ class BuildPromptChatMessages {
     ];
 
     return [
-      ChatMessage.model('', parts: parts),
+      if (parts.isNotEmpty) ChatMessage.model('', parts: parts),
       if (resultParts.isNotEmpty) ChatMessage.user('', parts: resultParts),
     ];
   }

--- a/apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart
+++ b/apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart
@@ -58,9 +58,56 @@ void main() {
       );
 
       final resultMessage = result[2];
-      expect(resultMessage.role.name, 'model');
+      expect(resultMessage.role.name, 'user');
       expect(resultMessage.toolResults, hasLength(1));
       expect(resultMessage.toolResults.single.callId, 'tool-1');
+    });
+
+    test('groups resolved tool responses in one user message', () {
+      final messages = [
+        MessageEntity(
+          id: 'assistant-1',
+          conversationId: 'conversation-1',
+          content: '',
+          messageType: MessageType.text,
+          isUser: false,
+          status: MessageStatus.sent,
+          createdAt: DateTime(2025),
+          updatedAt: DateTime(2025),
+          metadata: const MessageMetadataEntity(
+            toolCalls: [
+              MessageToolCallEntity(
+                id: 'tool-1',
+                name: 'first_tool',
+                argumentsRaw: '{}',
+                responseRaw: 'first result',
+                resultStatus: ToolCallResultStatus.success,
+              ),
+              MessageToolCallEntity(
+                id: 'tool-2',
+                name: 'second_tool',
+                argumentsRaw: '{}',
+                responseRaw: 'second result',
+                resultStatus: ToolCallResultStatus.success,
+              ),
+            ],
+          ),
+        ),
+      ];
+
+      final result = usecase.call(messages);
+
+      expect(result, hasLength(2));
+      expect(result.first.role.name, 'model');
+      expect(result.first.toolCalls, hasLength(2));
+
+      final resultMessage = result.last;
+      expect(resultMessage.role.name, 'user');
+      expect(resultMessage.toolResults, hasLength(2));
+      expect(resultMessage.toolResults.map((part) => part.callId), [
+        'tool-1',
+        'tool-2',
+      ]);
     });
 
     test(
@@ -94,6 +141,7 @@ void main() {
         expect(result, hasLength(2));
         final resultMessage = result[1];
         expect(resultMessage.toolResults, hasLength(1));
+        expect(resultMessage.role.name, 'user');
         expect(
           resultMessage.toolResults.single.result,
           ToolCallResultStatus.toolNotFound.toResponseString(),

--- a/apps/auravibes_app/test/services/chatbot_service/chat_message_adapter_test.dart
+++ b/apps/auravibes_app/test/services/chatbot_service/chat_message_adapter_test.dart
@@ -84,7 +84,7 @@ void main() {
       expect(modelMsg.toolCalls.single.toolName, 'calculator');
 
       final resultMsg = result[1];
-      expect(resultMsg.role.name, 'model');
+      expect(resultMsg.role.name, 'user');
       expect(resultMsg.toolResults, hasLength(1));
       expect(resultMsg.toolResults.single.callId, 'tc1');
     });


### PR DESCRIPTION
## Summary
- Tool results were emitted as individual `ChatMessage.model` messages, which Anthropic's mapper silently discards — causing duplicate tool calls
- Groups all resolved `ToolPart.result` items into a single `ChatMessage.user` and keeps `ToolPart.call` items in the assistant `ChatMessage.model` message
- Adds guard to skip empty `TextPart('')` when assistant content is empty

## Changed
- `apps/auravibes_app/lib/services/chatbot_service/build_prompt_chat_messages.dart`
- `apps/auravibes_app/test/services/chatbot_service/build_prompt_chat_messages_test.dart`
- `apps/auravibes_app/test/services/chatbot_service/chat_message_adapter_test.dart`