### PR TITLE
fix: truncate URL tool output to 50 KiB/2000 lines for model context

### DIFF
--- a/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
+++ b/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
@@ -97,27 +97,43 @@ final class UrlTool extends NativeToolEntity<String, String> {
         .expand((e) => e.value.map((v) => '${e.key}: $v'))
         .join('\n');
 
-    final bodyResult = _truncateBody(transformed.body);
+    final formatLabel = transformed.format.label;
+    final metadataOverhead = utf8
+        .encode(
+          'Status: ${response.statusCode}\n'
+          'Elapsed: ${response.elapsed.inMilliseconds}ms\n'
+          'Content-Type: ${transformed.contentType ?? 'unknown'}\n'
+          'Format: $formatLabel\n'
+          'Headers:\n$headerLines\n\n',
+        )
+        .length;
+
+    final bodyBudget = (_maxToolOutputBytes - metadataOverhead).clamp(
+      0,
+      _maxToolOutputBytes,
+    );
+    final bodyResult = _truncateBody(transformed.body, maxBytes: bodyBudget);
     final wasTruncated = transformed.truncated || bodyResult.truncated;
-    final truncatedNote = wasTruncated ? ' (truncated)' : '';
 
     return 'Status: ${response.statusCode}\n'
         'Elapsed: ${response.elapsed.inMilliseconds}ms\n'
         'Content-Type: ${transformed.contentType ?? 'unknown'}\n'
-        'Format: ${transformed.format.label}$truncatedNote\n'
+        'Format: $formatLabel${wasTruncated ? ' (truncated)' : ''}\n'
         'Headers:\n$headerLines\n\n'
         '${bodyResult.body}';
   }
 
   static const int _maxToolOutputBytes = 50 * 1024;
-  static const _maxToolOutputLines = 2000;
+  static const int _maxToolOutputLines = 2000;
+  static const int _truncationNoteReserve = 55;
 
