### PR TITLE
fix: stream workspace model selections

### DIFF
--- a/apps/auravibes_app/lib/data/database/drift/daos/workspace_model_selections_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/workspace_model_selections_dao.dart
@@ -45,6 +45,20 @@ class WorkspaceModelSelectionsDao extends DatabaseAccessor<AppDatabase>
         .get();
   }
 
+  Stream<List<WorkspaceModelSelectionWithConnection>>
+  watchAllWorkspaceModelSelectionsByWorkspace({
+    required List<String> workspaceIds,
+  }) {
+    final query = _queryJoins()
+      ..where(modelConnections.workspaceId.isIn(workspaceIds));
+
+    return query
+        .map(
+          _mapJoin,
+        )
+        .watch();
+  }
+
   Future<WorkspaceModelSelectionWithConnection?> getWorkspaceModelSelectionById(
     String id,
   ) {

--- a/apps/auravibes_app/lib/data/database/drift/daos/workspace_model_selections_dao.dart
+++ b/apps/auravibes_app/lib/data/database/drift/daos/workspace_model_selections_dao.dart
@@ -35,10 +35,7 @@ class WorkspaceModelSelectionsDao extends DatabaseAccessor<AppDatabase>
   getAllWorkspaceModelSelectionsByWorkspace({
     required List<String> workspaceIds,
   }) {
-    final query = _queryJoins()
-      ..where(modelConnections.workspaceId.isIn(workspaceIds));
-
-    return query
+    return _queryWorkspaceModelSelectionsByWorkspace(workspaceIds: workspaceIds)
         .map(
           _mapJoin,
         )
@@ -49,10 +46,7 @@ class WorkspaceModelSelectionsDao extends DatabaseAccessor<AppDatabase>
   watchAllWorkspaceModelSelectionsByWorkspace({
     required List<String> workspaceIds,
   }) {
-    final query = _queryJoins()
-      ..where(modelConnections.workspaceId.isIn(workspaceIds));
-
-    return query
+    return _queryWorkspaceModelSelectionsByWorkspace(workspaceIds: workspaceIds)
         .map(
           _mapJoin,
         )
@@ -85,6 +79,14 @@ class WorkspaceModelSelectionsDao extends DatabaseAccessor<AppDatabase>
         apiModelProviders.id.equalsExp(modelConnections.modelId),
       ),
     ]);
+  }
+
+  JoinedSelectStatement<HasResultSet, dynamic>
+  _queryWorkspaceModelSelectionsByWorkspace({
+    required List<String> workspaceIds,
+  }) {
+    return _queryJoins()
+      ..where(modelConnections.workspaceId.isIn(workspaceIds));
   }
 
   WorkspaceModelSelectionWithConnection _mapJoin(TypedResult row) =>

--- a/apps/auravibes_app/lib/data/repositories/workspace_model_selection_repository_impl.dart
+++ b/apps/auravibes_app/lib/data/repositories/workspace_model_selection_repository_impl.dart
@@ -41,6 +41,21 @@ class WorkspaceModelSelectionRepositoryImpl
   }
 
   @override
