### PR TITLE
chore: Enable the private-named-parameters experiment across analyzer configs

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,9 @@ formatter:
 
 
 analyzer:
+  enable-experiment:
+    - private-named-parameters
+
   exclude:
     - "**/**.g.dart"
     - "lib/**.g.dart"
@@ -61,5 +64,4 @@ linter:
     ##
     flutter_style_todos: false
     discarded_futures: false
-
 

--- a/packages/auravibes_ui/analysis_options.yaml
+++ b/packages/auravibes_ui/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:very_good_analysis/analysis_options.yaml
+
+analyzer:
+  enable-experiment:
+    - private-named-parameters

--- a/widgetbook/analysis_options.yaml
+++ b/widgetbook/analysis_options.yaml
@@ -9,6 +9,10 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  enable-experiment:
+    - private-named-parameters
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`


### PR DESCRIPTION
## Summary
- Enabled `private-named-parameters` in the root analyzer config.
- Added the same experiment flag to `packages/auravibes_ui` and `widgetbook` so all Dart entrypoints share the setting.
- Kept the change scoped to analyzer configuration only.

## Testing
- `fvm dart run melos analyze` passed.
- Analyzer still reports existing unrelated info-level lints, but no config errors from the experiment flag.