### PR TITLE
feat: HTML-to-Markdown URL content transformer with format selection

### DIFF
--- a/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
+++ b/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
@@ -141,6 +141,14 @@ final class UrlTool extends NativeToolEntity<String, String> {
     };
     final isStructuredBody = rawBody != null && rawBody is! String;
 
+    final format = switch (json['format']) {
+      null => UrlResponseFormat.defaultFormat,
+      final String s => UrlResponseFormat.fromString(s),
+      _ => throw const FormatException(
+        'Format must be a string: markdown, text, or html.',
+      ),
+    };
+
     final resolvedHost = await _ensurePublicHost(uri.host);
 
     final effectiveHeaders = <String, String>{
@@ -155,14 +163,6 @@ final class UrlTool extends NativeToolEntity<String, String> {
     final effectiveUrl = uri.scheme == 'https'
         ? uri.toString()
         : uri.replace(host: resolvedHost).toString();
-
-    final format = switch (json['format']) {
-      null => UrlResponseFormat.defaultFormat,
-      final String s => UrlResponseFormat.fromString(s),
-      _ => throw const FormatException(
-        'Format must be a string: markdown, text, or html.',
-      ),
-    };
 
     return UrlRequest(
       url: effectiveUrl,

--- a/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
+++ b/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
@@ -6,15 +6,19 @@ import 'package:auravibes_app/domain/entities/tool_spec.dart';
 import 'package:auravibes_app/services/tools/native_tool_entity.dart';
 import 'package:auravibes_app/services/url/models/url_request.dart';
 import 'package:auravibes_app/services/url/models/url_response.dart';
+import 'package:auravibes_app/services/url/url_content_transformer.dart';
 import 'package:auravibes_app/services/url/url_service.dart';
 
 const _privateNetworkUrlError =
     'Private or local network URLs are not allowed.';
 
 final class UrlTool extends NativeToolEntity<String, String> {
-  UrlTool({UrlService? urlService}) : _urlService = urlService;
+  UrlTool({UrlService? urlService, UrlContentTransformer? transformer})
+    : _urlService = urlService,
+      _transformer = transformer ?? const UrlContentTransformer();
 
   final UrlService? _urlService;
+  final UrlContentTransformer _transformer;
 
   @override
   ToolSpec getTool() {
@@ -36,7 +40,11 @@ final class UrlTool extends NativeToolEntity<String, String> {
                 '"method" (optional) - HTTP method '
                 '(GET, POST, PUT, DELETE, PATCH, HEAD), '
                 '"headers" (optional) - JSON object of HTTP headers, '
-                '"body" (optional) - request body for POST/PUT/PATCH.',
+                '"body" (optional) - request body for POST/PUT/PATCH, '
+                '"format" (optional) - markdown, text, html, '
+                'or omit for default (markdown). '
+                'Controls the Accept header sent and how the response '
+                'body is transformed before being returned.',
           },
         },
         'required': ['input'],
@@ -65,7 +73,7 @@ final class UrlTool extends NativeToolEntity<String, String> {
         return;
       }
 
-      completer.complete(_formatResponse(response));
+      completer.complete(_formatResponse(response, request.format));
     }().catchError((Object error, StackTrace stackTrace) {
       if (completer.isCanceled) {
         return;
@@ -77,15 +85,26 @@ final class UrlTool extends NativeToolEntity<String, String> {
     return completer.operation;
   }
 
-  String _formatResponse(UrlResponse response) {
+  String _formatResponse(
+    UrlResponse response,
+    UrlResponseFormat requestedFormat,
+  ) {
+    final transformed = _transformer.transform(
+      response,
+      requestedFormat: requestedFormat,
+    );
     final headerLines = response.headers.entries
         .expand((e) => e.value.map((v) => '${e.key}: $v'))
         .join('\n');
 
+    final truncatedNote = transformed.truncated ? ' (truncated)' : '';
+
     return 'Status: ${response.statusCode}\n'
         'Elapsed: ${response.elapsed.inMilliseconds}ms\n'
+        'Content-Type: ${transformed.contentType ?? 'unknown'}\n'
+        'Format: ${transformed.format.label}$truncatedNote\n'
         'Headers:\n$headerLines\n\n'
-        '${response.body}';
+        '${transformed.body}';
   }
 
   Future<UrlRequest> _buildRequest(String toolInput) async {
@@ -137,11 +156,20 @@ final class UrlTool extends NativeToolEntity<String, String> {
         ? uri.toString()
         : uri.replace(host: resolvedHost).toString();
 
+    final format = switch (json['format']) {
+      null => UrlResponseFormat.defaultFormat,
+      final String s => UrlResponseFormat.fromString(s),
+      _ => throw const FormatException(
+        'Format must be a string: markdown, text, or html.',
+      ),
+    };
+
     return UrlRequest(
       url: effectiveUrl,
       method: method,
       headers: effectiveHeaders,
       body: body,
+      format: format,
     );
   }
 

--- a/apps/auravibes_app/lib/services/url/models/transformed_url_content.dart
+++ b/apps/auravibes_app/lib/services/url/models/transformed_url_content.dart
@@ -1,0 +1,32 @@
+enum UrlContentFormat {
+  markdown,
+  text,
+  json,
+  html,
+  unsupported
+  ;
+
+  String get label => switch (this) {
+    markdown => 'markdown',
+    text => 'text',
+    json => 'json',
+    html => 'html',
+    unsupported => 'unsupported',
+  };
+}
+
+class TransformedUrlContent {
+  const TransformedUrlContent({
+    required this.body,
+    required this.format,
+    required this.originalLength,
+    required this.truncated,
+    this.contentType,
+  });
+
+  final String body;
+  final UrlContentFormat format;
+  final String? contentType;
+  final int originalLength;
+  final bool truncated;
+}

--- a/apps/auravibes_app/lib/services/url/models/url_request.dart
+++ b/apps/auravibes_app/lib/services/url/models/url_request.dart
@@ -15,6 +15,40 @@ enum UrlRequestMethod {
   final String value;
 }
 
+enum UrlResponseFormat {
+  defaultFormat(''),
+  markdown('markdown'),
+  text('text'),
+  html('html')
+  ;
+
+  const UrlResponseFormat(this.label);
+  final String label;
+
+  String get acceptHeader => switch (this) {
+    .html =>
+      'text/html;q=1.0, application/xhtml+xml;q=0.9, '
+          'text/plain;q=0.8, text/markdown;q=0.7, */*;q=0.1',
+    .text =>
+      'text/plain;q=1.0, text/markdown;q=0.9, '
+          'text/html;q=0.8, */*;q=0.1',
+    _ =>
+      'text/markdown;q=1.0, text/x-markdown;q=0.9, '
+          'text/plain;q=0.8, text/html;q=0.7, */*;q=0.1',
+  };
+
+  static UrlResponseFormat fromString(String? value) {
+    if (value == null || value.isEmpty) return .defaultFormat;
+    return values.firstWhere(
+      (f) => f.label == value,
+      orElse: () => throw FormatException(
+        'Unsupported format: $value. '
+        'Supported formats: markdown, text, html.',
+      ),
+    );
+  }
+}
+
 @freezed
 abstract class UrlRequest with _$UrlRequest {
   const factory UrlRequest({
@@ -23,5 +57,6 @@ abstract class UrlRequest with _$UrlRequest {
     Map<String, String>? headers,
     String? body,
     @Default(Duration(seconds: 30)) Duration timeout,
+    @Default(UrlResponseFormat.defaultFormat) UrlResponseFormat format,
   }) = _UrlRequest;
 }

--- a/apps/auravibes_app/lib/services/url/models/url_request.dart
+++ b/apps/auravibes_app/lib/services/url/models/url_request.dart
@@ -38,9 +38,10 @@ enum UrlResponseFormat {
   };
 
   static UrlResponseFormat fromString(String? value) {
-    if (value == null || value.isEmpty) return .defaultFormat;
+    final normalized = value?.trim().toLowerCase();
+    if (normalized == null || normalized.isEmpty) return .defaultFormat;
     return values.firstWhere(
-      (f) => f.label == value,
+      (f) => f.label == normalized,
       orElse: () => throw FormatException(
         'Unsupported format: $value. '
         'Supported formats: markdown, text, html.',

--- a/apps/auravibes_app/lib/services/url/models/url_request.freezed.dart
+++ b/apps/auravibes_app/lib/services/url/models/url_request.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$UrlRequest {
 
- String get url; UrlRequestMethod get method; Map<String, String>? get headers; String? get body; Duration get timeout;
+ String get url; UrlRequestMethod get method; Map<String, String>? get headers; String? get body; Duration get timeout; UrlResponseFormat get format;
 /// Create a copy of UrlRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $UrlRequestCopyWith<UrlRequest> get copyWith => _$UrlRequestCopyWithImpl<UrlRequ
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is UrlRequest&&(identical(other.url, url) || other.url == url)&&(identical(other.method, method) || other.method == method)&&const DeepCollectionEquality().equals(other.headers, headers)&&(identical(other.body, body) || other.body == body)&&(identical(other.timeout, timeout) || other.timeout == timeout));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UrlRequest&&(identical(other.url, url) || other.url == url)&&(identical(other.method, method) || other.method == method)&&const DeepCollectionEquality().equals(other.headers, headers)&&(identical(other.body, body) || other.body == body)&&(identical(other.timeout, timeout) || other.timeout == timeout)&&(identical(other.format, format) || other.format == format));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,url,method,const DeepCollectionEquality().hash(headers),body,timeout);
+int get hashCode => Object.hash(runtimeType,url,method,const DeepCollectionEquality().hash(headers),body,timeout,format);
 
 @override
 String toString() {
-  return 'UrlRequest(url: $url, method: $method, headers: $headers, body: $body, timeout: $timeout)';
+  return 'UrlRequest(url: $url, method: $method, headers: $headers, body: $body, timeout: $timeout, format: $format)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $UrlRequestCopyWith<$Res>  {
   factory $UrlRequestCopyWith(UrlRequest value, $Res Function(UrlRequest) _then) = _$UrlRequestCopyWithImpl;
 @useResult
 $Res call({
- String url, UrlRequestMethod method, Map<String, String>? headers, String? body, Duration timeout
+ String url, UrlRequestMethod method, Map<String, String>? headers, String? body, Duration timeout, UrlResponseFormat format
 });
 
 
@@ -62,14 +62,15 @@ class _$UrlRequestCopyWithImpl<$Res>
 
 /// Create a copy of UrlRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? url = null,Object? method = null,Object? headers = freezed,Object? body = freezed,Object? timeout = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? url = null,Object? method = null,Object? headers = freezed,Object? body = freezed,Object? timeout = null,Object? format = null,}) {
   return _then(_self.copyWith(
 url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
 as String,method: null == method ? _self.method : method // ignore: cast_nullable_to_non_nullable
 as UrlRequestMethod,headers: freezed == headers ? _self.headers : headers // ignore: cast_nullable_to_non_nullable
 as Map<String, String>?,body: freezed == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
 as String?,timeout: null == timeout ? _self.timeout : timeout // ignore: cast_nullable_to_non_nullable
-as Duration,
+as Duration,format: null == format ? _self.format : format // ignore: cast_nullable_to_non_nullable
+as UrlResponseFormat,
   ));
 }
 
@@ -154,10 +155,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String url,  UrlRequestMethod method,  Map<String, String>? headers,  String? body,  Duration timeout)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String url,  UrlRequestMethod method,  Map<String, String>? headers,  String? body,  Duration timeout,  UrlResponseFormat format)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _UrlRequest() when $default != null:
-return $default(_that.url,_that.method,_that.headers,_that.body,_that.timeout);case _:
+return $default(_that.url,_that.method,_that.headers,_that.body,_that.timeout,_that.format);case _:
   return orElse();
 
 }
@@ -175,10 +176,10 @@ return $default(_that.url,_that.method,_that.headers,_that.body,_that.timeout);c
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String url,  UrlRequestMethod method,  Map<String, String>? headers,  String? body,  Duration timeout)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String url,  UrlRequestMethod method,  Map<String, String>? headers,  String? body,  Duration timeout,  UrlResponseFormat format)  $default,) {final _that = this;
 switch (_that) {
 case _UrlRequest():
-return $default(_that.url,_that.method,_that.headers,_that.body,_that.timeout);case _:
+return $default(_that.url,_that.method,_that.headers,_that.body,_that.timeout,_that.format);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -195,10 +196,10 @@ return $default(_that.url,_that.method,_that.headers,_that.body,_that.timeout);c
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String url,  UrlRequestMethod method,  Map<String, String>? headers,  String? body,  Duration timeout)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String url,  UrlRequestMethod method,  Map<String, String>? headers,  String? body,  Duration timeout,  UrlResponseFormat format)?  $default,) {final _that = this;
 switch (_that) {
 case _UrlRequest() when $default != null:
-return $default(_that.url,_that.method,_that.headers,_that.body,_that.timeout);case _:
+return $default(_that.url,_that.method,_that.headers,_that.body,_that.timeout,_that.format);case _:
   return null;
 
 }
@@ -210,7 +211,7 @@ return $default(_that.url,_that.method,_that.headers,_that.body,_that.timeout);c
 
 
 class _UrlRequest implements UrlRequest {
-  const _UrlRequest({required this.url, this.method = UrlRequestMethod.get, final  Map<String, String>? headers, this.body, this.timeout = const Duration(seconds: 30)}): _headers = headers;
+  const _UrlRequest({required this.url, this.method = UrlRequestMethod.get, final  Map<String, String>? headers, this.body, this.timeout = const Duration(seconds: 30), this.format = UrlResponseFormat.defaultFormat}): _headers = headers;
   
 
 @override final  String url;
@@ -226,6 +227,7 @@ class _UrlRequest implements UrlRequest {
 
 @override final  String? body;
 @override@JsonKey() final  Duration timeout;
+@override@JsonKey() final  UrlResponseFormat format;
 
 /// Create a copy of UrlRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -237,16 +239,16 @@ _$UrlRequestCopyWith<_UrlRequest> get copyWith => __$UrlRequestCopyWithImpl<_Url
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UrlRequest&&(identical(other.url, url) || other.url == url)&&(identical(other.method, method) || other.method == method)&&const DeepCollectionEquality().equals(other._headers, _headers)&&(identical(other.body, body) || other.body == body)&&(identical(other.timeout, timeout) || other.timeout == timeout));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UrlRequest&&(identical(other.url, url) || other.url == url)&&(identical(other.method, method) || other.method == method)&&const DeepCollectionEquality().equals(other._headers, _headers)&&(identical(other.body, body) || other.body == body)&&(identical(other.timeout, timeout) || other.timeout == timeout)&&(identical(other.format, format) || other.format == format));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,url,method,const DeepCollectionEquality().hash(_headers),body,timeout);
+int get hashCode => Object.hash(runtimeType,url,method,const DeepCollectionEquality().hash(_headers),body,timeout,format);
 
 @override
 String toString() {
-  return 'UrlRequest(url: $url, method: $method, headers: $headers, body: $body, timeout: $timeout)';
+  return 'UrlRequest(url: $url, method: $method, headers: $headers, body: $body, timeout: $timeout, format: $format)';
 }
 
 
@@ -257,7 +259,7 @@ abstract mixin class _$UrlRequestCopyWith<$Res> implements $UrlRequestCopyWith<$
   factory _$UrlRequestCopyWith(_UrlRequest value, $Res Function(_UrlRequest) _then) = __$UrlRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String url, UrlRequestMethod method, Map<String, String>? headers, String? body, Duration timeout
+ String url, UrlRequestMethod method, Map<String, String>? headers, String? body, Duration timeout, UrlResponseFormat format
 });
 
 
@@ -274,14 +276,15 @@ class __$UrlRequestCopyWithImpl<$Res>
 
 /// Create a copy of UrlRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? url = null,Object? method = null,Object? headers = freezed,Object? body = freezed,Object? timeout = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? url = null,Object? method = null,Object? headers = freezed,Object? body = freezed,Object? timeout = null,Object? format = null,}) {
   return _then(_UrlRequest(
 url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
 as String,method: null == method ? _self.method : method // ignore: cast_nullable_to_non_nullable
 as UrlRequestMethod,headers: freezed == headers ? _self._headers : headers // ignore: cast_nullable_to_non_nullable
 as Map<String, String>?,body: freezed == body ? _self.body : body // ignore: cast_nullable_to_non_nullable
 as String?,timeout: null == timeout ? _self.timeout : timeout // ignore: cast_nullable_to_non_nullable
-as Duration,
+as Duration,format: null == format ? _self.format : format // ignore: cast_nullable_to_non_nullable
+as UrlResponseFormat,
   ));
 }
 

