### PR TITLE
feat: add worktree database prefix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,83 +1,33 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "prod Debug",
-            "request": "launch",
-            "type": "dart",
-            "flutterMode": "debug",
-            "cwd": "apps/auravibes_app",
-            "args": [
-                "--flavor",
-                "prod"
-            ],
-            "program": "lib/main.dart"
-        },
-        {
-            "name": "prod Profile",
-            "request": "launch",
-            "type": "dart",
-            "flutterMode": "profile",
-            "cwd": "apps/auravibes_app",
-            "args": [
-                "--flavor",
-                "prod"
-            ],
-            "program": "lib/main.dart"
-        },
-        {
-            "name": "prod Release",
-            "request": "launch",
-            "type": "dart",
-            "flutterMode": "release",
-            "cwd": "apps/auravibes_app",
-            "args": [
-                "--flavor",
-                "prod"
-            ],
-            "program": "lib/main.dart"
-        },
-        {
-            "name": "dev Debug",
-            "request": "launch",
-            "type": "dart",
-            "flutterMode": "debug",
-            "cwd": "apps/auravibes_app",
-            "args": [
-                "--flavor",
-                "dev"
-            ],
-            "program": "lib/main.dart"
-        },
-        {
-            "name": "dev Profile",
-            "request": "launch",
-            "type": "dart",
-            "flutterMode": "profile",
-            "cwd": "apps/auravibes_app",
-            "args": [
-                "--flavor",
-                "dev"
-            ],
-            "program": "lib/main.dart"
-        },
-        {
-            "name": "dev Release",
-            "request": "launch",
-            "type": "dart",
-            "flutterMode": "release",
-            "cwd": "apps/auravibes_app",
-            "args": [
-                "--flavor",
-                "dev"
-            ],
-            "program": "lib/main.dart"
-        },
-        {
-            "name": "Widgetbook",
-            "cwd": "widgetbook",
-            "request": "launch",
-            "type": "dart"
-        },
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "dev Debug",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "debug",
+      "cwd": "apps/auravibes_app",
+      "toolArgs": ["--flavor", "dev"],
+      "program": "lib/main.dart"
+    },
+    {
+      "name": "dev Debug (DB prefix)",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "debug",
+      "cwd": "apps/auravibes_app",
+      "toolArgs": [
+        "--flavor",
+        "dev",
+        "--dart-define=DB_PREFIX=${workspaceFolderBasename}_"
+      ],
+      "program": "lib/main.dart"
+    },
+    {
+      "name": "Widgetbook",
+      "cwd": "widgetbook",
+      "request": "launch",
+      "type": "dart"
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <img src="assets/screenshots/settings.png" width="250" alt="Settings Screen">
 </div>
 
-*TODO: Add actual screenshots showing key app features*
+_TODO: Add actual screenshots showing key app features_
 
 ## ✨ Features
 
@@ -31,7 +31,7 @@
 - 🌐 **Multi-Language**: Support for English and Spanish with easy localization
 - 🔒 **Secure Storage**: Secure local storage for API keys and sensitive data
 
-*TODO: Verify feature list is current and accurate*
+_TODO: Verify feature list is current and accurate_
 
 ## 🚀 Getting Started
 
@@ -46,8 +46,8 @@ Before you begin, ensure you have the following installed:
   - Install [FVM](https://fvm.app) first: `dart pub global activate fvm`
 
 - **Dart SDK**: 3.11.1 or higher (included with Flutter)
-  
 - **FVM (Flutter Version Management)**: 4.0.5 or higher
+
   ```bash
   dart pub global activate fvm
   ```
@@ -56,36 +56,41 @@ Before you begin, ensure you have the following installed:
   ```bash
   dart pub global activate melos
   ```
-<details>
+  <details>
 
 <summary>Platform-Specific Requirements</summary>
 
 **Android Development**
+
 - Android Studio (latest version) with Flutter and Dart plugins
 - Android SDK API level 21 or higher
 - Android SDK Build-Tools
 
 **iOS Development** (macOS only)
+
 - Xcode 14.0 or higher
 - CocoaPods: `sudo gem install cocoapods`
 - iOS Simulator or physical iOS device
 
 **macOS Development**
+
 - Xcode 14.0 or higher
 - CocoaPods
 
 **Linux Development**
+
 - GTK 3.0 development libraries
 - See [Linux setup guide](https://flutter.dev/docs/desktop#additional-linux-requirements)
 
 **Windows Development**
+
 - Visual Studio 2022 with C++ desktop development
 - See [Windows setup guide](https://flutter.dev/docs/desktop#additional-windows-requirements)
 
 **Web Development**
+
 - Chrome browser (latest version)
 </details>
-
 
 ### Installation
 
@@ -133,12 +138,10 @@ The app supports two flavors: **dev** (development) and **prod** (production).
 
 The project includes pre-configured launch configurations in `.vscode/launch.json`:
 
-- **prod Debug**: Production flavor, debug mode
-- **prod Profile**: Production flavor, profile mode  
-- **prod Release**: Production flavor, release mode
 - **dev Debug**: Development flavor, debug mode
-- **dev Profile**: Development flavor, profile mode
-- **dev Release**: Development flavor, release mode
+- **dev Debug (DB prefix)**: Development flavor, debug mode with a
+  workspace-folder database prefix for isolated worktrees
+- **Widgetbook**: UI component catalog, debug mode
 
 #### Using Command Line
 
@@ -184,8 +187,6 @@ fvm flutter run -d linux --flavor prod
 - **Networking**: [Dio](https://pub.dev/packages/dio) for HTTP requests
 - **Localization**: [Easy Localization](https://pub.dev/packages/easy_localization)
 - **Code Generation**: [Build Runner](https://pub.dev/packages/build_runner), [Freezed](https://pub.dev/packages/freezed)
-
-
 
 ---
 

--- a/apps/auravibes_app/lib/data/database/drift/app_database.dart
+++ b/apps/auravibes_app/lib/data/database/drift/app_database.dart
@@ -68,8 +68,8 @@ class AppDatabase extends _$AppDatabase {
   ///
   /// If [connection] is provided, uses that connection.
   /// Otherwise, creates a default SQLite database connection.
-  AppDatabase({QueryExecutor? connection})
-    : super(connection ?? _openConnection());
+  AppDatabase({QueryExecutor? connection, String? dbPrefix})
+    : super(connection ?? _openConnection(dbPrefix: dbPrefix));
 
   /// Database schema version.
   @override
@@ -94,16 +94,14 @@ class AppDatabase extends _$AppDatabase {
   ///
   /// This method sets up a cross-platform SQLite database connection
   /// with proper configuration for mobile and desktop platforms.
-  static QueryExecutor _openConnection() {
+  static QueryExecutor _openConnection({String? dbPrefix}) {
     return driftDatabase(
-      name: 'auravibes_app',
+      name: '${dbPrefix ?? ''}auravibes_app',
       web: .new(
         sqlite3Wasm: Uri.parse('sqlite3.wasm'),
         driftWorker: Uri.parse('drift_worker.dart.js'),
       ),
-      native: const DriftNativeOptions(
-        shareAcrossIsolates: true,
-      ),
+      native: const DriftNativeOptions(shareAcrossIsolates: true),
     );
   }
 

--- a/apps/auravibes_app/lib/data/database/drift/app_database.dart
+++ b/apps/auravibes_app/lib/data/database/drift/app_database.dart
@@ -68,6 +68,9 @@ class AppDatabase extends _$AppDatabase {
   ///
   /// If [connection] is provided, uses that connection.
   /// Otherwise, creates a default SQLite database connection.
+  /// When [connection] is null, [dbPrefix] is used to prefix the underlying
+  /// database name for the default connection. If [connection] is provided,
+  /// [dbPrefix] has no effect.
   AppDatabase({QueryExecutor? connection, String? dbPrefix})
     : super(connection ?? _openConnection(dbPrefix: dbPrefix));
 

--- a/apps/auravibes_app/lib/providers/app_providers.dart
+++ b/apps/auravibes_app/lib/providers/app_providers.dart
@@ -10,5 +10,8 @@ Future<SharedPreferences> sharedPreferences(Ref ref) =>
 
 @Riverpod(keepAlive: true)
 AppDatabase appDatabase(Ref ref) {
-  return AppDatabase();
+  const dbPrefix = String.fromEnvironment('DB_PREFIX');
+  return AppDatabase(
+    dbPrefix: dbPrefix.isNotEmpty ? dbPrefix : null,
+  );
 }

--- a/apps/auravibes_app/lib/providers/app_providers.g.dart
+++ b/apps/auravibes_app/lib/providers/app_providers.g.dart
@@ -89,4 +89,4 @@ final class AppDatabaseProvider
   }
 }
 
-String _$appDatabaseHash() => r'8c69eb46d45206533c176c88a926608e79ca927d';
+String _$appDatabaseHash() => r'3131cb79975c9b14bd7ded105339594011847b06';


### PR DESCRIPTION
## Summary
- Add optional DB filename prefix support through `DB_PREFIX` dart define.
- Simplify VS Code launch configs to dev debug, prefixed dev debug, and Widgetbook.
- Use `${workspaceFolderBasename}_` for prefixed worktree launches without generated files.

## Verification
- `jq empty .vscode/launch.json`
- `fvm flutter test test/providers/app_providers_test.dart --no-pub`