-  ({String body, bool truncated}) _truncateBody(String body) {
+  ({String body, bool truncated}) _truncateBody(String body, {int? maxBytes}) {
+    final effectiveMaxBytes = maxBytes ?? _maxToolOutputBytes;
     final originalByteCount = utf8.encode(body).length;
     final allLines = const LineSplitter().convert(body);
 
     if (allLines.length <= _maxToolOutputLines &&
-        originalByteCount <= _maxToolOutputBytes) {
+        originalByteCount <= effectiveMaxBytes) {
       return (body: body, truncated: false);
     }
 
@@ -125,8 +141,10 @@ final class UrlTool extends NativeToolEntity<String, String> {
         ? allLines.take(_maxToolOutputLines).join('\n')
         : body;
 
-    const noteReserve = 55;
-    const maxContentBytes = _maxToolOutputBytes - noteReserve;
+    final maxContentBytes = (effectiveMaxBytes - _truncationNoteReserve).clamp(
+      0,
+      effectiveMaxBytes,
+    );
     if (utf8.encode(result).length > maxContentBytes) {
       result = _truncateUtf8(result, maxContentBytes);
     }
@@ -143,6 +161,9 @@ final class UrlTool extends NativeToolEntity<String, String> {
 
     var end = maxBytes;
     while (end > 0 && (bytes[end - 1] & 0xC0) == 0x80) {
+      end--;
+    }
+    if (end > 0 && bytes[end - 1] >= 0xC0) {
       end--;
     }
     return utf8.decode(bytes.sublist(0, end));

--- a/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
+++ b/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
@@ -97,14 +97,55 @@ final class UrlTool extends NativeToolEntity<String, String> {
         .expand((e) => e.value.map((v) => '${e.key}: $v'))
         .join('\n');
 
-    final truncatedNote = transformed.truncated ? ' (truncated)' : '';
+    final bodyResult = _truncateBody(transformed.body);
+    final wasTruncated = transformed.truncated || bodyResult.truncated;
+    final truncatedNote = wasTruncated ? ' (truncated)' : '';
 
     return 'Status: ${response.statusCode}\n'
         'Elapsed: ${response.elapsed.inMilliseconds}ms\n'
         'Content-Type: ${transformed.contentType ?? 'unknown'}\n'
         'Format: ${transformed.format.label}$truncatedNote\n'
         'Headers:\n$headerLines\n\n'
-        '${transformed.body}';
+        '${bodyResult.body}';
+  }
+
+  static const int _maxToolOutputBytes = 50 * 1024;
+  static const _maxToolOutputLines = 2000;
+
+  ({String body, bool truncated}) _truncateBody(String body) {
+    final originalByteCount = utf8.encode(body).length;
+    final allLines = const LineSplitter().convert(body);
+
+    if (allLines.length <= _maxToolOutputLines &&
+        originalByteCount <= _maxToolOutputBytes) {
+      return (body: body, truncated: false);
+    }
+
+    var result = allLines.length > _maxToolOutputLines
+        ? allLines.take(_maxToolOutputLines).join('\n')
+        : body;
+
+    const noteReserve = 55;
+    const maxContentBytes = _maxToolOutputBytes - noteReserve;
+    if (utf8.encode(result).length > maxContentBytes) {
+      result = _truncateUtf8(result, maxContentBytes);
+    }
+
+    final omitted = originalByteCount - utf8.encode(result).length;
+    final note = '\n... [truncated: $omitted bytes omitted]';
+
+    return (body: '$result$note', truncated: true);
+  }
+
+  String _truncateUtf8(String text, int maxBytes) {
+    final bytes = utf8.encode(text);
+    if (bytes.length <= maxBytes) return text;
+
+    var end = maxBytes;
+    while (end > 0 && (bytes[end - 1] & 0xC0) == 0x80) {
+      end--;
+    }
+    return utf8.decode(bytes.sublist(0, end));
   }
 
   Future<UrlRequest> _buildRequest(String toolInput) async {

--- a/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
+++ b/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
@@ -103,7 +103,17 @@ final class UrlTool extends NativeToolEntity<String, String> {
           'Status: ${response.statusCode}\n'
           'Elapsed: ${response.elapsed.inMilliseconds}ms\n'
           'Content-Type: ${transformed.contentType ?? 'unknown'}\n'
-          'Format: $formatLabel\n'
+          'Format: $formatLabel (truncated)\n'
+          'Headers:\n$headerLines\n\n',
+        )
+        .length;
+
+    final metaLines = const LineSplitter()
+        .convert(
+          'Status:${response.statusCode}\n'
+          'Elapsed:${response.elapsed.inMilliseconds}ms\n'
+          'Content-Type:${transformed.contentType ?? 'unknown'}\n'
+          'Format:$formatLabel (truncated)\n'
           'Headers:\n$headerLines\n\n',
         )
         .length;
@@ -112,7 +122,18 @@ final class UrlTool extends NativeToolEntity<String, String> {
       0,
       _maxToolOutputBytes,
     );
-    final bodyResult = _truncateBody(transformed.body, maxBytes: bodyBudget);
+    final bodyLineBudget = (_maxToolOutputLines - metaLines).clamp(
+      0,
+      _maxToolOutputLines,
+    );
+
+    final bodyResult = bodyBudget > 0
+        ? _truncateBody(
+            transformed.body,
+            maxBytes: bodyBudget,
+            maxLines: bodyLineBudget,
+          )
+        : (body: '', truncated: transformed.body.isNotEmpty);
     final wasTruncated = transformed.truncated || bodyResult.truncated;
 
     return 'Status: ${response.statusCode}\n'
@@ -127,18 +148,39 @@ final class UrlTool extends NativeToolEntity<String, String> {
   static const int _maxToolOutputLines = 2000;
   static const int _truncationNoteReserve = 55;
 
-  ({String body, bool truncated}) _truncateBody(String body, {int? maxBytes}) {
-    final effectiveMaxBytes = maxBytes ?? _maxToolOutputBytes;
-    final originalByteCount = utf8.encode(body).length;
-    final allLines = const LineSplitter().convert(body);
+  List<String> _takeLines(String text, int limit) {
+    final lines = <String>[];
+    var start = 0;
+    for (var i = 0; i < text.length; i++) {
+      if (text[i] == '\n') {
+        lines.add(text.substring(start, i));
+        start = i + 1;
+        if (lines.length > limit) break;
+      }
+    }
+    if (start < text.length && lines.length <= limit) {
+      lines.add(text.substring(start));
+    }
+    return lines;
+  }
 
-    if (allLines.length <= _maxToolOutputLines &&
+  ({String body, bool truncated}) _truncateBody(
+    String body, {
+    int? maxBytes,
+    int? maxLines,
+  }) {
+    final effectiveMaxBytes = maxBytes ?? _maxToolOutputBytes;
+    final effectiveMaxLines = maxLines ?? _maxToolOutputLines;
+    final originalByteCount = utf8.encode(body).length;
+    final allLines = _takeLines(body, effectiveMaxLines);
+
+    if (allLines.length <= effectiveMaxLines &&
         originalByteCount <= effectiveMaxBytes) {
       return (body: body, truncated: false);
     }
 
-    var result = allLines.length > _maxToolOutputLines
-        ? allLines.take(_maxToolOutputLines).join('\n')
+    var result = allLines.length > effectiveMaxLines
+        ? allLines.sublist(0, effectiveMaxLines).join('\n')
         : body;
 
     final maxContentBytes = (effectiveMaxBytes - _truncationNoteReserve).clamp(
@@ -151,8 +193,16 @@ final class UrlTool extends NativeToolEntity<String, String> {
 
     final omitted = originalByteCount - utf8.encode(result).length;
     final note = '\n... [truncated: $omitted bytes omitted]';
+    final combined = '$result$note';
 
-    return (body: '$result$note', truncated: true);
+    if (utf8.encode(combined).length > effectiveMaxBytes) {
+      return (
+        body: _truncateUtf8(combined, effectiveMaxBytes),
+        truncated: true,
+      );
+    }
+
+    return (body: combined, truncated: true);
   }
 
   String _truncateUtf8(String text, int maxBytes) {

--- a/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
+++ b/apps/auravibes_app/lib/services/tools/native_tools/url_tool.dart
@@ -134,14 +134,33 @@ final class UrlTool extends NativeToolEntity<String, String> {
             maxLines: bodyLineBudget,
           )
         : (body: '', truncated: transformed.body.isNotEmpty);
-    final wasTruncated = transformed.truncated || bodyResult.truncated;
+    var wasTruncated = transformed.truncated || bodyResult.truncated;
 
-    return 'Status: ${response.statusCode}\n'
+    var result =
+        'Status: ${response.statusCode}\n'
         'Elapsed: ${response.elapsed.inMilliseconds}ms\n'
         'Content-Type: ${transformed.contentType ?? 'unknown'}\n'
         'Format: $formatLabel${wasTruncated ? ' (truncated)' : ''}\n'
         'Headers:\n$headerLines\n\n'
         '${bodyResult.body}';
+
+    final resultBytes = utf8.encode(result).length;
+    final resultLines = _takeLines(result, _maxToolOutputLines + 1).length;
+
+    if (resultBytes > _maxToolOutputBytes ||
+        resultLines > _maxToolOutputLines) {
+      wasTruncated = true;
+      result = _truncateTotal(
+        'Status: ${response.statusCode}\n'
+        'Elapsed: ${response.elapsed.inMilliseconds}ms\n'
+        'Content-Type: ${transformed.contentType ?? 'unknown'}\n'
+        'Format: $formatLabel (truncated)\n'
+        'Headers:\n$headerLines\n\n'
+        '${bodyResult.body}',
+      );
+    }
+
+    return result;
   }
 
   static const int _maxToolOutputBytes = 50 * 1024;
@@ -217,6 +236,24 @@ final class UrlTool extends NativeToolEntity<String, String> {
       end--;
     }
     return utf8.decode(bytes.sublist(0, end));
+  }
+
+  String _truncateTotal(String text) {
+    var output = text;
+
+    final lines = _takeLines(output, _maxToolOutputLines + 1);
+    if (lines.length > _maxToolOutputLines) {
+      output = lines.sublist(0, _maxToolOutputLines).join('\n');
+    }
+
+    final originalBytes = utf8.encode(output).length;
+    output = _truncateUtf8(
+      output,
+      _maxToolOutputBytes - _truncationNoteReserve,
+    );
+
+    final omitted = originalBytes - utf8.encode(output).length;
+    return '$output\n... [truncated: $omitted bytes omitted]';
   }
 
   Future<UrlRequest> _buildRequest(String toolInput) async {

--- a/apps/auravibes_app/test/services/tools/native_tools/url_tool_test.dart
+++ b/apps/auravibes_app/test/services/tools/native_tools/url_tool_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:auravibes_app/services/tools/native_tool_entity.dart';
 import 'package:auravibes_app/services/tools/native_tools/url_tool.dart';
 import 'package:auravibes_app/services/url/url_service.dart';
@@ -529,6 +531,84 @@ void main() {
               .value,
           throwsA(isA<FormatException>()),
         );
+      });
+    });
+
+    group('output truncation', () {
+      test('truncates large response body and preserves metadata', () async {
+        final largeContent = List.generate(
+          3000,
+          (i) => 'Line $i: ${'x' * 60}',
+        ).join('\n');
+        final dio = Dio()
+          ..httpClientAdapter = _SuccessAdapter(
+            body: largeContent,
+            statusCode: 200,
+          );
+        final tool = UrlTool(urlService: UrlService(dio: dio));
+
+        final result = await tool.runner('{"url": "https://1.1.1.1"}').value;
+
+        expect(result, contains('Status: 200'));
+        expect(result, contains('Content-Type:'));
+        expect(result, contains('Format:'));
+        expect(result, contains('Headers:'));
+        expect(result, contains('[truncated:'));
+        expect(result, contains('bytes omitted'));
+        expect(result, contains('Line 0:'));
+        expect(result, isNot(contains('Line 2999:')));
+
+        final resultBytes = utf8.encode(result).length;
+        expect(resultBytes, lessThanOrEqualTo(52000));
+      });
+
+      test('marks format as truncated', () async {
+        final largeContent = List.generate(
+          3000,
+          (i) => 'Line $i: ${'x' * 60}',
+        ).join('\n');
+        final dio = Dio()
+          ..httpClientAdapter = _SuccessAdapter(
+            body: largeContent,
+            statusCode: 200,
+          );
+        final tool = UrlTool(urlService: UrlService(dio: dio));
+
+        final result = await tool.runner('{"url": "https://1.1.1.1"}').value;
+
+        expect(result, contains('Format:'));
+        expect(result, contains('(truncated)'));
+      });
+
+      test('does not truncate small response body', () async {
+        final dio = Dio()
+          ..httpClientAdapter = _SuccessAdapter(
+            body: 'Hello world',
+            statusCode: 200,
+          );
+        final tool = UrlTool(urlService: UrlService(dio: dio));
+
+        final result = await tool.runner('{"url": "https://1.1.1.1"}').value;
+
+        expect(result, contains('Hello world'));
+        expect(result, isNot(contains('[truncated:')));
+        expect(result, isNot(contains('(truncated)')));
+      });
+
+      test('truncates response exceeding line limit', () async {
+        final manyLines = List.generate(2500, (i) => 'Line $i').join('\n');
+        final dio = Dio()
+          ..httpClientAdapter = _SuccessAdapter(
+            body: manyLines,
+            statusCode: 200,
+          );
+        final tool = UrlTool(urlService: UrlService(dio: dio));
+
+        final result = await tool.runner('{"url": "https://1.1.1.1"}').value;
+
+        expect(result, contains('[truncated:'));
+        expect(result, contains('Line 0'));
+        expect(result, isNot(contains('Line 2499')));
       });
     });
   });

--- a/apps/auravibes_app/test/services/tools/native_tools/url_tool_test.dart
+++ b/apps/auravibes_app/test/services/tools/native_tools/url_tool_test.dart
@@ -610,6 +610,30 @@ void main() {
         expect(result, contains('Line 0'));
         expect(result, isNot(contains('Line 2499')));
       });
+
+      test('truncates total output when metadata exceeds cap', () async {
+        final largeHeaders = <String, List<String>>{
+          for (var i = 0; i < 2500; i++) 'x-header-$i': [('y' * 60)],
+        };
+        final dio = Dio()
+          ..httpClientAdapter = _SuccessAdapter(
+            body: 'small body',
+            statusCode: 200,
+            extraHeaders: largeHeaders,
+          );
+        final tool = UrlTool(urlService: UrlService(dio: dio));
+
+        final result = await tool.runner('{"url": "https://1.1.1.1"}').value;
+
+        expect(result, contains('[truncated:'));
+        expect(result, contains('(truncated)'));
+
+        final resultBytes = utf8.encode(result).length;
+        expect(resultBytes, lessThanOrEqualTo(50 * 1024));
+
+        final lineCount = const LineSplitter().convert(result).length;
+        expect(lineCount, lessThanOrEqualTo(2000));
+      });
     });
   });
 }

