### PR TITLE
chore: disable CodeRabbit auto-review on PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -69,18 +69,7 @@ reviews:
         - No test-of-tests or trivial assertions
 
   auto_review:
-    enabled: true
-    drafts: false
-    auto_incremental_review: true
-    auto_pause_after_reviewed_commits: 0
-    ignore_title_keywords:
-      - "WIP"
-      - "wip"
-    base_branches:
-      - "main"
-      - "develop"
-      - "feat/*"
-      - "setup/*"
+    enabled: false
 
   finishing_touches:
     docstrings:


### PR DESCRIPTION
## Summary

- Disable `auto_review` in `.coderabbit.yaml` by setting `enabled: false`
- Removes auto-review triggers on push/draft/base-branch matching
- CodeRabbit can still be invoked manually via `@coderabbitai review`

## Why

Reduce noise from automated reviews. Manual invocation gives more control over when reviews run.