### PR TITLE
fix: read streamed URL error responses

### DIFF
--- a/apps/auravibes_app/lib/services/url/url_service.dart
+++ b/apps/auravibes_app/lib/services/url/url_service.dart
@@ -59,7 +59,7 @@ class UrlService {
             ),
           );
         })
-        .catchError((Object error, StackTrace stackTrace) {
+        .catchError((Object error, StackTrace stackTrace) async {
           if (completer.isCanceled) {
             return;
           }
@@ -72,12 +72,18 @@ class UrlService {
           }
 
           if (error is DioException) {
+            final body = await _readErrorResponseBody(
+              error.response?.data,
+              error.message,
+            );
+            if (completer.isCanceled) {
+              return;
+            }
+
             completer.complete(
               UrlResponse(
                 statusCode: error.response?.statusCode ?? 0,
-                body: _truncateText(
-                  error.response?.data?.toString() ?? error.message ?? '',
-                ),
+                body: body,
                 headers: error.response?.headers.map ?? const {},
                 elapsed: stopwatch.elapsed,
               ),
@@ -89,6 +95,18 @@ class UrlService {
         });
 
     return completer.operation;
+  }
+
+  Future<String> _readErrorResponseBody(Object? data, String? message) async {
+    if (data is ResponseBody) {
+      return _readResponseBody(data);
+    }
+
+    if (data is List<int>) {
+      return _truncateText(utf8.decode(data, allowMalformed: true));
+    }
+
+    return _truncateText(data?.toString() ?? message ?? '');
   }
 
   Future<String> _readResponseBody(ResponseBody? responseBody) async {

--- a/apps/auravibes_app/lib/services/url/url_service.dart
+++ b/apps/auravibes_app/lib/services/url/url_service.dart
@@ -12,6 +12,7 @@ class UrlService {
   final Dio _dio;
 
   static const int _maxResponseSize = 1024 * 1024;
+  static const String _truncatedSuffix = '\n... [truncated]';
 
   CancelableOperation<UrlResponse> execute(UrlRequest request) {
     final cancelToken = CancelToken();
@@ -60,53 +61,81 @@ class UrlService {
           );
         })
         .catchError((Object error, StackTrace stackTrace) async {
-          if (completer.isCanceled) {
-            return;
-          }
-
-          stopwatch.stop();
-
-          if (error is DioException && error.type == DioExceptionType.cancel) {
-            completer.operation.cancel();
-            return;
-          }
-
-          if (error is DioException) {
-            final body = await _readErrorResponseBody(
-              error.response?.data,
-              error.message,
-            );
-            if (completer.isCanceled) {
-              return;
-            }
-
-            completer.complete(
-              UrlResponse(
-                statusCode: error.response?.statusCode ?? 0,
-                body: body,
-                headers: error.response?.headers.map ?? const {},
-                elapsed: stopwatch.elapsed,
-              ),
-            );
-            return;
-          }
-
-          completer.completeError(error, stackTrace);
+          await _handleRequestError(
+            error,
+            stackTrace,
+            completer,
+            stopwatch,
+          );
         });
 
     return completer.operation;
   }
 
-  Future<String> _readErrorResponseBody(Object? data, String? message) async {
-    if (data is ResponseBody) {
-      return _readResponseBody(data);
+  Future<void> _handleRequestError(
+    Object error,
+    StackTrace stackTrace,
+    CancelableCompleter<UrlResponse> completer,
+    Stopwatch stopwatch,
+  ) async {
+    if (completer.isCanceled) {
+      return;
     }
 
-    if (data is List<int>) {
-      return _truncateText(utf8.decode(data, allowMalformed: true));
+    stopwatch.stop();
+
+    if (error is! DioException) {
+      completer.completeError(error, stackTrace);
+      return;
     }
 
-    return _truncateText(data?.toString() ?? message ?? '');
+    if (error.type == DioExceptionType.cancel) {
+      completer.operation.cancel();
+      return;
+    }
+
+    final body = await _safeReadErrorResponseBody(
+      error.response?.data,
+      error.message,
+    );
+    if (completer.isCanceled) {
+      return;
+    }
+
+    completer.complete(
+      UrlResponse(
+        statusCode: error.response?.statusCode ?? 0,
+        body: body,
+        headers: error.response?.headers.map ?? const {},
+        elapsed: stopwatch.elapsed,
+      ),
+    );
+  }
+
+  Future<String> _safeReadErrorResponseBody(
+    Object? data,
+    String? message,
+  ) async {
+    try {
+      return await _readErrorResponseBody(data, message);
+    } on Object {
+      return _truncateText(message ?? '');
+    }
+  }
+
+  Future<String> _readErrorResponseBody(Object? data, String? message) async =>
+      switch (data) {
+        ResponseBody() => _readResponseBody(data),
+        List<int>() => _decodeErrorBytes(data),
+        _ => _truncateText(data?.toString() ?? message ?? ''),
+      };
+
+  String _decodeErrorBytes(List<int> data) {
+    final bytes = data.length <= _maxResponseSize
+        ? data
+        : data.take(_maxResponseSize).toList(growable: false);
+    final body = utf8.decode(bytes, allowMalformed: true);
+    return data.length <= _maxResponseSize ? body : '$body$_truncatedSuffix';
   }
 
   Future<String> _readResponseBody(ResponseBody? responseBody) async {
@@ -127,7 +156,7 @@ class UrlService {
 
         final remainingChars = _maxResponseSize - receivedChars;
         if (remainingChars <= 0) {
-          buffer.write('\n... [truncated]');
+          buffer.write(_truncatedSuffix);
           completer.complete(buffer.toString());
           unawaited(subscription.cancel());
           return;
@@ -142,7 +171,7 @@ class UrlService {
 
         buffer
           ..write(decodedChunk.substring(0, remainingChars))
-          ..write('\n... [truncated]');
+          ..write(_truncatedSuffix);
         receivedChars += remainingChars;
         completer.complete(buffer.toString());
         unawaited(subscription.cancel());
@@ -168,7 +197,7 @@ class UrlService {
       return body;
     }
 
-    return '${body.substring(0, _maxResponseSize)}\n... [truncated]';
+    return '${body.substring(0, _maxResponseSize)}$_truncatedSuffix';
   }
 
   Map<String, String> _buildEffectiveHeaders(UrlRequest request) {

--- a/apps/auravibes_app/test/services/url/url_service_test.dart
+++ b/apps/auravibes_app/test/services/url/url_service_test.dart
@@ -139,28 +139,31 @@ void main() {
       expect(response.body.length, lessThan(largeBody.length));
     });
 
-    test('handles DioException without response', () async {
-      final adapter = _FakeHttpClientAdapter(
-        onFetch: (options, _, _) async {
-          throw DioException(
-            requestOptions: RequestOptions(path: options.path),
-            message: 'Connection refused',
-            type: DioExceptionType.connectionError,
-          );
-        },
-      );
-      final dio = Dio()..httpClientAdapter = adapter;
-      final service = UrlService(dio: dio);
+    test(
+      'handles DioException without response and with request path',
+      () async {
+        final adapter = _FakeHttpClientAdapter(
+          onFetch: (options, _, _) async {
+            throw DioException(
+              requestOptions: RequestOptions(path: options.path),
+              message: 'Connection refused',
+              type: DioExceptionType.connectionError,
+            );
+          },
+        );
+        final dio = Dio()..httpClientAdapter = adapter;
+        final service = UrlService(dio: dio);
 
-      final response = await service
-          .execute(const UrlRequest(url: 'https://example.com'))
-          .value;
+        final response = await service
+            .execute(const UrlRequest(url: 'https://example.com'))
+            .value;
 
-      expect(response.statusCode, 0);
-      expect(response.body, contains('Connection refused'));
-    });
+        expect(response.statusCode, 0);
+        expect(response.body, contains('Connection refused'));
+      },
+    );
 
-    test('handles DioException without response', () async {
+    test('handles DioException without response or request path', () async {
       final adapter = _FakeHttpClientAdapter(
         onFetch: (options, _, _) async {
           throw DioException(

--- a/apps/auravibes_app/test/services/url/url_service_test.dart
+++ b/apps/auravibes_app/test/services/url/url_service_test.dart
@@ -87,6 +87,32 @@ void main() {
       expect(response.body, 'Server Error');
     });
 
+    test('reads streamed DioException response data', () async {
+      final adapter = _FakeHttpClientAdapter(
+        onFetch: (options, _, _) async {
+          throw DioException(
+            requestOptions: RequestOptions(path: options.path),
+            response: Response(
+              requestOptions: RequestOptions(),
+              statusCode: 404,
+              data: ResponseBody.fromString('Not Found', 404),
+            ),
+            type: DioExceptionType.badResponse,
+          );
+        },
+      );
+      final dio = Dio()..httpClientAdapter = adapter;
+      final service = UrlService(dio: dio);
+
+      final response = await service
+          .execute(const UrlRequest(url: 'https://example.com/missing'))
+          .value;
+
+      expect(response.statusCode, 404);
+      expect(response.body, 'Not Found');
+      expect(response.body, isNot(contains('ResponseBody')));
+    });
+
     test('truncates large DioException response data', () async {
       final largeBody = 'x' * (1024 * 1024 + 100);
       final adapter = _FakeHttpClientAdapter(

--- a/apps/auravibes_app/test/services/url/url_service_test.dart
+++ b/apps/auravibes_app/test/services/url/url_service_test.dart
@@ -113,6 +113,90 @@ void main() {
       expect(response.body, isNot(contains('ResponseBody')));
     });
 
+    test('decodes byte list DioException response data', () async {
+      final adapter = _FakeHttpClientAdapter(
+        onFetch: (options, _, _) async {
+          throw DioException(
+            requestOptions: RequestOptions(path: options.path),
+            response: Response(
+              requestOptions: RequestOptions(),
+              statusCode: 400,
+              data: 'Bad Request'.codeUnits,
+            ),
+            type: DioExceptionType.badResponse,
+          );
+        },
+      );
+      final dio = Dio()..httpClientAdapter = adapter;
+      final service = UrlService(dio: dio);
+
+      final response = await service
+          .execute(const UrlRequest(url: 'https://example.com/bad'))
+          .value;
+
+      expect(response.statusCode, 400);
+      expect(response.body, 'Bad Request');
+    });
+
+    test('truncates byte list DioException response data', () async {
+      final data = Uint8List(1024 * 1024 + 100)
+        ..fillRange(0, 1024 * 1024 + 100, 120);
+      final adapter = _FakeHttpClientAdapter(
+        onFetch: (options, _, _) async {
+          throw DioException(
+            requestOptions: RequestOptions(path: options.path),
+            response: Response(
+              requestOptions: RequestOptions(),
+              statusCode: 500,
+              data: data,
+            ),
+            type: DioExceptionType.badResponse,
+          );
+        },
+      );
+      final dio = Dio()..httpClientAdapter = adapter;
+      final service = UrlService(dio: dio);
+
+      final response = await service
+          .execute(const UrlRequest(url: 'https://example.com/large'))
+          .value;
+
+      expect(response.body, contains('[truncated]'));
+      expect(response.body.length, lessThan(data.length));
+    });
+
+    test(
+      'falls back to DioException message when error stream fails',
+      () async {
+        final adapter = _FakeHttpClientAdapter(
+          onFetch: (options, _, _) async {
+            throw DioException(
+              requestOptions: RequestOptions(path: options.path),
+              response: Response(
+                requestOptions: RequestOptions(),
+                statusCode: 502,
+                data: ResponseBody(
+                  Stream<Uint8List>.error(StateError('stream failed')),
+                  502,
+                ),
+              ),
+              message: 'Bad gateway',
+              type: DioExceptionType.badResponse,
+            );
+          },
+        );
+        final dio = Dio()..httpClientAdapter = adapter;
+        final service = UrlService(dio: dio);
+
+        final response = await service
+            .execute(const UrlRequest(url: 'https://example.com/bad-gateway'))
+            .value;
+
+        expect(response.statusCode, 502);
+        expect(response.body, 'Bad gateway');
+      },
+    );
+
     test('truncates large DioException response data', () async {
       final largeBody = 'x' * (1024 * 1024 + 100);
       final adapter = _FakeHttpClientAdapter(
@@ -184,13 +268,10 @@ void main() {
       expect(response.body, contains('Connection refused'));
     });
 
-    test('rethrows non-Dio exceptions as DioException', () async {
+    test('handles adapter errors wrapped by Dio', () async {
       final adapter = _FakeHttpClientAdapter(
         onFetch: (options, _, _) async {
-          throw DioException(
-            requestOptions: RequestOptions(path: options.path),
-            error: StateError('unexpected'),
-          );
+          throw StateError('unexpected');
         },
       );
       final dio = Dio()..httpClientAdapter = adapter;
@@ -293,6 +374,29 @@ void main() {
 
       expect(response.body, contains('[truncated]'));
       expect(response.body.length, lessThanOrEqualTo(1024 * 1024 + 50));
+    });
+
+    test('truncates response body after exact limit chunk', () async {
+      final adapter = _FakeHttpClientAdapter(
+        onFetch: (options, _, _) async {
+          return ResponseBody(
+            Stream<Uint8List>.fromIterable([
+              Uint8List(1024 * 1024)..fillRange(0, 1024 * 1024, 120),
+              Uint8List.fromList('overflow'.codeUnits),
+            ]),
+            200,
+          );
+        },
+      );
+      final dio = Dio()..httpClientAdapter = adapter;
+      final service = UrlService(dio: dio);
+
+      final response = await service
+          .execute(const UrlRequest(url: 'https://example.com'))
+          .value;
+
+      expect(response.body, contains('[truncated]'));
+      expect(response.body, isNot(contains('overflow')));
     });
 
     test('includes elapsed duration in response', () async {


### PR DESCRIPTION
## Summary
- Read streamed Dio error response bodies before storing URL tool results.
- Decode byte-list error response data instead of stringifying raw objects.
- Add regression coverage so streamed error bodies do not render as `Instance of 'ResponseBody'`.

## Tests
- `fvm flutter test test/services/url/url_service_test.dart --no-pub`
- `fvm flutter test test/services/tools/native_tools/url_tool_test.dart --no-pub`
- `fvm dart format lib/services/url/url_service.dart test/services/url/url_service_test.dart`
- Analyzer checked `lib/services/url/url_service.dart` and `test/services/url/url_service_test.dart`