+  Stream<List<WorkspaceModelSelectionWithConnectionEntity>>
+  watchWorkspaceModelSelections(
+    WorkspaceModelSelectionFilter filter,
+  ) {
+    return _database.workspaceModelSelectionsDao
+        .watchAllWorkspaceModelSelectionsByWorkspace(
+          workspaceIds: filter.workspaces,
+        )
+        .map(
+          (tableResults) =>
+              tableResults.map(_withProviderTableToEntity).toList(),
+        );
+  }
+
+  @override
   Future<WorkspaceModelSelectionWithConnectionEntity?>
   getWorkspaceModelSelectionById(
     String id,

--- a/apps/auravibes_app/lib/domain/repositories/workspace_model_selection_repository.dart
+++ b/apps/auravibes_app/lib/domain/repositories/workspace_model_selection_repository.dart
@@ -17,6 +17,11 @@ abstract class WorkspaceModelSelectionRepository {
     WorkspaceModelSelectionFilter filter,
   );
 
+  Stream<List<WorkspaceModelSelectionWithConnectionEntity>>
+  watchWorkspaceModelSelections(
+    WorkspaceModelSelectionFilter filter,
+  );
+
   Future<WorkspaceModelSelectionWithConnectionEntity?>
   getWorkspaceModelSelectionById(
     String id,

--- a/apps/auravibes_app/lib/features/models/providers/workspace_model_selections_providers.dart
+++ b/apps/auravibes_app/lib/features/models/providers/workspace_model_selections_providers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:auravibes_app/domain/entities/workspace_model_selection_entities.dart';
 import 'package:auravibes_app/features/models/providers/model_connection_repositories_providers.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -24,15 +26,30 @@ listWorkspaceModelSelections(
 @riverpod
 Stream<Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>>
 listModelsGroupedByProvider(Ref ref, {required String workspaceId}) {
-  final workspaceModelSelectionRepository = ref.watch(
-    workspaceModelSelectionRepositoryProvider,
+  final controller =
+      StreamController<
+        Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>
+      >();
+  final subscription = ref.listen(
+    listWorkspaceModelSelectionsProvider(workspaceId: workspaceId),
+    (_, next) {
+      switch (next) {
+        case AsyncData(:final value):
+          controller.add(_groupModelsByProvider(value));
+        case AsyncError(:final error, :final stackTrace):
+          controller.addError(error, stackTrace);
+        case AsyncLoading():
+      }
+    },
+    fireImmediately: true,
   );
 
-  return workspaceModelSelectionRepository
-      .watchWorkspaceModelSelections(
-        WorkspaceModelSelectionFilter(workspaces: [workspaceId]),
-      )
-      .map(_groupModelsByProvider);
+  ref.onDispose(() {
+    subscription.close();
+    unawaited(controller.close());
+  });
+
+  return controller.stream;
 }
 
 Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>

--- a/apps/auravibes_app/lib/features/models/providers/workspace_model_selections_providers.dart
+++ b/apps/auravibes_app/lib/features/models/providers/workspace_model_selections_providers.dart
@@ -5,16 +5,16 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'workspace_model_selections_providers.g.dart';
 
 @riverpod
-Future<List<WorkspaceModelSelectionWithConnectionEntity>>
+Stream<List<WorkspaceModelSelectionWithConnectionEntity>>
 listWorkspaceModelSelections(
   Ref ref, {
   required String workspaceId,
-}) async {
+}) {
   final workspaceModelSelectionRepository = ref.watch(
     workspaceModelSelectionRepositoryProvider,
   );
 
-  return workspaceModelSelectionRepository.getWorkspaceModelSelections(
+  return workspaceModelSelectionRepository.watchWorkspaceModelSelections(
     WorkspaceModelSelectionFilter(workspaces: [workspaceId]),
   );
 }
@@ -22,13 +22,23 @@ listWorkspaceModelSelections(
 /// Groups models by provider name for two-step model selection.
 /// Returns a map where keys are provider names and values are lists of models.
 @riverpod
-Future<Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>>
-listModelsGroupedByProvider(Ref ref, {required String workspaceId}) async {
-  // Await the underlying FutureProvider so loading/error states propagate automatically.
-  final models = await ref.watch(
-    listWorkspaceModelSelectionsProvider(workspaceId: workspaceId).future,
+Stream<Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>>
+listModelsGroupedByProvider(Ref ref, {required String workspaceId}) {
+  final workspaceModelSelectionRepository = ref.watch(
+    workspaceModelSelectionRepositoryProvider,
   );
 
+  return workspaceModelSelectionRepository
+      .watchWorkspaceModelSelections(
+        WorkspaceModelSelectionFilter(workspaces: [workspaceId]),
+      )
+      .map(_groupModelsByProvider);
+}
+
+Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>
+_groupModelsByProvider(
+  List<WorkspaceModelSelectionWithConnectionEntity> models,
+) {
   final grouped = <String, List<WorkspaceModelSelectionWithConnectionEntity>>{};
 
   for (final model in models) {

--- a/apps/auravibes_app/lib/features/models/providers/workspace_model_selections_providers.g.dart
+++ b/apps/auravibes_app/lib/features/models/providers/workspace_model_selections_providers.g.dart
@@ -18,11 +18,11 @@ final class ListWorkspaceModelSelectionsProvider
         $FunctionalProvider<
           AsyncValue<List<WorkspaceModelSelectionWithConnectionEntity>>,
           List<WorkspaceModelSelectionWithConnectionEntity>,
-          FutureOr<List<WorkspaceModelSelectionWithConnectionEntity>>
+          Stream<List<WorkspaceModelSelectionWithConnectionEntity>>
         >
     with
         $FutureModifier<List<WorkspaceModelSelectionWithConnectionEntity>>,
-        $FutureProvider<List<WorkspaceModelSelectionWithConnectionEntity>> {
+        $StreamProvider<List<WorkspaceModelSelectionWithConnectionEntity>> {
   ListWorkspaceModelSelectionsProvider._({
     required ListWorkspaceModelSelectionsFamily super.from,
     required String super.argument,
@@ -46,11 +46,11 @@ final class ListWorkspaceModelSelectionsProvider
 
   @$internal
   @override
-  $FutureProviderElement<List<WorkspaceModelSelectionWithConnectionEntity>>
-  $createElement($ProviderPointer pointer) => $FutureProviderElement(pointer);
+  $StreamProviderElement<List<WorkspaceModelSelectionWithConnectionEntity>>
+  $createElement($ProviderPointer pointer) => $StreamProviderElement(pointer);
 
   @override
-  FutureOr<List<WorkspaceModelSelectionWithConnectionEntity>> create(Ref ref) {
+  Stream<List<WorkspaceModelSelectionWithConnectionEntity>> create(Ref ref) {
     final argument = this.argument as String;
     return listWorkspaceModelSelections(ref, workspaceId: argument);
   }
@@ -68,12 +68,12 @@ final class ListWorkspaceModelSelectionsProvider
 }
 
 String _$listWorkspaceModelSelectionsHash() =>
-    r'5b21df64ae426016853c1310564c0c7484076b2a';
+    r'740a84131efe0dc2bdac9b61bb74cfb93138b680';
 
 final class ListWorkspaceModelSelectionsFamily extends $Family
     with
         $FunctionalFamilyOverride<
-          FutureOr<List<WorkspaceModelSelectionWithConnectionEntity>>,
+          Stream<List<WorkspaceModelSelectionWithConnectionEntity>>,
           String
         > {
   ListWorkspaceModelSelectionsFamily._()
@@ -109,15 +109,13 @@ final class ListModelsGroupedByProviderProvider
             Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>
           >,
           Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>,
-          FutureOr<
-            Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>
-          >
+          Stream<Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>>
         >
     with
         $FutureModifier<
           Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>
         >,
-        $FutureProvider<
+        $StreamProvider<
           Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>
         > {
   /// Groups models by provider name for two-step model selection.
@@ -145,14 +143,15 @@ final class ListModelsGroupedByProviderProvider
 
   @$internal
   @override
-  $FutureProviderElement<
+  $StreamProviderElement<
     Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>
   >
-  $createElement($ProviderPointer pointer) => $FutureProviderElement(pointer);
+  $createElement($ProviderPointer pointer) => $StreamProviderElement(pointer);
 
   @override
-  FutureOr<Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>>
-  create(Ref ref) {
+  Stream<Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>> create(
+    Ref ref,
+  ) {
     final argument = this.argument as String;
     return listModelsGroupedByProvider(ref, workspaceId: argument);
   }
@@ -170,7 +169,7 @@ final class ListModelsGroupedByProviderProvider
 }
 
 String _$listModelsGroupedByProviderHash() =>
-    r'bf84c1bc14d9b96f4fc7874e12097a4a4f391180';
+    r'c1ddc90a50b0b6adc8c3fc7e9b1005f6fc4a87f3';
 
 /// Groups models by provider name for two-step model selection.
 /// Returns a map where keys are provider names and values are lists of models.
@@ -178,7 +177,7 @@ String _$listModelsGroupedByProviderHash() =>
 final class ListModelsGroupedByProviderFamily extends $Family
     with
         $FunctionalFamilyOverride<
-          FutureOr<
+          Stream<
             Map<String, List<WorkspaceModelSelectionWithConnectionEntity>>
           >,
           String

--- a/apps/auravibes_app/lib/features/models/providers/workspace_model_selections_providers.g.dart
+++ b/apps/auravibes_app/lib/features/models/providers/workspace_model_selections_providers.g.dart
@@ -169,7 +169,7 @@ final class ListModelsGroupedByProviderProvider
 }
 
 String _$listModelsGroupedByProviderHash() =>
-    r'c1ddc90a50b0b6adc8c3fc7e9b1005f6fc4a87f3';
+    r'da344a279e1c6d9116b82f612fa60bcc6cdb2a0d';
 
 /// Groups models by provider name for two-step model selection.
 /// Returns a map where keys are provider names and values are lists of models.

--- a/apps/auravibes_app/test/data/database/drift/daos/workspace_model_selections_dao_test.dart
+++ b/apps/auravibes_app/test/data/database/drift/daos/workspace_model_selections_dao_test.dart
@@ -60,6 +60,46 @@ void main() {
       expect(results.length, equals(1));
     });
 
+    test('watchAllWorkspaceModelSelectionsByWorkspace emits inserts', () async {
+      await database.apiModelProvidersDao.upsertProvider(
+        ApiModelProvidersCompanion.insert(id: 'openai', name: 'OpenAI'),
+      );
+      final conn = await database.modelConnectionsDao.insertModelConnection(
+        ModelConnectionsCompanion.insert(
+          name: 'Conn',
+          modelId: 'openai',
+          keyValue: 'key',
+          workspaceId: workspaceId,
+        ),
+      );
+
+      final initial = await database.workspaceModelSelectionsDao
+          .watchAllWorkspaceModelSelectionsByWorkspace(
+            workspaceIds: [workspaceId],
+          )
+          .first;
+      expect(initial, isEmpty);
+
+      final expectation = expectLater(
+        database.workspaceModelSelectionsDao
+            .watchAllWorkspaceModelSelectionsByWorkspace(
+              workspaceIds: [workspaceId],
+            ),
+        emitsThrough(hasLength(1)),
+      );
+
+      await database.workspaceModelSelectionsDao.insertWorkspaceModelSelections(
+        [
+          WorkspaceModelSelectionsCompanion.insert(
+            modelId: 'openai',
+            modelConnectionId: conn.id,
+          ),
+        ],
+      );
+
+      await expectation;
+    });
+
     test(
       'getAllWorkspaceModelSelectionsByWorkspace returns empty for no match',
       () async {

--- a/apps/auravibes_app/test/data/database/drift/daos/workspace_model_selections_dao_test.dart
+++ b/apps/auravibes_app/test/data/database/drift/daos/workspace_model_selections_dao_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:auravibes_app/data/database/drift/app_database.dart';
 import 'package:auravibes_app/domain/enums/workspace_type.dart';
 import 'package:drift/drift.dart' hide isNotNull, isNull;
@@ -73,20 +75,15 @@ void main() {
         ),
       );
 
-      final initial = await database.workspaceModelSelectionsDao
+      final stream = database.workspaceModelSelectionsDao
           .watchAllWorkspaceModelSelectionsByWorkspace(
             workspaceIds: [workspaceId],
-          )
-          .first;
-      expect(initial, isEmpty);
+          );
+      final iterator = StreamIterator(stream);
+      addTearDown(iterator.cancel);
 
-      final expectation = expectLater(
-        database.workspaceModelSelectionsDao
-            .watchAllWorkspaceModelSelectionsByWorkspace(
-              workspaceIds: [workspaceId],
-            ),
-        emitsThrough(hasLength(1)),
-      );
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, isEmpty);
 
       await database.workspaceModelSelectionsDao.insertWorkspaceModelSelections(
         [
@@ -97,7 +94,8 @@ void main() {
         ],
       );
 
-      await expectation;
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, hasLength(1));
     });
 
     test(

--- a/apps/auravibes_app/test/data/repositories/model_connection_repository_impl_test.mocks.dart
+++ b/apps/auravibes_app/test/data/repositories/model_connection_repository_impl_test.mocks.dart
@@ -2054,6 +2054,28 @@ class MockWorkspaceModelSelectionsDao extends _i1.Mock
           as _i6.Future<List<_i8.WorkspaceModelSelectionWithConnection>>);
 
   @override
+  _i6.Stream<List<_i8.WorkspaceModelSelectionWithConnection>>
+  watchAllWorkspaceModelSelectionsByWorkspace({
+    required List<String>? workspaceIds,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #watchAllWorkspaceModelSelectionsByWorkspace,
+              [],
+              {#workspaceIds: workspaceIds},
+            ),
+            returnValue:
+                _i6.Stream<
+                  List<_i8.WorkspaceModelSelectionWithConnection>
+                >.empty(),
+            returnValueForMissingStub:
+                _i6.Stream<
+                  List<_i8.WorkspaceModelSelectionWithConnection>
+                >.empty(),
+          )
+          as _i6.Stream<List<_i8.WorkspaceModelSelectionWithConnection>>);
+
+  @override
   _i6.Future<_i8.WorkspaceModelSelectionWithConnection?>
   getWorkspaceModelSelectionById(String? id) =>
       (super.noSuchMethod(

--- a/apps/auravibes_app/test/data/repositories/workspace_model_selection_repository_impl_test.mocks.dart
+++ b/apps/auravibes_app/test/data/repositories/workspace_model_selection_repository_impl_test.mocks.dart
@@ -391,6 +391,28 @@ class MockWorkspaceModelSelectionsDao extends _i1.Mock
           as _i6.Future<List<_i5.WorkspaceModelSelectionWithConnection>>);
 
   @override
+  _i6.Stream<List<_i5.WorkspaceModelSelectionWithConnection>>
+  watchAllWorkspaceModelSelectionsByWorkspace({
+    required List<String>? workspaceIds,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #watchAllWorkspaceModelSelectionsByWorkspace,
+              [],
+              {#workspaceIds: workspaceIds},
+            ),
+            returnValue:
+                _i6.Stream<
+                  List<_i5.WorkspaceModelSelectionWithConnection>
+                >.empty(),
+            returnValueForMissingStub:
+                _i6.Stream<
+                  List<_i5.WorkspaceModelSelectionWithConnection>
+                >.empty(),
+          )
+          as _i6.Stream<List<_i5.WorkspaceModelSelectionWithConnection>>);
+
+  @override
   _i6.Future<_i5.WorkspaceModelSelectionWithConnection?>
   getWorkspaceModelSelectionById(String? id) =>
       (super.noSuchMethod(

--- a/apps/auravibes_app/test/domain/repositories/workspace_model_selection_repository_test.dart
+++ b/apps/auravibes_app/test/domain/repositories/workspace_model_selection_repository_test.dart
@@ -23,6 +23,14 @@ class _StubRepository implements WorkspaceModelSelectionRepository {
   }
 
   @override
+  Stream<List<WorkspaceModelSelectionWithConnectionEntity>>
+  watchWorkspaceModelSelections(
+    WorkspaceModelSelectionFilter filter,
+  ) {
+    return Stream.value(selectionResults);
+  }
+
+  @override
   Future<WorkspaceModelSelectionWithConnectionEntity?>
   getWorkspaceModelSelectionById(
     String id,
@@ -53,6 +61,18 @@ void main() {
       final result = await repo.getWorkspaceModelSelections(
         const WorkspaceModelSelectionFilter(),
       );
+
+      expect(result, isEmpty);
+    });
+
+    test('watchWorkspaceModelSelections streams empty by default', () async {
+      final repo = _StubRepository();
+
+      final result = await repo
+          .watchWorkspaceModelSelections(
+            const WorkspaceModelSelectionFilter(),
+          )
+          .first;
 
       expect(result, isEmpty);
     });

--- a/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
+++ b/apps/auravibes_app/test/features/chats/providers/chat_messages_provider_test.dart
@@ -441,6 +441,14 @@ class _FakeWorkspaceModelSelectionRepository
   ) {
     throw UnimplementedError();
   }
+
+  @override
+  Stream<List<WorkspaceModelSelectionWithConnectionEntity>>
+  watchWorkspaceModelSelections(
+    WorkspaceModelSelectionFilter filter,
+  ) {
+    throw UnimplementedError();
+  }
 }
 
 class _FakeApiModelRepository implements ApiModelRepository {

--- a/apps/auravibes_app/test/features/chats/screens/list_chats_screen_test.dart
+++ b/apps/auravibes_app/test/features/chats/screens/list_chats_screen_test.dart
@@ -34,7 +34,7 @@ void main() {
                     Stream.value([]),
               ),
               listWorkspaceModelSelectionsProvider.overrideWith(
-                (ref, workspaceId) => [],
+                (ref, workspaceId) => Stream.value([]),
               ),
               streamingTitleProvider.overrideWith((ref, id) => null),
             ],

--- a/apps/auravibes_app/test/features/chats/screens/new_chat_screen_test.dart
+++ b/apps/auravibes_app/test/features/chats/screens/new_chat_screen_test.dart
@@ -78,7 +78,7 @@ void main() {
                 const NewChatState(),
               ),
               listModelsGroupedByProviderProvider.overrideWith(
-                (ref, workspaceId) => {},
+                (ref, workspaceId) => Stream.value({}),
               ),
             ],
             child: Theme(

--- a/apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.mocks.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/continue_agent_usecase_test.mocks.dart
@@ -378,6 +378,20 @@ class MockWorkspaceModelSelectionRepository extends _i1.Mock
           >);
 
   @override
+  _i8.Stream<List<_i10.WorkspaceModelSelectionWithConnectionEntity>>
+  watchWorkspaceModelSelections(_i10.WorkspaceModelSelectionFilter? filter) =>
+      (super.noSuchMethod(
+            Invocation.method(#watchWorkspaceModelSelections, [filter]),
+            returnValue:
+                _i8.Stream<
+                  List<_i10.WorkspaceModelSelectionWithConnectionEntity>
+                >.empty(),
+          )
+          as _i8.Stream<
+            List<_i10.WorkspaceModelSelectionWithConnectionEntity>
+          >);
+
+  @override
   _i8.Future<_i10.WorkspaceModelSelectionWithConnectionEntity?>
   getWorkspaceModelSelectionById(String? id) =>
       (super.noSuchMethod(

--- a/apps/auravibes_app/test/features/chats/usecases/send_new_message_usecase_test.mocks.dart
+++ b/apps/auravibes_app/test/features/chats/usecases/send_new_message_usecase_test.mocks.dart
@@ -221,6 +221,20 @@ class MockWorkspaceModelSelectionRepository extends _i1.Mock
           >);
 
   @override
+  _i11.Stream<List<_i13.WorkspaceModelSelectionWithConnectionEntity>>
+  watchWorkspaceModelSelections(_i13.WorkspaceModelSelectionFilter? filter) =>
+      (super.noSuchMethod(
+            Invocation.method(#watchWorkspaceModelSelections, [filter]),
+            returnValue:
+                _i11.Stream<
+                  List<_i13.WorkspaceModelSelectionWithConnectionEntity>
+                >.empty(),
+          )
+          as _i11.Stream<
+            List<_i13.WorkspaceModelSelectionWithConnectionEntity>
+          >);
+
+  @override
   _i11.Future<_i13.WorkspaceModelSelectionWithConnectionEntity?>
   getWorkspaceModelSelectionById(String? id) =>
       (super.noSuchMethod(

--- a/apps/auravibes_app/test/features/chats/widgets/chat_list_widget_test.dart
+++ b/apps/auravibes_app/test/features/chats/widgets/chat_list_widget_test.dart
@@ -85,7 +85,7 @@ void main() {
           overrides: [
             conversationRepositoryProvider.overrideWithValue(repo),
             listWorkspaceModelSelectionsProvider.overrideWith(
-              (ref, workspaceId) async => [],
+              (ref, workspaceId) => Stream.value([]),
             ),
           ],
         ),
@@ -109,7 +109,7 @@ void main() {
           overrides: [
             conversationRepositoryProvider.overrideWithValue(repo),
             listWorkspaceModelSelectionsProvider.overrideWith(
-              (ref, workspaceId) async => [],
+              (ref, workspaceId) => Stream.value([]),
             ),
           ],
         ),
@@ -135,7 +135,7 @@ void main() {
             conversationRepositoryProvider.overrideWithValue(repo),
             streamingTitleProvider.overrideWith((ref, id) => null),
             listWorkspaceModelSelectionsProvider.overrideWith(
-              (ref, workspaceId) async => [],
+              (ref, workspaceId) => Stream.value([]),
             ),
           ],
         ),
@@ -161,7 +161,7 @@ void main() {
             conversationRepositoryProvider.overrideWithValue(repo),
             streamingTitleProvider.overrideWith((ref, id) => null),
             listWorkspaceModelSelectionsProvider.overrideWith(
-              (ref, workspaceId) async => [],
+              (ref, workspaceId) => Stream.value([]),
             ),
           ],
         ),
@@ -186,7 +186,7 @@ void main() {
             conversationRepositoryProvider.overrideWithValue(repo),
             streamingTitleProvider.overrideWith((ref, id) => null),
             listWorkspaceModelSelectionsProvider.overrideWith(
-              (ref, workspaceId) async => [],
+              (ref, workspaceId) => Stream.value([]),
             ),
           ],
         ),
@@ -210,7 +210,7 @@ void main() {
           overrides: [
             conversationRepositoryProvider.overrideWithValue(repo),
             listWorkspaceModelSelectionsProvider.overrideWith(
-              (ref, workspaceId) async => [],
+              (ref, workspaceId) => Stream.value([]),
             ),
           ],
         ),
@@ -238,7 +238,7 @@ void main() {
             conversationRepositoryProvider.overrideWithValue(repo),
             streamingTitleProvider.overrideWith((ref, id) => null),
             listWorkspaceModelSelectionsProvider.overrideWith(
-              (ref, workspaceId) async => [],
+              (ref, workspaceId) => Stream.value([]),
             ),
           ],
         ),
@@ -265,7 +265,7 @@ void main() {
               (ref, id) => 'Streamed Title',
             ),
             listWorkspaceModelSelectionsProvider.overrideWith(
-              (ref, workspaceId) async => [],
+              (ref, workspaceId) => Stream.value([]),
             ),
           ],
         ),
@@ -292,7 +292,7 @@ void main() {
             conversationRepositoryProvider.overrideWithValue(repo),
             streamingTitleProvider.overrideWith((ref, id) => null),
             listWorkspaceModelSelectionsProvider.overrideWith(
-              (ref, workspaceId) async => [],
+              (ref, workspaceId) => Stream.value([]),
             ),
           ],
         ),
@@ -315,7 +315,7 @@ void main() {
           overrides: [
             conversationRepositoryProvider.overrideWithValue(repo),
             listWorkspaceModelSelectionsProvider.overrideWith(
-              (ref, workspaceId) async => [],
+              (ref, workspaceId) => Stream.value([]),
             ),
           ],
         ),

--- a/apps/auravibes_app/test/features/models/providers/workspace_model_selections_providers_test.dart
+++ b/apps/auravibes_app/test/features/models/providers/workspace_model_selections_providers_test.dart
@@ -19,6 +19,12 @@ class _FakeWorkspaceModelSelectionRepository
   }
 
   @override
+  Stream<List<WorkspaceModelSelectionWithConnectionEntity>>
+  watchWorkspaceModelSelections(WorkspaceModelSelectionFilter filter) {
+    return Stream.value(selections);
+  }
+
+  @override
   Future<void> createWorkspaceModelSelections(
     List<WorkspaceModelSelectionToCreate> selections,
   ) {
@@ -70,9 +76,13 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final result = await container.read(
-        listWorkspaceModelSelectionsProvider(workspaceId: 'ws-1').future,
+      final provider = listWorkspaceModelSelectionsProvider(
+        workspaceId: 'ws-1',
       );
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+
+      final result = await container.read(provider.future);
       expect(result, hasLength(1));
       expect(
         result.first.workspaceModelSelection.id,
@@ -164,9 +174,11 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final result = await container.read(
-        listModelsGroupedByProviderProvider(workspaceId: 'ws-1').future,
-      );
+      final provider = listModelsGroupedByProviderProvider(workspaceId: 'ws-1');
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+
+      final result = await container.read(provider.future);
 
       expect(result.keys, equals(['Anthropic', 'OpenAI']));
       expect(result['OpenAI'], hasLength(2));
@@ -183,9 +195,11 @@ void main() {
       );
       addTearDown(container.dispose);
 
-      final result = await container.read(
-        listModelsGroupedByProviderProvider(workspaceId: 'ws-1').future,
-      );
+      final provider = listModelsGroupedByProviderProvider(workspaceId: 'ws-1');
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+
+      final result = await container.read(provider.future);
       expect(result, isEmpty);
     });
   });

--- a/apps/auravibes_app/test/features/models/providers/workspace_model_selections_providers_test.dart
+++ b/apps/auravibes_app/test/features/models/providers/workspace_model_selections_providers_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:auravibes_app/domain/entities/api_model_provider.dart';
 import 'package:auravibes_app/domain/entities/model_connection_entities.dart';
 import 'package:auravibes_app/domain/entities/workspace_model_selection_entities.dart';
@@ -9,8 +11,14 @@ import 'package:riverpod/riverpod.dart';
 
 class _FakeWorkspaceModelSelectionRepository
     implements WorkspaceModelSelectionRepository {
-  _FakeWorkspaceModelSelectionRepository([this.selections = const []]);
+  _FakeWorkspaceModelSelectionRepository([
+    this.selections = const [],
+    this.selectionStream,
+  ]);
+
   final List<WorkspaceModelSelectionWithConnectionEntity> selections;
+  final Stream<List<WorkspaceModelSelectionWithConnectionEntity>>?
+  selectionStream;
 
   @override
   Future<List<WorkspaceModelSelectionWithConnectionEntity>>
@@ -21,7 +29,7 @@ class _FakeWorkspaceModelSelectionRepository
   @override
   Stream<List<WorkspaceModelSelectionWithConnectionEntity>>
   watchWorkspaceModelSelections(WorkspaceModelSelectionFilter filter) {
-    return Stream.value(selections);
+    return selectionStream ?? Stream.value(selections);
   }
 
   @override
@@ -88,6 +96,92 @@ void main() {
         result.first.workspaceModelSelection.id,
         'sel-1',
       );
+    });
+
+    test('emits updated selections after initial value', () async {
+      final now = DateTime(2026);
+      final initialSelection = WorkspaceModelSelectionWithConnectionEntity(
+        workspaceModelSelection: WorkspaceModelSelectionEntity(
+          id: 'sel-1',
+          modelId: 'gpt-4',
+          modelConnectionId: 'conn-1',
+          createdAt: now,
+          updatedAt: now,
+        ),
+        modelConnection: ModelConnectionEntity(
+          id: 'conn-1',
+          name: 'OpenAI',
+          key: 'key',
+          modelId: 'gpt-4',
+          workspaceId: 'ws-1',
+          createdAt: now,
+          updatedAt: now,
+        ),
+        modelsProvider: const ApiModelProviderEntity(
+          id: 'openai',
+          name: 'OpenAI',
+          type: null,
+        ),
+      );
+      final updatedSelection = WorkspaceModelSelectionWithConnectionEntity(
+        workspaceModelSelection: WorkspaceModelSelectionEntity(
+          id: 'sel-2',
+          modelId: 'claude-3',
+          modelConnectionId: 'conn-2',
+          createdAt: now,
+          updatedAt: now,
+        ),
+        modelConnection: ModelConnectionEntity(
+          id: 'conn-2',
+          name: 'Anthropic',
+          key: 'key',
+          modelId: 'claude-3',
+          workspaceId: 'ws-1',
+          createdAt: now,
+          updatedAt: now,
+        ),
+        modelsProvider: const ApiModelProviderEntity(
+          id: 'anthropic',
+          name: 'Anthropic',
+          type: null,
+        ),
+      );
+      final controller =
+          StreamController<List<WorkspaceModelSelectionWithConnectionEntity>>();
+      addTearDown(controller.close);
+      final container = ProviderContainer(
+        overrides: [
+          workspaceModelSelectionRepositoryProvider.overrideWithValue(
+            _FakeWorkspaceModelSelectionRepository([], controller.stream),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final provider = listWorkspaceModelSelectionsProvider(
+        workspaceId: 'ws-1',
+      );
+      final secondEmission =
+          Completer<List<WorkspaceModelSelectionWithConnectionEntity>>();
+      var emissionCount = 0;
+      final subscription = container.listen(provider, (_, next) {
+        switch (next) {
+          case AsyncData(:final value):
+            emissionCount++;
+            if (emissionCount == 2) {
+              secondEmission.complete(value);
+            }
+          case AsyncError() || AsyncLoading():
+        }
+      });
+      addTearDown(subscription.close);
+
+      final firstEmission = container.read(provider.future);
+      controller.add([initialSelection]);
+      expect(await firstEmission, hasLength(1));
+
+      controller.add([initialSelection, updatedSelection]);
+      expect(await secondEmission.future, hasLength(2));
     });
   });
 


### PR DESCRIPTION
## Summary
- Stream workspace model selections from Drift through the repository layer.
- Convert model selection Riverpod providers to stream providers so chat screens refresh when providers change.
- Update generated providers, mocks, and focused tests for the stream contract.

## Verification
- `fvm flutter test test/features/models/providers/workspace_model_selections_providers_test.dart --no-pub`
- `fvm flutter test test/data/database/drift/daos/workspace_model_selections_dao_test.dart --no-pub`
- `fvm flutter test test/domain/repositories/workspace_model_selection_repository_test.dart --no-pub`
- `fvm flutter test test/features/chats/screens/list_chats_screen_test.dart test/features/chats/screens/new_chat_screen_test.dart test/features/chats/widgets/chat_list_widget_test.dart --no-pub`
- `fvm dart run melos analyze` (reports only pre-existing info lints outside this change)