### PR TITLE
build(sonar): exclude widgetbook stories from coverage analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.inclusions=**/*.dart
 sonar.test.inclusions=**/test/**,**/integration_test/**,**/*_test.dart
 
 sonar.exclusions=**/drift_worker.js,.specify/scripts/**,**/*.g.dart,**/*.freezed.dart,**/*.mocks.dart,**/test/**,**/integration_test/**,**/*_test.dart
-sonar.coverage.exclusions=**/*.g.dart,**/*.freezed.dart,**/*.mocks.dart,**/drift_worker.js,.specify/scripts/**
+sonar.coverage.exclusions=**/*.g.dart,**/*.freezed.dart,**/*.mocks.dart,**/drift_worker.js,.specify/scripts/**,widgetbook/lib/**/*_stories.dart
 sonar.cpd.exclusions=**/*.g.dart,**/*.freezed.dart,**/*.mocks.dart,**/drift_worker.js
 
 sonar.dart.lcov.reportPaths=**/coverage/lcov.info


### PR DESCRIPTION
## Summary

- Adds `widgetbook/lib/**/*_stories.dart` to `sonar.coverage.exclusions`
- Widgetbook story files are visual previews, not testable logic — they should not count toward coverage metrics