--- a/apps/auravibes_app/lib/services/url/url_content_transformer.dart
+++ b/apps/auravibes_app/lib/services/url/url_content_transformer.dart
@@ -1,0 +1,548 @@
+// ignore_for_file: cascade_invocations
+// StringBuffer.write returns void, making cascades meaningless.
+// The _processTable method's for-loop bodies separate consecutive
+// buffer calls where cascading across control flow is misleading.
+
+import 'package:auravibes_app/services/url/models/transformed_url_content.dart';
+import 'package:auravibes_app/services/url/models/url_request.dart';
+import 'package:auravibes_app/services/url/models/url_response.dart';
+import 'package:html/dom.dart' as dom;
+import 'package:html/parser.dart' as parser;
+
+class UrlContentTransformer {
+  const UrlContentTransformer();
+
+  static const int maxOutputLength = 1024 * 1024;
+
+  static final Set<String> _blockTags = {
+    'div',
+    'section',
+    'article',
+    'main',
+    'header',
+    'footer',
+    'aside',
+    'p',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'pre',
+    'blockquote',
+    'figure',
+    'figcaption',
+    'details',
+    'summary',
+    'fieldset',
+    'form',
+  };
+
+  static final Set<String> _stripTags = {
+    'script',
+    'style',
+    'noscript',
+    'iframe',
+    'object',
+    'embed',
+    'svg',
+    'canvas',
+    'applet',
+    'map',
+    'area',
+  };
+
+  static final Set<String> _skipContentTags = {
+    'nav',
+  };
+
+  TransformedUrlContent transform(
+    UrlResponse response, {
+    UrlResponseFormat requestedFormat = UrlResponseFormat.defaultFormat,
+  }) {
+    final contentType = _extractContentType(response.headers);
+    final body = response.body;
+    final originalLength = body.length;
+
+    final effectiveFormat = requestedFormat == UrlResponseFormat.defaultFormat
+        ? UrlResponseFormat.markdown
+        : requestedFormat;
+
+    if (contentType == null) {
+      return _passthrough(
+        body,
+        originalLength,
+        contentType,
+        UrlContentFormat.unsupported,
+      );
+    }
+
+    if (contentType.contains('text/html')) {
+      return switch (effectiveFormat) {
+        UrlResponseFormat.html => _passthrough(
+          body,
+          originalLength,
+          contentType,
+          UrlContentFormat.html,
+        ),
+        UrlResponseFormat.text => _transformHtmlToText(
+          body,
+          originalLength,
+          contentType,
+        ),
+        _ => _transformHtml(body, originalLength, contentType),
+      };
+    }
+
+    if (contentType.contains('application/json')) {
+      return _passthrough(
+        body,
+        originalLength,
+        contentType,
+        UrlContentFormat.json,
+      );
+    }
+
+    if (contentType.contains('text/plain') ||
+        contentType.contains('text/markdown')) {
+      return _passthrough(
+        body,
+        originalLength,
+        contentType,
+        UrlContentFormat.text,
+      );
+    }
+
+    return _passthrough(
+      body,
+      originalLength,
+      contentType,
+      UrlContentFormat.unsupported,
+    );
+  }
+
+  TransformedUrlContent _transformHtml(
+    String body,
+    int originalLength,
+    String contentType,
+  ) {
+    final document = parser.parse(body);
+
+    _stripUnwantedElements(document);
+
+    final titleElement = document.querySelector('title');
+    final title = titleElement?.text.trim();
+
+    final bodyElement = document.body;
+    if (bodyElement == null) {
+      final text = document.text?.trim() ?? '';
+      final (output, truncated) = _truncateIfNeeded(text, originalLength);
+      return TransformedUrlContent(
+        body: output,
+        format: .markdown,
+        contentType: contentType,
+        originalLength: originalLength,
+        truncated: truncated,
+      );
+    }
+
+    final buffer = StringBuffer();
+    if (title != null && title.isNotEmpty) {
+      buffer
+        ..writeln('# $title')
+        ..writeln();
+    }
+
+    _processChildren(bodyElement, buffer, 0);
+
+    var markdown = buffer.toString().trim();
+
+    markdown = _collapseBlankLines(markdown);
+
+    final (output, truncated) = _truncateIfNeeded(markdown, originalLength);
+
+    return TransformedUrlContent(
+      body: output,
+      format: .markdown,
+      contentType: contentType,
+      originalLength: originalLength,
+      truncated: truncated,
+    );
+  }
+
+  TransformedUrlContent _transformHtmlToText(
+    String body,
+    int originalLength,
+    String contentType,
+  ) {
+    final document = parser.parse(body);
+
+    _stripUnwantedElements(document);
+
+    final bodyElement = document.body;
+    final text = bodyElement?.text ?? document.text ?? '';
+
+    final cleaned = text
+        .replaceAll(RegExp(r'[ \t]+'), ' ')
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .trim();
+
+    final (output, truncated) = _truncateIfNeeded(cleaned, originalLength);
+
+    return TransformedUrlContent(
+      body: output,
+      format: .text,
+      contentType: contentType,
+      originalLength: originalLength,
+      truncated: truncated,
+    );
+  }
+
+  void _stripUnwantedElements(dom.Document document) {
+    for (final tag in _stripTags) {
+      for (final element in document.querySelectorAll(tag)) {
+        element.remove();
+      }
+    }
+  }
+
+  void _processChildren(dom.Element parent, StringBuffer buffer, int depth) {
+    for (final node in parent.nodes) {
+      if (node is dom.Text) {
+        _processTextNode(node, buffer);
+      } else if (node is dom.Element) {
+        _processElementNode(node, buffer, depth);
+      }
+    }
+  }
+
+  void _processInlineChildren(dom.Element parent, StringBuffer buffer) {
+    for (final node in parent.nodes) {
+      if (node is dom.Text) {
+        _processTextNode(node, buffer);
+      } else if (node is dom.Element) {
+        _processElementNode(node, buffer, 0);
+      }
+    }
+  }
+
+  void _processTextNode(dom.Text textNode, StringBuffer buffer) {
+    final text = _escapeMarkdownText(textNode.text);
+    if (text.isNotEmpty) {
+      buffer.write(text);
+    }
+  }
+
+  String _escapeMarkdownText(String text) {
+    return text
+        .replaceAll(r'\', r'\\')
+        .replaceAll('`', r'\`')
+        .replaceAll('*', r'\*')
+        .replaceAll('_', r'\_')
+        .replaceAll('[', r'\[')
+        .replaceAll(']', r'\]')
+        .replaceAll('<', r'\<')
+        .replaceAll('|', r'\|')
+        .replaceAll('~', r'\~');
+  }
+
+  void _processElementNode(
+    dom.Element element,
+    StringBuffer buffer,
+    int depth,
+  ) {
+    // ignore: long-method - HTML tag dispatch switch covers all elements
+    final tag = element.localName?.toLowerCase() ?? '';
+
+    if (_stripTags.contains(tag)) {
+      return;
+    }
+
+    if (_skipContentTags.contains(tag)) {
+      return;
+    }
+
+    switch (tag) {
+      case 'br':
+        buffer.writeln();
+        return;
+      case 'hr':
+        buffer.writeln();
+        buffer.writeln('---');
+        buffer.writeln();
+        return;
+      case 'h1':
+      case 'h2':
+      case 'h3':
+      case 'h4':
+      case 'h5':
+      case 'h6':
+        final level = int.parse(tag.substring(1));
+        final inlineBuffer = StringBuffer();
+        _processInlineChildren(element, inlineBuffer);
+        final text = inlineBuffer.toString().trim();
+        if (text.isNotEmpty) {
+          _ensureNewline(buffer);
+          buffer.writeln('${'#' * level} $text');
+          _ensureNewline(buffer);
+        }
+        return;
+      case 'p':
+        final inlineBuffer = StringBuffer();
+        _processInlineChildren(element, inlineBuffer);
+        final text = inlineBuffer.toString().trim();
+        if (text.isNotEmpty) {
+          _ensureNewline(buffer);
+          buffer.writeln(text);
+        }
+        return;
+      case 'li':
+        _ensureNewline(buffer);
+        final indent = '  ' * (depth > 0 ? depth - 1 : 0);
+        final isOrdered = _isInsideOrderedList(element);
+        final marker = isOrdered ? '1. ' : '- ';
+        buffer.write('$indent$marker');
+        _processChildren(element, buffer, depth);
+        return;
+      case 'a':
+        final href = element.attributes['href'];
+        final inlineBuffer = StringBuffer();
+        _processInlineChildren(element, inlineBuffer);
+        final text = inlineBuffer.toString().trim();
+        if (text.isEmpty) return;
+        if (href != null && href.isNotEmpty) {
+          buffer.write('[$text]($href)');
+        } else {
+          buffer.write(text);
+        }
+        return;
+      case 'strong':
+      case 'b':
+        final inlineBuffer = StringBuffer();
+        _processInlineChildren(element, inlineBuffer);
+        final text = inlineBuffer.toString().trim();
+        if (text.isNotEmpty) {
+          buffer.write('**$text**');
+        }
+        return;
+      case 'em':
+      case 'i':
+        final inlineBuffer = StringBuffer();
+        _processInlineChildren(element, inlineBuffer);
+        final text = inlineBuffer.toString().trim();
+        if (text.isNotEmpty) {
+          buffer.write('*$text*');
+        }
+        return;
+      case 'code':
+        if (_isPreChild(element)) {
+          return;
+        }
+        final text = element.text.trim();
+        if (text.isNotEmpty) {
+          buffer.write('`$text`');
+        }
+        return;
+      case 'pre':
+        _processPreElement(element, buffer);
+        return;
+      case 'blockquote':
+        _processBlockquote(element, buffer, depth);
+        return;
+      case 'img':
+        final alt = element.attributes['alt'] ?? '';
+        final src = element.attributes['src'] ?? '';
+        if (alt.isNotEmpty || src.isNotEmpty) {
+          _ensureNewline(buffer);
+          buffer.writeln('![$alt]($src)');
+        }
+        return;
+      case 'ul':
+      case 'ol':
+        _ensureNewline(buffer);
+        _processChildren(element, buffer, depth + 1);
+        _ensureNewline(buffer);
+        return;
+      case 'table':
+        _ensureNewline(buffer);
+        _processTable(element, buffer);
+        _ensureNewline(buffer);
+        return;
+      case 'thead':
+      case 'tbody':
+      case 'tfoot':
+        _processChildren(element, buffer, depth);
+        return;
+      case 'tr':
+      case 'th':
+      case 'td':
+        return;
+      default:
+        if (_isBlockTag(tag)) {
+          _ensureNewline(buffer);
+          _processChildren(element, buffer, depth + 1);
+          _ensureNewline(buffer);
+        } else {
+          _processChildren(element, buffer, depth);
+        }
+    }
+  }
+
+  void _processPreElement(dom.Element element, StringBuffer buffer) {
+    _ensureNewline(buffer);
+    buffer.writeln('```');
+
+    final codeElement = element.querySelector('code');
+    final text = codeElement?.text ?? element.text;
+
+    if (text.isNotEmpty) {
+      buffer.writeln(text.trimRight());
+    }
+
+    buffer.writeln('```');
+    _ensureNewline(buffer);
+  }
+
+  void _processBlockquote(
+    dom.Element element,
+    StringBuffer buffer,
+    int depth,
+  ) {
+    _ensureNewline(buffer);
+
+    final inlineBuffer = StringBuffer();
+    _processInlineChildren(element, inlineBuffer);
+    final text = inlineBuffer.toString().trim();
+    if (text.isNotEmpty) {
+      for (final line in text.split('\n')) {
+        buffer.writeln('> $line');
+      }
+    }
+
+    _ensureNewline(buffer);
+  }
+
+  void _processTable(dom.Element table, StringBuffer buffer) {
+    final rows = <List<String>>[];
+    for (final tr in table.querySelectorAll('tr')) {
+      final cells = <String>[];
+      for (final cell in tr.querySelectorAll('th, td')) {
+        cells.add(
+          cell.text.trim().replaceAll('\n', ' ').replaceAll('|', r'\|'),
+        );
+      }
+      if (cells.isNotEmpty) rows.add(cells);
+    }
+
+    if (rows.isEmpty) return;
+
+    var colCount = 0;
+    for (final row in rows) {
+      if (row.length > colCount) colCount = row.length;
+    }
+
+    buffer.write('| ');
+    for (var i = 0; i < colCount; i++) {
+      buffer.write(i < rows[0].length ? rows[0][i] : '');
+      buffer.write(' | ');
+    }
+    buffer.writeln();
+
+    buffer.write('| ');
+    for (var i = 0; i < colCount; i++) {
+      buffer.write('--- | ');
+    }
+    buffer.writeln();
+
+    for (var i = 1; i < rows.length; i++) {
+      buffer.write('| ');
+      for (var j = 0; j < colCount; j++) {
+        buffer.write(j < rows[i].length ? rows[i][j] : '');
+        buffer.write(' | ');
+      }
+      buffer.writeln();
+    }
+  }
+
+  bool _isBlockTag(String tag) {
+    return _blockTags.contains(tag);
+  }
+
+  bool _isInsideOrderedList(dom.Element element) {
+    var parent = element.parent;
+    while (parent != null) {
+      if (parent.localName?.toLowerCase() == 'ol') return true;
+      if (parent.localName?.toLowerCase() == 'ul') return false;
+      parent = parent.parent;
+    }
+    return false;
+  }
+
+  bool _isPreChild(dom.Element element) {
+    var parent = element.parent;
+    while (parent != null) {
+      if (parent.localName?.toLowerCase() == 'pre') return true;
+      parent = parent.parent;
+    }
+    return false;
+  }
+
+  void _ensureNewline(StringBuffer buffer) {
+    if (buffer.isEmpty) return;
+    final str = buffer.toString();
+    if (!str.endsWith('\n\n') && !str.endsWith('\n\n\n')) {
+      buffer.writeln();
+    }
+  }
+
+  String _collapseBlankLines(String markdown) {
+    return markdown.replaceAll(RegExp(r'\n{3,}'), '\n\n');
+  }
+
+  TransformedUrlContent _passthrough(
+    String body,
+    int originalLength,
+    String? contentType,
+    UrlContentFormat format,
+  ) {
+    if (body.isEmpty) {
+      return TransformedUrlContent(
+        body: body,
+        format: format,
+        contentType: contentType,
+        originalLength: originalLength,
+        truncated: false,
+      );
+    }
+
+    final (output, truncated) = _truncateIfNeeded(body, originalLength);
+
+    return TransformedUrlContent(
+      body: output,
+      format: format,
+      contentType: contentType,
+      originalLength: originalLength,
+      truncated: truncated,
+    );
+  }
+
+  (String, bool) _truncateIfNeeded(String body, int originalLength) {
+    if (body.length <= maxOutputLength) {
+      return (body, false);
+    }
+    return ('${body.substring(0, maxOutputLength)}\n... [truncated]', true);
+  }
+
+  String? _extractContentType(Map<String, List<String>> headers) {
+    for (final entry in headers.entries) {
+      if (entry.key.toLowerCase() == 'content-type') {
+        final values = entry.value;
+        if (values.isNotEmpty) {
+          return values.first.split(';').first.trim().toLowerCase();
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/apps/auravibes_app/lib/services/url/url_content_transformer.dart
+++ b/apps/auravibes_app/lib/services/url/url_content_transformer.dart
@@ -13,6 +13,7 @@ class UrlContentTransformer {
   const UrlContentTransformer();
 
   static const int maxOutputLength = 1024 * 1024;
+  static const _truncationSuffix = '\n... [truncated]';
 
   static final Set<String> _blockTags = {
     'div',
@@ -95,7 +96,9 @@ class UrlContentTransformer {
       };
     }
 
-    if (contentType.contains('application/json')) {
+    final isJson =
+        contentType == 'application/json' || contentType.endsWith('+json');
+    if (isJson) {
       return _passthrough(
         body,
         originalLength,
@@ -104,8 +107,17 @@ class UrlContentTransformer {
       );
     }
 
-    if (contentType.contains('text/plain') ||
-        contentType.contains('text/markdown')) {
+    if (contentType.contains('text/markdown') ||
+        contentType.contains('text/x-markdown')) {
+      return _passthrough(
+        body,
+        originalLength,
+        contentType,
+        UrlContentFormat.markdown,
+      );
+    }
+
+    if (contentType.contains('text/plain')) {
       return _passthrough(
         body,
         originalLength,
@@ -137,7 +149,8 @@ class UrlContentTransformer {
     final bodyElement = document.body;
     if (bodyElement == null) {
       final text = document.text?.trim() ?? '';
-      final (output, truncated) = _truncateIfNeeded(text, originalLength);
+      final escaped = _escapeMarkdownText(text);
+      final (output, truncated) = _truncateIfNeeded(escaped, originalLength);
       return TransformedUrlContent(
         body: output,
         format: .markdown,
@@ -247,6 +260,22 @@ class UrlContentTransformer {
         .replaceAll('~', r'\~');
   }
 
+  String _escapeCodeContent(String text) {
+    if (!text.contains('`')) return '`$text`';
+    var maxRun = 0;
+    var run = 0;
+    for (var i = 0; i < text.length; i++) {
+      if (text[i] == '`') {
+        run++;
+        if (run > maxRun) maxRun = run;
+      } else {
+        run = 0;
+      }
+    }
+    final fence = '`' * (maxRun + 1);
+    return '$fence $text $fence';
+  }
+
   void _processElementNode(
     dom.Element element,
     StringBuffer buffer,
@@ -306,49 +335,24 @@ class UrlContentTransformer {
         _processChildren(element, buffer, depth);
         return;
       case 'a':
-        final href = element.attributes['href'];
-        final inlineBuffer = StringBuffer();
-        _processInlineChildren(element, inlineBuffer);
-        final text = inlineBuffer.toString().trim();
-        if (text.isEmpty) return;
-        if (href != null && href.isNotEmpty) {
-          buffer.write('[$text]($href)');
-        } else {
-          buffer.write(text);
-        }
+        _processAnchor(element, buffer);
         return;
       case 'strong':
       case 'b':
-        final inlineBuffer = StringBuffer();
-        _processInlineChildren(element, inlineBuffer);
-        final text = inlineBuffer.toString().trim();
-        if (text.isNotEmpty) {
-          buffer.write('**$text**');
-        }
+        _processBold(element, buffer);
         return;
       case 'em':
       case 'i':
-        final inlineBuffer = StringBuffer();
-        _processInlineChildren(element, inlineBuffer);
-        final text = inlineBuffer.toString().trim();
-        if (text.isNotEmpty) {
-          buffer.write('*$text*');
-        }
+        _processItalic(element, buffer);
         return;
       case 'code':
-        if (_isPreChild(element)) {
-          return;
-        }
-        final text = element.text.trim();
-        if (text.isNotEmpty) {
-          buffer.write('`$text`');
-        }
+        _processInlineCode(element, buffer);
         return;
       case 'pre':
         _processPreElement(element, buffer);
         return;
       case 'blockquote':
-        _processBlockquote(element, buffer, depth);
+        _processBlockquote(element, buffer);
         return;
       case 'img':
         final alt = element.attributes['alt'] ?? '';
@@ -407,7 +411,6 @@ class UrlContentTransformer {
   void _processBlockquote(
     dom.Element element,
     StringBuffer buffer,
-    int depth,
   ) {
     _ensureNewline(buffer);
 
@@ -442,12 +445,7 @@ class UrlContentTransformer {
       if (row.length > colCount) colCount = row.length;
     }
 
-    buffer.write('| ');
-    for (var i = 0; i < colCount; i++) {
-      buffer.write(i < rows[0].length ? rows[0][i] : '');
-      buffer.write(' | ');
-    }
-    buffer.writeln();
+    _writeTableRow(rows[0], colCount, buffer);
 
     buffer.write('| ');
     for (var i = 0; i < colCount; i++) {
@@ -456,12 +454,7 @@ class UrlContentTransformer {
     buffer.writeln();
 
     for (var i = 1; i < rows.length; i++) {
-      buffer.write('| ');
-      for (var j = 0; j < colCount; j++) {
-        buffer.write(j < rows[i].length ? rows[i][j] : '');
-        buffer.write(' | ');
-      }
-      buffer.writeln();
+      _writeTableRow(rows[i], colCount, buffer);
     }
   }
 
@@ -489,11 +482,58 @@ class UrlContentTransformer {
   }
 
   void _ensureNewline(StringBuffer buffer) {
-    if (buffer.isEmpty) return;
-    final str = buffer.toString();
-    if (!str.endsWith('\n\n') && !str.endsWith('\n\n\n')) {
-      buffer.writeln();
+    final length = buffer.length;
+    if (length == 0) return;
+    if (length >= 2 && buffer.toString().endsWith('\n\n')) return;
+    buffer.writeln();
+  }
+
+  void _processAnchor(dom.Element element, StringBuffer buffer) {
+    final href = element.attributes['href'];
+    final inlineBuffer = StringBuffer();
+    _processInlineChildren(element, inlineBuffer);
+    final text = inlineBuffer.toString().trim();
+    if (text.isEmpty) return;
+    if (href != null && href.isNotEmpty) {
+      buffer.write('[$text]($href)');
+    } else {
+      buffer.write(text);
     }
+  }
+
+  void _processBold(dom.Element element, StringBuffer buffer) {
+    final inlineBuffer = StringBuffer();
+    _processInlineChildren(element, inlineBuffer);
+    final text = inlineBuffer.toString().trim();
+    if (text.isNotEmpty) {
+      buffer.write('**$text**');
+    }
+  }
+
+  void _processItalic(dom.Element element, StringBuffer buffer) {
+    final inlineBuffer = StringBuffer();
+    _processInlineChildren(element, inlineBuffer);
+    final text = inlineBuffer.toString().trim();
+    if (text.isNotEmpty) {
+      buffer.write('*$text*');
+    }
+  }
+
+  void _processInlineCode(dom.Element element, StringBuffer buffer) {
+    if (_isPreChild(element)) return;
+    final text = element.text.trim();
+    if (text.isNotEmpty) {
+      buffer.write(_escapeCodeContent(text));
+    }
+  }
+
+  void _writeTableRow(List<String> cells, int colCount, StringBuffer buffer) {
+    buffer.write('| ');
+    for (var i = 0; i < colCount; i++) {
+      buffer.write(i < cells.length ? cells[i] : '');
+      buffer.write(' | ');
+    }
+    buffer.writeln();
   }
 
   String _collapseBlankLines(String markdown) {
@@ -531,7 +571,11 @@ class UrlContentTransformer {
     if (body.length <= maxOutputLength) {
       return (body, false);
     }
-    return ('${body.substring(0, maxOutputLength)}\n... [truncated]', true);
+    return (
+      '${body.substring(0, maxOutputLength - _truncationSuffix.length)}'
+          '$_truncationSuffix',
+      true,
+    );
   }
 
   String? _extractContentType(Map<String, List<String>> headers) {

--- a/apps/auravibes_app/lib/services/url/url_content_transformer.dart
+++ b/apps/auravibes_app/lib/services/url/url_content_transformer.dart
@@ -281,7 +281,6 @@ class UrlContentTransformer {
     StringBuffer buffer,
     int depth,
   ) {
-    // ignore: long-method - HTML tag dispatch switch covers all elements
     final tag = element.localName?.toLowerCase() ?? '';
 
     if (_stripTags.contains(tag)) {
@@ -294,45 +293,16 @@ class UrlContentTransformer {
 
     switch (tag) {
       case 'br':
-        buffer.writeln();
-        return;
       case 'hr':
-        buffer.writeln();
-        buffer.writeln('---');
-        buffer.writeln();
-        return;
       case 'h1':
       case 'h2':
       case 'h3':
       case 'h4':
       case 'h5':
       case 'h6':
-        final level = int.parse(tag.substring(1));
-        final inlineBuffer = StringBuffer();
-        _processInlineChildren(element, inlineBuffer);
-        final text = inlineBuffer.toString().trim();
-        if (text.isNotEmpty) {
-          _ensureNewline(buffer);
-          buffer.writeln('${'#' * level} $text');
-          _ensureNewline(buffer);
-        }
-        return;
       case 'p':
-        final inlineBuffer = StringBuffer();
-        _processInlineChildren(element, inlineBuffer);
-        final text = inlineBuffer.toString().trim();
-        if (text.isNotEmpty) {
-          _ensureNewline(buffer);
-          buffer.writeln(text);
-        }
-        return;
       case 'li':
-        _ensureNewline(buffer);
-        final indent = '  ' * (depth > 0 ? depth - 1 : 0);
-        final isOrdered = _isInsideOrderedList(element);
-        final marker = isOrdered ? '1. ' : '- ';
-        buffer.write('$indent$marker');
-        _processChildren(element, buffer, depth);
+        _processTextBlockElement(element, buffer, depth, tag);
         return;
       case 'a':
         _processAnchor(element, buffer);
@@ -524,6 +494,56 @@ class UrlContentTransformer {
     final text = element.text.trim();
     if (text.isNotEmpty) {
       buffer.write(_escapeCodeContent(text));
+    }
+  }
+
+  void _processTextBlockElement(
+    dom.Element element,
+    StringBuffer buffer,
+    int depth,
+    String tag,
+  ) {
+    switch (tag) {
+      case 'br':
+        buffer.writeln();
+        return;
+      case 'hr':
+        buffer.writeln();
+        buffer.writeln('---');
+        buffer.writeln();
+        return;
+      case 'h1':
+      case 'h2':
+      case 'h3':
+      case 'h4':
+      case 'h5':
+      case 'h6':
+        final level = int.parse(tag.substring(1));
+        final inlineBuffer = StringBuffer();
+        _processInlineChildren(element, inlineBuffer);
+        final text = inlineBuffer.toString().trim();
+        if (text.isNotEmpty) {
+          _ensureNewline(buffer);
+          buffer.writeln('${'#' * level} $text');
+          _ensureNewline(buffer);
+        }
+        return;
+      case 'p':
+        final inlineBuffer = StringBuffer();
+        _processInlineChildren(element, inlineBuffer);
+        final text = inlineBuffer.toString().trim();
+        if (text.isNotEmpty) {
+          _ensureNewline(buffer);
+          buffer.writeln(text);
+        }
+        return;
+      case 'li':
+        _ensureNewline(buffer);
+        final indent = '  ' * (depth > 0 ? depth - 1 : 0);
+        final isOrdered = _isInsideOrderedList(element);
+        final marker = isOrdered ? '1. ' : '- ';
+        buffer.write('$indent$marker');
+        _processChildren(element, buffer, depth);
     }
   }
 

--- a/apps/auravibes_app/lib/services/url/url_service.dart
+++ b/apps/auravibes_app/lib/services/url/url_service.dart
@@ -28,6 +28,31 @@ class UrlService {
           (key) => key.toLowerCase() == Headers.contentTypeHeader,
         ) ??
         false;
+    final hasAccept =
+        request.headers?.keys.any(
+          (key) => key.toLowerCase() == Headers.acceptHeader,
+        ) ??
+        false;
+    final hasUserAgent =
+        request.headers?.keys.any(
+          (key) => key.toLowerCase() == 'user-agent',
+        ) ??
+        false;
+    final hasAcceptLanguage =
+        request.headers?.keys.any(
+          (key) => key.toLowerCase() == 'accept-language',
+        ) ??
+        false;
+    final effectiveHeaders = <String, String>{
+      ...?request.headers,
+      if (!hasAccept) Headers.acceptHeader: request.format.acceptHeader,
+      if (!hasUserAgent)
+        'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+            'AppleWebKit/537.36 (KHTML, like Gecko) '
+            'Chrome/143.0.0.0 Safari/537.36',
+      if (!hasAcceptLanguage) 'Accept-Language': 'en-US,en;q=0.9',
+    };
     final requestBody = request.body == null || hasContentType
         ? request.body
         : Stream<List<int>>.value(utf8.encode(request.body!));
@@ -39,7 +64,7 @@ class UrlService {
           cancelToken: cancelToken,
           options: Options(
             method: request.method.value,
-            headers: request.headers,
+            headers: effectiveHeaders,
             sendTimeout: request.timeout,
             receiveTimeout: request.timeout,
             responseType: ResponseType.stream,

--- a/apps/auravibes_app/lib/services/url/url_service.dart
+++ b/apps/auravibes_app/lib/services/url/url_service.dart
@@ -23,37 +23,10 @@ class UrlService {
       },
     );
     final stopwatch = Stopwatch()..start();
-    final hasContentType =
-        request.headers?.keys.any(
-          (key) => key.toLowerCase() == Headers.contentTypeHeader,
-        ) ??
-        false;
-    final hasAccept =
-        request.headers?.keys.any(
-          (key) => key.toLowerCase() == Headers.acceptHeader,
-        ) ??
-        false;
-    final hasUserAgent =
-        request.headers?.keys.any(
-          (key) => key.toLowerCase() == 'user-agent',
-        ) ??
-        false;
-    final hasAcceptLanguage =
-        request.headers?.keys.any(
-          (key) => key.toLowerCase() == 'accept-language',
-        ) ??
-        false;
-    final effectiveHeaders = <String, String>{
-      ...?request.headers,
-      if (!hasAccept) Headers.acceptHeader: request.format.acceptHeader,
-      if (!hasUserAgent)
-        'User-Agent':
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
-            'AppleWebKit/537.36 (KHTML, like Gecko) '
-            'Chrome/143.0.0.0 Safari/537.36',
-      if (!hasAcceptLanguage) 'Accept-Language': 'en-US,en;q=0.9',
-    };
-    final requestBody = request.body == null || hasContentType
+    final effectiveHeaders = _buildEffectiveHeaders(request);
+    final requestBody =
+        request.body == null ||
+            _hasHeader(request.headers, Headers.contentTypeHeader)
         ? request.body
         : Stream<List<int>>.value(utf8.encode(request.body!));
 
@@ -178,5 +151,26 @@ class UrlService {
     }
 
     return '${body.substring(0, _maxResponseSize)}\n... [truncated]';
+  }
+
+  Map<String, String> _buildEffectiveHeaders(UrlRequest request) {
+    final headers = request.headers;
+    return <String, String>{
+      ...?headers,
+      if (!_hasHeader(headers, Headers.acceptHeader))
+        Headers.acceptHeader: request.format.acceptHeader,
+      if (!_hasHeader(headers, 'user-agent'))
+        'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+            'AppleWebKit/537.36 (KHTML, like Gecko) '
+            'Chrome/143.0.0.0 Safari/537.36',
+      if (!_hasHeader(headers, 'accept-language'))
+        'Accept-Language': 'en-US,en;q=0.9',
+    };
+  }
+
+  bool _hasHeader(Map<String, String>? headers, String name) {
+    if (headers == null) return false;
+    return headers.keys.any((k) => k.toLowerCase() == name);
   }
 }

--- a/apps/auravibes_app/pubspec.yaml
+++ b/apps/auravibes_app/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   freezed_annotation: ^3.1.0
   go_router: ^17.2.3
   hooks_riverpod: ^3.0.3
+  html: ^0.15.6
   http: ^1.6.0
   json_annotation: ^4.9.0
   logging: ^1.3.0

--- a/apps/auravibes_app/test/services/tools/native_tools/url_tool_test.dart
+++ b/apps/auravibes_app/test/services/tools/native_tools/url_tool_test.dart
@@ -345,6 +345,192 @@ void main() {
 
       expect(result, contains('Status: 200'));
     });
+
+    test('transforms HTML response to markdown with format header', () async {
+      final dio = Dio()
+        ..httpClientAdapter = _SuccessAdapter(
+          body: '<html><body><h1>Hello</h1><p>World</p></body></html>',
+          statusCode: 200,
+          extraHeaders: {
+            'content-type': ['text/html'],
+          },
+        );
+      final tool = UrlTool(urlService: UrlService(dio: dio));
+
+      final result = await tool.runner('https://1.1.1.1').value;
+
+      expect(result, contains('Format: markdown'));
+      expect(result, contains('Content-Type: text/html'));
+      expect(result, contains('# Hello'));
+      expect(result, contains('World'));
+    });
+
+    test('transforms JSON response with json format header', () async {
+      final dio = Dio()
+        ..httpClientAdapter = _SuccessAdapter(
+          body: '{"key": "value"}',
+          statusCode: 200,
+          extraHeaders: {
+            'content-type': ['application/json'],
+          },
+        );
+      final tool = UrlTool(urlService: UrlService(dio: dio));
+
+      final result = await tool.runner('https://1.1.1.1').value;
+
+      expect(result, contains('Format: json'));
+      expect(result, contains('Content-Type: application/json'));
+      expect(result, contains('{"key": "value"}'));
+    });
+
+    test('transforms plain text with text format header', () async {
+      final dio = Dio()
+        ..httpClientAdapter = _SuccessAdapter(
+          body: 'Hello world',
+          statusCode: 200,
+          extraHeaders: {
+            'content-type': ['text/plain'],
+          },
+        );
+      final tool = UrlTool(urlService: UrlService(dio: dio));
+
+      final result = await tool.runner('https://1.1.1.1').value;
+
+      expect(result, contains('Format: text'));
+      expect(result, contains('Content-Type: text/plain'));
+      expect(result, contains('Hello world'));
+    });
+
+    test('handles unknown content type with unsupported format', () async {
+      final dio = Dio()
+        ..httpClientAdapter = _SuccessAdapter(
+          body: 'data',
+          statusCode: 200,
+        );
+      final tool = UrlTool(urlService: UrlService(dio: dio));
+
+      final result = await tool.runner('https://1.1.1.1').value;
+
+      expect(result, contains('Format: unsupported'));
+      expect(result, contains('Content-Type: unknown'));
+    });
+
+    group('format parameter', () {
+      test('accepts format: markdown', () async {
+        String? sentAccept;
+        final dio = Dio()
+          ..httpClientAdapter = _InspectAdapter(
+            body: '<html><body><h1>Hi</h1></body></html>',
+            statusCode: 200,
+            extraHeaders: {
+              'content-type': ['text/html'],
+            },
+            onInspect: (method, headers, body) {
+              sentAccept = headers?['accept'] as String?;
+            },
+          );
+        final tool = UrlTool(urlService: UrlService(dio: dio));
+
+        final result = await tool
+            .runner(
+              '{"url": "https://1.1.1.1", "format": "markdown"}',
+            )
+            .value;
+
+        expect(result, contains('Format: markdown'));
+        expect(result, contains('# Hi'));
+        expect(sentAccept, isNotNull);
+        expect(sentAccept, contains('text/html'));
+        expect(sentAccept, contains('text/markdown'));
+      });
+
+      test('accepts format: text', () async {
+        final dio = Dio()
+          ..httpClientAdapter = _SuccessAdapter(
+            body: '<html><body><h1>Title</h1><p>Content</p></body></html>',
+            statusCode: 200,
+            extraHeaders: {
+              'content-type': ['text/html'],
+            },
+          );
+        final tool = UrlTool(urlService: UrlService(dio: dio));
+
+        final result = await tool
+            .runner(
+              '{"url": "https://1.1.1.1", "format": "text"}',
+            )
+            .value;
+
+        expect(result, contains('Format: text'));
+        expect(result, contains('Title'));
+        expect(result, contains('Content'));
+        expect(result, isNot(contains('#')));
+      });
+
+      test('accepts format: html', () async {
+        final dio = Dio()
+          ..httpClientAdapter = _SuccessAdapter(
+            body: '<html><body><h1>Raw</h1></body></html>',
+            statusCode: 200,
+            extraHeaders: {
+              'content-type': ['text/html'],
+            },
+          );
+        final tool = UrlTool(urlService: UrlService(dio: dio));
+
+        final result = await tool
+            .runner(
+              '{"url": "https://1.1.1.1", "format": "html"}',
+            )
+            .value;
+
+        expect(result, contains('Format: html'));
+        expect(result, contains('<h1>Raw</h1>'));
+      });
+
+      test('omitted format defaults to markdown', () async {
+        final dio = Dio()
+          ..httpClientAdapter = _SuccessAdapter(
+            body: '<html><body><h1>Hello</h1></body></html>',
+            statusCode: 200,
+            extraHeaders: {
+              'content-type': ['text/html'],
+            },
+          );
+        final tool = UrlTool(urlService: UrlService(dio: dio));
+
+        final result = await tool.runner('https://1.1.1.1').value;
+
+        expect(result, contains('Format: markdown'));
+        expect(result, contains('# Hello'));
+      });
+
+      test('rejects invalid format string', () {
+        final tool = UrlTool();
+
+        expect(
+          tool
+              .runner(
+                '{"url": "https://example.com", "format": "unknown"}',
+              )
+              .value,
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('rejects non-string format value', () {
+        final tool = UrlTool();
+
+        expect(
+          tool
+              .runner(
+                '{"url": "https://example.com", "format": 123}',
+              )
+              .value,
+          throwsA(isA<FormatException>()),
+        );
+      });
+    });
   });
 }
 
@@ -381,11 +567,13 @@ final class _InspectAdapter implements HttpClientAdapter {
     required this.body,
     required this.statusCode,
     required this.onInspect,
+    this.extraHeaders,
   });
 
   final String body;
   final int statusCode;
   final void Function(String?, Map<String, dynamic>?, String?) onInspect;
+  final Map<String, List<String>>? extraHeaders;
 
   @override
   Future<ResponseBody> fetch(
@@ -402,7 +590,11 @@ final class _InspectAdapter implements HttpClientAdapter {
       requestBody = String.fromCharCodes(bytes);
     }
     onInspect(options.method, options.headers, requestBody);
-    return ResponseBody.fromString(body, statusCode);
+    return ResponseBody.fromString(
+      body,
+      statusCode,
+      headers: extraHeaders ?? const {},
+    );
   }
 
   @override

--- a/apps/auravibes_app/test/services/url/url_content_transformer_test.dart
+++ b/apps/auravibes_app/test/services/url/url_content_transformer_test.dart
@@ -377,6 +377,13 @@ void main() {
           );
           expect(txt.format, UrlContentFormat.text);
           expect(txt.body, 'Hello world');
+
+          final html = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.html,
+          );
+          expect(html.format, UrlContentFormat.text);
+          expect(html.body, 'Hello world');
         },
       );
     });
@@ -625,6 +632,6 @@ UrlResponse _responseWithContentType(String body, String? contentType) {
             'content-type': [contentType],
           }
         : {},
-    elapsed: Duration.zero,
+    elapsed: .zero,
   );
 }

--- a/apps/auravibes_app/test/services/url/url_content_transformer_test.dart
+++ b/apps/auravibes_app/test/services/url/url_content_transformer_test.dart
@@ -1,0 +1,630 @@
+import 'package:auravibes_app/services/url/models/transformed_url_content.dart';
+import 'package:auravibes_app/services/url/models/url_request.dart';
+import 'package:auravibes_app/services/url/models/url_response.dart';
+import 'package:auravibes_app/services/url/url_content_transformer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('UrlContentTransformer', () {
+    const transformer = UrlContentTransformer();
+
+    group('HTML transformation', () {
+      test('converts heading tags to markdown headings', () {
+        final response = _htmlResponse('<h1>Title</h1><p>Content here.</p>');
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('# Title'));
+        expect(result.body, contains('Content here.'));
+      });
+
+      test('strips script and style tags', () {
+        final response = _htmlResponse(
+          '<html><head><script>alert("xss")</script><style>body { color: red; }</style></head><body><p>Safe content</p></body></html>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('Safe content'));
+        expect(result.body, isNot(contains('alert')));
+        expect(result.body, isNot(contains('color: red')));
+      });
+
+      test('converts links to markdown links', () {
+        final response = _htmlResponse(
+          '<p>Visit <a href="https://example.com">Example</a> site.</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('[Example](https://example.com)'));
+      });
+
+      test('converts emphasis and strong tags', () {
+        final response = _htmlResponse(
+          '<p>This is <strong>bold</strong> and <em>italic</em> text.</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('**bold**'));
+        expect(result.body, contains('*italic*'));
+      });
+
+      test('converts unordered lists', () {
+        final response = _htmlResponse(
+          '<ul><li>Item 1</li><li>Item 2</li></ul>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('- Item 1'));
+        expect(result.body, contains('- Item 2'));
+      });
+
+      test('converts ordered lists', () {
+        final response = _htmlResponse(
+          '<ol><li>First</li><li>Second</li></ol>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('1. First'));
+        expect(result.body, contains('1. Second'));
+      });
+
+      test('converts blockquotes', () {
+        final response = _htmlResponse(
+          '<blockquote><p>Quoted text</p></blockquote>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('> Quoted text'));
+      });
+
+      test('converts code elements inline', () {
+        final response = _htmlResponse(
+          '<p>Use <code>print()</code> function.</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('`print()`'));
+      });
+
+      test('converts pre elements to code blocks', () {
+        final response = _htmlResponse(
+          '<pre><code>const x = 1;\nprint(x);</code></pre>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('```'));
+        expect(result.body, contains('const x = 1;'));
+        expect(result.body, contains('print(x);'));
+      });
+
+      test('extracts title as h1', () {
+        final response = _htmlResponse(
+          '<html><head><title>Page Title</title></head><body><p>Content</p></body></html>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('# Page Title'));
+      });
+
+      test('handles images with alt text', () {
+        final response = _htmlResponse(
+          '<p>Here is an image: <img src="photo.jpg" alt="A photo"></p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('![A photo](photo.jpg)'));
+      });
+
+      test('handles horizontal rules', () {
+        final response = _htmlResponse(
+          '<p>Above</p><hr><p>Below</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('---'));
+      });
+
+      test('strips svg elements', () {
+        final response = _htmlResponse(
+          '<p>Text</p><svg><circle cx="50" cy="50" r="40"/></svg><p>More</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('Text'));
+        expect(result.body, contains('More'));
+        expect(result.body, isNot(contains('circle')));
+      });
+
+      test('handles deeply nested content', () {
+        final response = _htmlResponse(
+          '<div><section><article><p>Nested paragraph</p></article></section></div>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('Nested paragraph'));
+      });
+
+      test('returns empty body for empty HTML', () {
+        final response = _htmlResponse('');
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, isEmpty);
+      });
+    });
+
+    group('JSON transformation', () {
+      test('preserves JSON content as-is', () {
+        final response = _jsonResponse('{"key": "value"}');
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.json);
+        expect(result.body, '{"key": "value"}');
+        expect(result.truncated, isFalse);
+      });
+    });
+
+    group('Plain text transformation', () {
+      test('preserves plain text as-is', () {
+        final response = _plainTextResponse('Hello world');
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.text);
+        expect(result.body, 'Hello world');
+      });
+    });
+
+    group('Unknown content type', () {
+      test('preserves content with unsupported format', () {
+        final response = _responseWithContentType(
+          'binary data',
+          'application/octet-stream',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.unsupported);
+        expect(result.body, 'binary data');
+      });
+    });
+
+    group('Missing content type', () {
+      test('preserves content when no content-type header', () {
+        final response = _responseWithContentType('some text', null);
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.unsupported);
+        expect(result.body, 'some text');
+      });
+    });
+
+    group('Truncation', () {
+      test('truncates content exceeding max length', () {
+        const leading = 'Start ';
+        final padding = 'x' * (UrlContentTransformer.maxOutputLength + 100);
+        final response = _plainTextResponse('$leading$padding');
+        final result = transformer.transform(response);
+
+        expect(result.truncated, isTrue);
+        expect(result.body, contains('[truncated]'));
+        expect(result.body.startsWith(leading), isTrue);
+        expect(result.originalLength, greaterThan(result.body.length));
+      });
+
+      test('does not truncate content within max length', () {
+        final response = _plainTextResponse('Short content');
+        final result = transformer.transform(response);
+
+        expect(result.truncated, isFalse);
+      });
+    });
+
+    group('Requested format', () {
+      test(
+        'default format maps HTML to markdown',
+        () {
+          final response = _htmlResponse('<h1>Hello</h1>');
+          final result = transformer.transform(response);
+
+          expect(result.format, UrlContentFormat.markdown);
+          expect(result.body, contains('# Hello'));
+        },
+      );
+
+      test(
+        'markdown format maps HTML to markdown',
+        () {
+          final response = _htmlResponse('<h1>Hello</h1>');
+          final result = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.markdown,
+          );
+
+          expect(result.format, UrlContentFormat.markdown);
+          expect(result.body, contains('# Hello'));
+        },
+      );
+
+      test(
+        'text format maps HTML to plain text',
+        () {
+          final response = _htmlResponse(
+            '<h1>Title</h1><p>Paragraph with '
+            '<a href="https://example.com">link</a> and '
+            '<strong>bold</strong> text.</p>',
+          );
+          final result = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.text,
+          );
+
+          expect(result.format, UrlContentFormat.text);
+          expect(result.body, contains('Title'));
+          expect(result.body, contains('Paragraph'));
+          expect(result.body, contains('link'));
+          expect(result.body, contains('bold'));
+          expect(result.body, isNot(contains('#')));
+          expect(result.body, isNot(contains('**')));
+          expect(result.body, isNot(contains('[')));
+        },
+      );
+
+      test(
+        'html format returns raw HTML body',
+        () {
+          const html = '<h1>Raw</h1><p>Content</p>';
+          final response = _htmlResponse(html);
+          final result = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.html,
+          );
+
+          expect(result.format, UrlContentFormat.html);
+          expect(result.body, contains('<h1>Raw</h1>'));
+          expect(result.body, contains('<p>Content</p>'));
+        },
+      );
+
+      test(
+        'html format returns raw HTML body (no stripping)',
+        () {
+          const html =
+              '<html><script>alert(1)</script><body><p>Safe</p></body></html>';
+          final response = _htmlResponse(html);
+          final result = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.html,
+          );
+
+          expect(result.format, UrlContentFormat.html);
+          expect(result.body, contains('<p>Safe</p>'));
+          expect(result.body, contains('<script'));
+        },
+      );
+
+      test(
+        'text format strips script tags',
+        () {
+          final response = _htmlResponse(
+            '<html><script>alert(1)</script><body><p>Safe</p></body></html>',
+          );
+          final result = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.text,
+          );
+
+          expect(result.format, UrlContentFormat.text);
+          expect(result.body, contains('Safe'));
+          expect(result.body, isNot(contains('alert')));
+        },
+      );
+
+      test(
+        'json content stays json regardless of requested format',
+        () {
+          final response = _jsonResponse('{"key": "value"}');
+
+          final md = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.markdown,
+          );
+          expect(md.format, UrlContentFormat.json);
+          expect(md.body, '{"key": "value"}');
+
+          final txt = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.text,
+          );
+          expect(txt.format, UrlContentFormat.json);
+          expect(txt.body, '{"key": "value"}');
+
+          final html = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.html,
+          );
+          expect(html.format, UrlContentFormat.json);
+          expect(html.body, '{"key": "value"}');
+        },
+      );
+
+      test(
+        'plain text stays text regardless of requested format',
+        () {
+          final response = _plainTextResponse('Hello world');
+
+          final md = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.markdown,
+          );
+          expect(md.format, UrlContentFormat.text);
+          expect(md.body, 'Hello world');
+
+          final txt = transformer.transform(
+            response,
+            requestedFormat: UrlResponseFormat.text,
+          );
+          expect(txt.format, UrlContentFormat.text);
+          expect(txt.body, 'Hello world');
+        },
+      );
+    });
+
+    group('Markdown escaping', () {
+      test('escapes asterisks in text content', () {
+        final response = _htmlResponse(
+          '<p>Use the * wildcard</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains(r'\*'));
+        expect(result.body, isNot(contains('*wildcard*')));
+      });
+
+      test('escapes underscores in text content', () {
+        final response = _htmlResponse(
+          '<p>Variable _name is private</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains(r'\_'));
+      });
+
+      test('escapes square brackets in text content', () {
+        final response = _htmlResponse(
+          '<p>Array [0] is first</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains(r'\['));
+        expect(result.body, contains(r'\]'));
+      });
+
+      test('escapes backticks in text content', () {
+        final response = _htmlResponse(
+          '<p>The ` char is special</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains(r'\`'));
+      });
+
+      test('escapes pipe characters in text', () {
+        final response = _htmlResponse(
+          '<p>Use | as OR operator</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains(r'\|'));
+      });
+
+      test('does not escape inside inline code', () {
+        final response = _htmlResponse(
+          '<p>Run <code>grep * | sort</code> to filter</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('`grep * | sort`'));
+      });
+
+      test('does not escape inside pre code blocks', () {
+        final response = _htmlResponse(
+          '<pre><code>const x = [1, 2];\nprint(*x);</code></pre>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('const x = [1, 2];'));
+        expect(result.body, contains('print(*x);'));
+      });
+
+      test('backslash itself is escaped', () {
+        final response = _htmlResponse(
+          r'<p>Path is C:\Users\name</p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains(r'C:\\Users\\name'));
+      });
+    });
+
+    group('Recursive inline handling', () {
+      test('preserves nested emphasis inside strong', () {
+        final response = _htmlResponse(
+          '<p>Read <strong><em>the docs</em></strong></p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('***the docs***'));
+      });
+
+      test('preserves nested link inside strong', () {
+        final response = _htmlResponse(
+          '<p>Visit <strong><a href="/docs">the docs</a></strong></p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('**[the docs](/docs)**'));
+      });
+
+      test('preserves nested code inside link text', () {
+        final response = _htmlResponse(
+          '<p>Check <a href="/api"><code>getUser()</code></a></p>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('[`getUser()`](/api)'));
+      });
+
+      test('preserves nested formatting inside heading', () {
+        final response = _htmlResponse(
+          '<h1>Welcome to <em>My</em> Site</h1>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('# Welcome to *My* Site'));
+      });
+
+      test('preserves nested formatting inside blockquote', () {
+        final response = _htmlResponse(
+          '<blockquote><p>This is <strong>very</strong> important</p></blockquote>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('> This is **very** important'));
+      });
+    });
+
+    group('Table conversion', () {
+      test('converts simple table to markdown', () {
+        final response = _htmlResponse(
+          '<table>'
+          '<tr><th>Name</th><th>Type</th></tr>'
+          '<tr><td>url</td><td>string</td></tr>'
+          '<tr><td>count</td><td>number</td></tr>'
+          '</table>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, contains('| Name | Type |'));
+        expect(result.body, contains('| --- | --- |'));
+        expect(result.body, contains('| url | string |'));
+        expect(result.body, contains('| count | number |'));
+      });
+
+      test('handles table with thead and tbody', () {
+        final response = _htmlResponse(
+          '<table>'
+          '<thead><tr><th>Key</th><th>Value</th></tr></thead>'
+          '<tbody><tr><td>a</td><td>1</td></tr></tbody>'
+          '</table>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('| Key | Value |'));
+        expect(result.body, contains('| a | 1 |'));
+      });
+
+      test('escapes pipe inside table cells', () {
+        final response = _htmlResponse(
+          '<table><tr><th>Expression</th></tr><tr><td>a | b</td></tr></table>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains(r'a \| b'));
+      });
+
+      test('handles empty table gracefully', () {
+        final response = _htmlResponse('<table></table>');
+        final result = transformer.transform(response);
+
+        expect(result.format, UrlContentFormat.markdown);
+        expect(result.body, isNot(contains('|')));
+      });
+
+      test('handles table with missing cells', () {
+        final response = _htmlResponse(
+          '<table>'
+          '<tr><th>A</th><th>B</th><th>C</th></tr>'
+          '<tr><td>1</td><td>2</td></tr>'
+          '</table>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('| A | B | C |'));
+        expect(result.body, contains('| 1 | 2 |  |'));
+      });
+    });
+
+    group('Nested list indentation', () {
+      test('indents nested unordered list items', () {
+        final response = _htmlResponse(
+          '<ul><li>Parent<ul><li>Child</li></ul></li></ul>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('- Parent'));
+        expect(result.body, contains('  - Child'));
+      });
+
+      test('indents deeply nested list items', () {
+        final response = _htmlResponse(
+          '<ul><li>Level 1<ul><li>Level 2<ul><li>Level 3</li></ul></li></ul></li></ul>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('- Level 1'));
+        expect(result.body, contains('  - Level 2'));
+        expect(result.body, contains('    - Level 3'));
+      });
+    });
+
+    group('Skip content tags', () {
+      test('skips nav element content entirely', () {
+        final response = _htmlResponse(
+          '<nav><ul><li><a href="/">Home</a></li></ul></nav><main><p>Main content</p></main>',
+        );
+        final result = transformer.transform(response);
+
+        expect(result.body, contains('Main content'));
+        expect(result.body, isNot(contains('Home')));
+      });
+    });
+  });
+}
+
+UrlResponse _htmlResponse(String html) {
+  return _responseWithContentType(html, 'text/html');
+}
+
+UrlResponse _jsonResponse(String json) {
+  return _responseWithContentType(json, 'application/json');
+}
+
+UrlResponse _plainTextResponse(String text) {
+  return _responseWithContentType(text, 'text/plain');
+}
+
+UrlResponse _responseWithContentType(String body, String? contentType) {
+  return UrlResponse(
+    statusCode: 200,
+    body: body,
+    headers: contentType != null
+        ? {
+            'content-type': [contentType],
+          }
+        : {},
+    elapsed: Duration.zero,
+  );
+}

--- a/apps/auravibes_app/test/services/url/url_service_test.dart
+++ b/apps/auravibes_app/test/services/url/url_service_test.dart
@@ -281,6 +281,168 @@ void main() {
 
       expect(response.elapsed, greaterThanOrEqualTo(Duration.zero));
     });
+
+    group('Accept header', () {
+      test('adds Accept header based on format', () async {
+        String? acceptHeader;
+        final adapter = _FakeHttpClientAdapter(
+          onFetch: (options, _, _) async {
+            acceptHeader = options.headers['accept'] as String?;
+            return ResponseBody.fromString('ok', 200);
+          },
+        );
+        final dio = Dio()..httpClientAdapter = adapter;
+        final service = UrlService(dio: dio);
+
+        await service
+            .execute(
+              const UrlRequest(
+                url: 'https://example.com',
+                format: UrlResponseFormat.markdown,
+              ),
+            )
+            .value;
+
+        expect(acceptHeader, isNotNull);
+        expect(acceptHeader, contains('text/html'));
+        expect(acceptHeader, contains('text/markdown'));
+      });
+
+      test('uses html Accept header for html format', () async {
+        String? acceptHeader;
+        final adapter = _FakeHttpClientAdapter(
+          onFetch: (options, _, _) async {
+            acceptHeader = options.headers['accept'] as String?;
+            return ResponseBody.fromString('ok', 200);
+          },
+        );
+        final dio = Dio()..httpClientAdapter = adapter;
+        final service = UrlService(dio: dio);
+
+        await service
+            .execute(
+              const UrlRequest(
+                url: 'https://example.com',
+                format: UrlResponseFormat.html,
+              ),
+            )
+            .value;
+
+        expect(acceptHeader, isNotNull);
+        expect(acceptHeader, contains('text/html'));
+        expect(acceptHeader, contains('application/xhtml+xml'));
+      });
+
+      test('preserves user-provided Accept header', () async {
+        String? acceptHeader;
+        final adapter = _FakeHttpClientAdapter(
+          onFetch: (options, _, _) async {
+            acceptHeader = options.headers['accept'] as String?;
+            return ResponseBody.fromString('ok', 200);
+          },
+        );
+        final dio = Dio()..httpClientAdapter = adapter;
+        final service = UrlService(dio: dio);
+
+        await service
+            .execute(
+              const UrlRequest(
+                url: 'https://example.com',
+                headers: {'Accept': 'application/json'},
+              ),
+            )
+            .value;
+
+        expect(acceptHeader, 'application/json');
+      });
+
+      test('adds default User-Agent header', () async {
+        String? userAgent;
+        final adapter = _FakeHttpClientAdapter(
+          onFetch: (options, _, _) async {
+            userAgent = options.headers['user-agent'] as String?;
+            return ResponseBody.fromString('ok', 200);
+          },
+        );
+        final dio = Dio()..httpClientAdapter = adapter;
+        final service = UrlService(dio: dio);
+
+        await service
+            .execute(
+              const UrlRequest(url: 'https://example.com'),
+            )
+            .value;
+
+        expect(userAgent, contains('Mozilla/5.0'));
+        expect(userAgent, contains('Chrome/'));
+      });
+
+      test('preserves user-provided User-Agent header', () async {
+        String? userAgent;
+        final adapter = _FakeHttpClientAdapter(
+          onFetch: (options, _, _) async {
+            userAgent = options.headers['user-agent'] as String?;
+            return ResponseBody.fromString('ok', 200);
+          },
+        );
+        final dio = Dio()..httpClientAdapter = adapter;
+        final service = UrlService(dio: dio);
+
+        await service
+            .execute(
+              const UrlRequest(
+                url: 'https://example.com',
+                headers: {'User-Agent': 'MyBot/1.0'},
+              ),
+            )
+            .value;
+
+        expect(userAgent, 'MyBot/1.0');
+      });
+
+      test('adds default Accept-Language header', () async {
+        String? acceptLanguage;
+        final adapter = _FakeHttpClientAdapter(
+          onFetch: (options, _, _) async {
+            acceptLanguage = options.headers['accept-language'] as String?;
+            return ResponseBody.fromString('ok', 200);
+          },
+        );
+        final dio = Dio()..httpClientAdapter = adapter;
+        final service = UrlService(dio: dio);
+
+        await service
+            .execute(
+              const UrlRequest(url: 'https://example.com'),
+            )
+            .value;
+
+        expect(acceptLanguage, 'en-US,en;q=0.9');
+      });
+
+      test('preserves user-provided Accept-Language header', () async {
+        String? acceptLanguage;
+        final adapter = _FakeHttpClientAdapter(
+          onFetch: (options, _, _) async {
+            acceptLanguage = options.headers['accept-language'] as String?;
+            return ResponseBody.fromString('ok', 200);
+          },
+        );
+        final dio = Dio()..httpClientAdapter = adapter;
+        final service = UrlService(dio: dio);
+
+        await service
+            .execute(
+              const UrlRequest(
+                url: 'https://example.com',
+                headers: {'Accept-Language': 'es-ES'},
+              ),
+            )
+            .value;
+
+        expect(acceptLanguage, 'es-ES');
+      });
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

Adds HTML-to-Markdown/Text content transformation to the URL tool, modeled after OpenCode's `webfetch` behavior. Fetched HTML pages are now converted to clean Markdown (or plain text, or raw HTML) before being sent to the AI model.

## Changes

### New files
- **`url_content_transformer.dart`** — Service-layer transformer: HTML→Markdown, HTML→Text, passthrough for JSON/text/unknown
- **`transformed_url_content.dart`** — Model: `TransformedUrlContent` with format enum
- **`url_content_transformer_test.dart`** — 50+ tests

### Modified files
- **`url_request.dart`** — `UrlResponseFormat` enum with OpenCode-style `Accept` headers
- **`url_service.dart`** — Default `User-Agent` and `Accept-Language` headers
- **`url_tool.dart`** — Optional `format` parameter wired to transformer
- **`pubspec.yaml`** — Added `html` package dependency
- **`url_tool_test.dart`**, **`url_service_test.dart`** — Integration tests

### Key behaviors
- HTML→Markdown: headings, links, bold/italic, nested lists, blockquotes, tables, code blocks
- Markdown escaping on text nodes (code/pre blocks untouched)
- Recursive inline formatting preserved
- Table→pipe tables with header/separator/data rows
- Content-type routing: HTML→transform, JSON→passthrough, text→passthrough
- Format: `markdown` (default), `text`, `html` — affects `Accept` header and output

## Verification

87 tests passing, zero analyzer issues.