--- a/apps/auravibes_app/test/services/tools/native_tools/url_tool_test.dart
+++ b/apps/auravibes_app/test/services/tools/native_tools/url_tool_test.dart
@@ -559,7 +559,7 @@ void main() {
         expect(result, isNot(contains('Line 2999:')));
 
         final resultBytes = utf8.encode(result).length;
-        expect(resultBytes, lessThanOrEqualTo(52000));
+        expect(resultBytes, lessThanOrEqualTo(50 * 1024));
       });
 
       test('marks format as truncated', () async {


### PR DESCRIPTION
## Summary

Adds preview truncation in `UrlTool._formatResponse` matching upstream opencode defaults (50 KiB bytes, 2000 lines). Previously the full transformed body (up to 1 MiB) was injected inline into the tool result, consuming excessive model context — for example, a Wikipedia fetch could produce ~90k tokens.

## Changes

- `url_tool.dart`: New `_truncateBody()` and `_truncateUtf8()` methods cap model-facing output; metadata headers always preserved; `Format` line shows `(truncated)` when applicable
- `url_tool_test.dart`: 4 new tests covering large body truncation, line-only limit, small body pass-through, and format marker

## Design

- Network/transform caps (1 MiB in `UrlService` and `UrlContentTransformer`) are unchanged — they protect the system. Only model-facing output is reduced.
- No disk persistence in this version — full output is not saved out-of-band (can be added later if a tool-output artifact service is introduced).